### PR TITLE
ignore gcs credential file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@ npm-debug.log
 # OS X metadata files
 .DS_Store
 
-# Python coverage 
+# Python coverage
 .coverage
+
+# Credential files
+/gcs-credentials.json


### PR DESCRIPTION
Ignore the gcs credential file so we don't mistakenly commit credential data to the public repo.