### PR TITLE
Continuous deployment instrumentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ script:
 - make test
 after_success:
 - bash <(curl -s https://codecov.io/bash)
+deploy:
+  provider: script
+  script: make deploy
+  on:
+    branch: master
 env:
   global:
   - DSS_S3_TEST_BUCKET=czi-hca-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ deploy:
   script: make deploy
   on:
     branch: master
+    python: 3.6
 env:
   global:
   - DSS_S3_TEST_BUCKET=czi-hca-test

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ test: lint
 	python -m unittest discover tests
 
 deploy: chalice/chalicelib
+	pip install chalice
+	pip install -r requirements.txt
 	git clean -df chalice/chalicelib
 	cp -R dss dss-api.yml chalice/chalicelib
 	(cd chalice; chalice deploy)

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ deploy:
 	git clean -df chalice/chalicelib
 	cp -R dss dss-api.yml chalice/chalicelib
 	chalice/build_deploy_config.sh $(STAGE)
-	(cd chalice; chalice deploy --no-autogen-policy --stage $(STAGE))
+	cd chalice; chalice deploy --no-autogen-policy --stage $(STAGE)
 
 .PHONY: test lint

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ deploy: chalice/chalicelib
 	pip install -r requirements.txt
 	git clean -df chalice/chalicelib
 	cp -R dss dss-api.yml chalice/chalicelib
-	(cd chalice; chalice deploy)
+	(cd chalice; chalice deploy --no-autogen-policy)
 
 .PHONY: test lint

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ deploy: chalice/chalicelib
 	pip install -r requirements.txt
 	git clean -df chalice/chalicelib
 	cp -R dss dss-api.yml chalice/chalicelib
-	chalice/build_deploy_config.sh $STAGE
-	(cd chalice; chalice deploy --no-autogen-policy --stage $STAGE)
+	chalice/build_deploy_config.sh $(STAGE)
+	(cd chalice; chalice deploy --no-autogen-policy --stage $(STAGE))
 
 .PHONY: test lint

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 test: lint
 	python -m unittest discover tests
 
-deploy: chalice/chalicelib
+deploy:
 	pip install chalice
 	pip install -r requirements.txt
 	git clean -df chalice/chalicelib

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 STAGE=dev
 
 lint:
-	flake8 dss test
+	flake8 dss tests chalice/*.py
 
 test: lint
 	python -m unittest discover tests

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,9 @@ lint:
 test: lint
 	python -m unittest discover tests
 
+deploy: chalice/chalicelib
+	git clean -df chalice/chalicelib
+	cp -R dss dss-api.yml chalice/chalicelib
+	(cd chalice; chalice deploy)
+
 .PHONY: test lint

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+SHELL=/bin/bash
+STAGE=dev
+
 lint:
 	flake8 dss test
 
@@ -9,6 +12,7 @@ deploy: chalice/chalicelib
 	pip install -r requirements.txt
 	git clean -df chalice/chalicelib
 	cp -R dss dss-api.yml chalice/chalicelib
-	(cd chalice; chalice deploy --no-autogen-policy)
+	chalice/build_deploy_config.sh $STAGE
+	(cd chalice; chalice deploy --no-autogen-policy --stage $STAGE)
 
 .PHONY: test lint

--- a/chalice/.chalice/config.json
+++ b/chalice/.chalice/config.json
@@ -1,0 +1,9 @@
+{
+  "version": "2.0",
+  "app_name": "dss",
+  "stages": {
+    "dev": {
+      "api_gateway_stage": "dev"
+    }
+  }
+}

--- a/chalice/.chalice/deployed.json
+++ b/chalice/.chalice/deployed.json
@@ -1,0 +1,11 @@
+{
+  "dev": {
+    "api_handler_name": "dss-dev",
+    "api_handler_arn": "",
+    "rest_api_id": "",
+    "region": "us-east-1",
+    "api_gateway_stage": "dev",
+    "backend": "api",
+    "chalice_version": "0.8.2"
+  }
+}

--- a/chalice/.chalice/policy.json
+++ b/chalice/.chalice/policy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    }
+  ]
+}

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -11,7 +11,7 @@ sys.path.insert(0, pkg_root)
 from dss import create_app # noqa
 
 def get_chalice_app(flask_app):
-    app = Chalice(app_name=__name__)
+    app = Chalice(app_name="dss")
     app.debug = True
 
     def dispatch(*args, **kwargs):
@@ -21,9 +21,6 @@ def get_chalice_app(flask_app):
                                             base_url="https://{}".format(app.current_request.headers["host"]),
                                             query_string=app.current_request.query_params,
                                             method=app.current_request.method,
-                                            content_type=None,
-                                            content_length=None,
-                                            errors_stream=None,
                                             headers=list(app.current_request.headers.items()),
                                             data=app.current_request.raw_body,
                                             environ_base=app.current_request.stage_vars):

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -11,8 +11,11 @@ sys.path.insert(0, pkg_root)
 from dss import create_app # noqa
 
 def get_chalice_app(flask_app):
-    app = Chalice(app_name="dss")
-    app.debug = True
+    app = Chalice(app_name=flask_app.name)
+    flask_app.debug = True
+    app.debug = flask_app.debug
+    app.log.setLevel(logging.DEBUG)
+    flask_app._logger = app.log
 
     def dispatch(*args, **kwargs):
         uri_params = app.current_request.uri_params or {}

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -17,7 +17,8 @@ def get_chalice_app(flask_app):
     app.debug = True
 
     def dispatch(*args, **kwargs):
-        path = app.current_request.context["resourcePath"].format(**app.current_request.uri_params)
+        uri_params = app.current_request.uri_params or {}
+        path = app.current_request.context["resourcePath"].format(**uri_params)
         with flask_app.test_request_context(path=path,
                                             base_url="https://{}".format(app.current_request.headers["host"]),
                                             query_string=app.current_request.query_params,

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -33,7 +33,6 @@ def get_chalice_app(flask_app):
     for rule in flask_app.url_map.iter_rules():
         routes[re.sub(r"<(.+?)(:.+?)?>", r"{\1}", rule.rule).rstrip("/")] += rule.methods
     for route, methods in routes.items():
-        print("ROUTE", route)
         app.route(route, methods=methods)(dispatch)
     return app
 

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -15,7 +15,6 @@ def get_chalice_app(flask_app):
     flask_app.debug = True
     app.debug = flask_app.debug
     app.log.setLevel(logging.DEBUG)
-    flask_app._logger = app.log
 
     def dispatch(*args, **kwargs):
         uri_params = app.current_request.uri_params or {}

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1,0 +1,44 @@
+import os, sys, re, logging, collections
+
+logging.basicConfig(level=logging.INFO)
+
+import flask
+from chalice import Chalice, Response
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))
+assert os.path.exists(pkg_root)
+sys.path.insert(0, pkg_root)
+
+from dss import create_app
+
+
+def get_chalice_app(flask_app):
+    app = Chalice(app_name=__name__)
+    app.debug = True
+
+    def dispatch(*args, **kwargs):
+        path = app.current_request.context["resourcePath"].format(**app.current_request.uri_params)
+        with flask_app.test_request_context(path=path,
+                                            base_url="https://{}".format(app.current_request.headers["host"]),
+                                            query_string=app.current_request.query_params,
+                                            method=app.current_request.method,
+                                            content_type=None,
+                                            content_length=None,
+                                            errors_stream=None,
+                                            headers=list(app.current_request.headers.items()),
+                                            data=app.current_request.raw_body,
+                                            environ_base=app.current_request.stage_vars):
+            flask_res = flask_app.full_dispatch_request()
+        return Response(status_code=flask_res._status_code,
+                        headers=dict(flask_res.headers),
+                        body="".join([c.decode() if isinstance(c, bytes) else c for c in flask_res.response]))
+
+    routes = collections.defaultdict(list)
+    for rule in flask_app.url_map.iter_rules():
+        routes[re.sub(r"<(.+?)(:.+?)?>", r"{\1}", rule.rule).rstrip("/")] += rule.methods
+    for route, methods in routes.items():
+        print("ROUTE", route)
+        app.route(route, methods=methods)(dispatch)
+    return app
+
+app = get_chalice_app(create_app().app)

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1,9 +1,6 @@
 import os, sys, re, logging, collections
 
-logging.basicConfig(level=logging.INFO)
-
-import flask # noqa
-from chalice import Chalice, Response # noqa
+import flask, chalice
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))
 sys.path.insert(0, pkg_root)
@@ -11,7 +8,7 @@ sys.path.insert(0, pkg_root)
 from dss import create_app # noqa
 
 def get_chalice_app(flask_app):
-    app = Chalice(app_name=flask_app.name)
+    app = chalice.Chalice(app_name=flask_app.name)
     flask_app.debug = True
     app.debug = flask_app.debug
     app.log.setLevel(logging.DEBUG)
@@ -27,9 +24,9 @@ def get_chalice_app(flask_app):
                                             data=app.current_request.raw_body,
                                             environ_base=app.current_request.stage_vars):
             flask_res = flask_app.full_dispatch_request()
-        return Response(status_code=flask_res._status_code,
-                        headers=dict(flask_res.headers),
-                        body="".join([c.decode() if isinstance(c, bytes) else c for c in flask_res.response]))
+        return chalice.Response(status_code=flask_res._status_code,
+                                headers=dict(flask_res.headers),
+                                body="".join([c.decode() if isinstance(c, bytes) else c for c in flask_res.response]))
 
     routes = collections.defaultdict(list)
     for rule in flask_app.url_map.iter_rules():

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -2,15 +2,13 @@ import os, sys, re, logging, collections
 
 logging.basicConfig(level=logging.INFO)
 
-import flask
-from chalice import Chalice, Response
+import flask # noqa
+from chalice import Chalice, Response # noqa
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))
-assert os.path.exists(pkg_root)
 sys.path.insert(0, pkg_root)
 
-from dss import create_app
-
+from dss import create_app # noqa
 
 def get_chalice_app(flask_app):
     app = Chalice(app_name=__name__)

--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -euo pipefail
+#!/bin/bash
+
+set -euo pipefail
 
 get_api_id() {
     for api_id in $(aws apigateway get-rest-apis | jq -r .items[].id); do

--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -euo pipefail
+
+get_api_id() {
+    for api_id in $(aws apigateway get-rest-apis | jq -r .items[].id); do
+        for resource_id in $(aws apigateway get-resources --rest-api-id $api_id | jq -r .items[].id); do
+            aws apigateway get-integration --rest-api-id $api_id --resource-id $resource_id --http-method GET >/dev/null 2>&1 || continue
+            uri=$(aws apigateway get-integration --rest-api-id $api_id --resource-id $resource_id --http-method GET | jq -r .uri)
+            if [[ $uri == *"$lambda_arn"* ]]; then
+                echo $api_id
+                return
+            fi
+        done
+    done
+}
+
+if [[ $# != 1 ]]; then
+    echo "Usage: $(basename $0) apigateway-stage"
+    exit 1
+fi
+
+stage=$1
+deployed_json="$(dirname $0)/.chalice/deployed.json"
+export lambda_name=$(jq -r .$stage.api_handler_name "$deployed_json")
+
+if [[ $lambda_name == "null" ]]; then
+    echo "Invalid stage $stage"
+    exit 1
+fi
+
+export lambda_arn=$(aws lambda list-functions | jq -r '.Functions[] | select(.FunctionName==env.lambda_name) | .FunctionArn')
+if [[ -z $lambda_arn ]]; then
+    echo "Lambda function $lambda_name not found, resetting Chalice config"
+    rm "$deployed_json"
+else
+    export api_id=$(get_api_id)
+    cat "$deployed_json" | jq .$stage.api_handler_arn=env.lambda_arn | jq .$stage.rest_api_id=env.api_id | sponge "$deployed_json"
+fi

--- a/chalice/requirements.txt
+++ b/chalice/requirements.txt
@@ -1,0 +1,1 @@
+../requirements.txt

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -17,10 +17,14 @@ from flask_failsafe import failsafe
 
 logging.basicConfig(level=logging.DEBUG)
 
+app = None
+logger = None
+
 @failsafe
 def create_app():
+    global app, logger
     app = connexion.App(__name__)
+    logger = app.app.logger
     resolver = RestyResolver("dss.api", collection_endpoint_name="list")
     app.add_api('../dss-api.yml', resolver=resolver, validate_responses=True)
-
     return app

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -10,21 +10,19 @@ from datetime import datetime, timedelta
 import boto3
 import google.cloud.storage
 from azure.storage.blob import BlockBlobService, BlobPermissions
-from flask import Flask, request, redirect, jsonify
+import flask
 import connexion
 from connexion.resolver import RestyResolver
 from flask_failsafe import failsafe
 
 logging.basicConfig(level=logging.DEBUG)
 
-app = None
-logger = None
+def get_logger():
+    return flask.current_app.logger
 
 @failsafe
 def create_app():
-    global app, logger
     app = connexion.App(__name__)
-    logger = app.app.logger
     resolver = RestyResolver("dss.api", collection_endpoint_name="list")
     app.add_api('../dss-api.yml', resolver=resolver, validate_responses=True)
     return app

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -1,8 +1,8 @@
 from flask import redirect
-from .. import logger
+from .. import get_logger
 
 def get(uuid, replica):
-    logger.info("This is a log message.")
+    get_logger().info("This is a log message.")
     return redirect("http://example.com")
 
 def list():

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -1,6 +1,8 @@
 from flask import redirect
+from .. import logger
 
 def get(uuid, replica):
+    logger.info("This is a log message.")
     return redirect("http://example.com")
 
 def list():


### PR DESCRIPTION
- Use [Chalice](https://github.com/awslabs/chalice) to enable deployment of the app to AWS Lambda/API Gateway
- Add a Chalice-Connexion adapter to preserve the ability to use Connexion validation
- Add a `deploy` config to Travis CI to perform automatic deployment any time we push to master

In our AWS account, I have separately set up the DNS/SSL/CloudFront to serve the app on https://hca-dss.czi.technology/v1/.