### PR TITLE
use patterns instead of minLength/maxLength.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -68,23 +68,19 @@ paths:
             X-DSS-CRC32C:
               type: string
               description: CRC32C of the file contents in hex.
-              minLength: 8
-              maxLength: 8
+              pattern: "^[A-Za-z0-9]{8}$"
             X-DSS-S3_ETAG:
               type: string
               description: S3 ETag of the file contents.
-              minLength: 32
-              maxLength: 38
+              pattern: "^[A-Za-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
             X-DSS-SHA1:
               type: string
               description: SHA-1 of the file contents in hex.
-              minLength: 40
-              maxLength: 40
+              pattern: "^[A-Za-z0-9]{40}$"
             X-DSS-SHA256:
               type: string
               description: SHA-256 of the file contents in hex.
-              minLength: 64
-              maxLength: 64
+              pattern: "^[A-Za-z0-9]{64}$"
         302:
           description: On a GET request, redirects to a signed URL.
           headers:
@@ -106,23 +102,19 @@ paths:
             X-DSS-CRC32C:
               type: string
               description: CRC32C of the file contents in hex.
-              minLength: 8
-              maxLength: 8
+              pattern: "^[A-Za-z0-9]{8}$"
             X-DSS-S3_ETAG:
               type: string
               description: S3 ETag of the file contents.
-              minLength: 32
-              maxLength: 38
+              pattern: "^[A-Za-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
             X-DSS-SHA1:
               type: string
               description: SHA-1 of the file contents in hex.
-              minLength: 40
-              maxLength: 40
+              pattern: "^[A-Za-z0-9]{40}$"
             X-DSS-SHA256:
               type: string
               description: SHA-256 of the file contents in hex.
-              minLength: 64
-              maxLength: 64
+              pattern: "^[A-Za-z0-9]{64}$"
         default:
           description: Unexpected error
           schema:


### PR DESCRIPTION
This allows us to further constrain the valid input set. Again, headers are not verified by connexion, but one day.... :)