### PR TITLE
fix what Bundle.list returns

### DIFF
--- a/dss/api/bundles.py
+++ b/dss/api/bundles.py
@@ -4,7 +4,7 @@ def get(uuid, replica):
     return redirect("http://example.com")
 
 def list():
-    return dict(files=[dict(uuid="", name="", versions=[])])
+    return dict(bundles=[dict(uuid="", versions=[])])
 
 def post():
     pass


### PR DESCRIPTION
This matches the swagger spec now and the endpoint does not fail.