### PR TITLE
flesh out GET/HEAD support for /files/<uuid>

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -32,17 +32,97 @@ paths:
       parameters:
         - name: uuid
           in: path
-          description: File unique ID.
+          description: A RFC4122-compliant ID for the file.
           required: true
           type: string
         - name: replica
           in: query
           description: Replica to fetch from.
-          required: true
+          required: false
           type: string
+        - name: timestamp
+          in: query
+          description: Timestamp of file creation in RFC3339.  If this is not provided, the latest version is returned.
+          required: false
+          type: string
+          format: date-time
       responses:
+        200:
+          description: On a HEAD request, returns metadata
+          headers:
+            # edits to here should probably be reflected in the 302 section immediately below.
+            X-DSS-BUNDLE_UUID:
+              type: string
+              description: A RFC4122-compliant ID for the bundle that contains this file.
+            X-DSS-CREATOR_UID:
+              type: integer
+              format: int64
+              description: User ID who created this file.
+            X-DSS-TIMESTAMP:
+              type: string
+              format: date-time
+              description: Timestamp of file creation in RFC3339.
+            X-DSS-CONTENT-TYPE:
+              type: string
+              description: Content-type of the file.
+            X-DSS-CRC32C:
+              type: string
+              description: CRC32C of the file contents in hex.
+              minLength: 8
+              maxLength: 8
+            X-DSS-MD5:
+              type: string
+              description: MD5 of the file contents in hex.
+              minLength: 32
+              maxLength: 32
+            X-DSS-SHA1:
+              type: string
+              description: SHA-1 of the file contents in hex.
+              minLength: 40
+              maxLength: 40
+            X-DSS-SHA256:
+              type: string
+              description: SHA-256 of the file contents in hex.
+              minLength: 64
+              maxLength: 64
         302:
-          description: Redirect to a file location
+          description: On a GET request, redirects to a signed URL.
+          headers:
+            # edits to here should probably be reflected in the 200 section immediately above.
+            X-DSS-BUNDLE_UUID:
+              type: string
+              description: A RFC4122-compliant ID for the bundle that contains this file.
+            X-DSS-CREATOR_UID:
+              type: integer
+              format: int64
+              description: User ID who created this file.
+            X-DSS-TIMESTAMP:
+              type: string
+              format: date-time
+              description: Timestamp of file creation in RFC3339.
+            X-DSS-CONTENT-TYPE:
+              type: string
+              description: Content-type of the file.
+            X-DSS-CRC32C:
+              type: string
+              description: CRC32C of the file contents in hex.
+              minLength: 8
+              maxLength: 8
+            X-DSS-MD5:
+              type: string
+              description: MD5 of the file contents in hex.
+              minLength: 32
+              maxLength: 32
+            X-DSS-SHA1:
+              type: string
+              description: SHA-1 of the file contents in hex.
+              minLength: 40
+              maxLength: 40
+            X-DSS-SHA256:
+              type: string
+              description: SHA-256 of the file contents in hex.
+              minLength: 64
+              maxLength: 64
         default:
           description: Unexpected error
           schema:

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -1,9 +1,33 @@
-from flask import redirect
+import binascii
+import hashlib
+
+from flask import redirect, request, make_response
+from werkzeug.exceptions import BadRequest
+
 from .. import get_logger
 
-def get(uuid: str, replica: str):
+def get(uuid: str, replica: str=None, timestamp: str=None):
+    if request.method == "GET" and replica is None:
+        # replica must be set when it's a GET request.
+        raise BadRequest()
     get_logger().info("This is a log message.")
-    return redirect("http://example.com")
+
+    if request.method == "GET":
+        response = redirect("http://example.com")
+    else:
+        response = make_response('', 200)
+
+    headers = response.headers
+    headers['X-DSS-BUNDLE_UUID'] = uuid
+    headers['X-DSS-CREATOR_UID'] = 123
+    headers['X-DSS-TIMESTAMP'] = 5353
+    headers['X-DSS-CONTENT-TYPE'] = "abcde"
+    headers['X-DSS-CRC32C'] = "%08X" % (binascii.crc32(b"abcde"),)
+    headers['X-DSS-MD5'] = hashlib.md5().hexdigest()
+    headers['X-DSS-SHA1'] = hashlib.sha1().hexdigest()
+    headers['X-DSS-SHA256'] = hashlib.sha256().hexdigest()
+
+    return response
 
 def list():
     return dict(files=[dict(uuid="", name="", versions=[])])

--- a/tests/test.py
+++ b/tests/test.py
@@ -25,6 +25,9 @@ class TestDSS(unittest.TestCase, TestRequest):
         res = self.app.get("/v1/files")
         self.assertEqual(res.status_code, requests.codes.ok)
 
+        res = self.app.head("/v1/files/123")
+        self.assertEqual(res.status_code, requests.codes.ok)
+
         res = self.app.get("/v1/files/123")
         self.assertEqual(res.status_code, requests.codes.bad_request)
         res = self.app.get("/v1/files/123?replica=aws")


### PR DESCRIPTION
 1. Updated UUID definition.
 2. `replica` is now not required.  It is enforced in code for only GET requests.
 3. Added `timestamp` parameter.
 4. Added response headers.  Unfortunately, it looks like connexion does not verify the minLength and maxLength fields of string headers (see https://github.com/zalando/connexion/blob/master/connexion/decorators/response.py), but if they add the proper support, this should hopefully match.
 5. Use a shared code path for GET and HEAD.