### PR TITLE
Don't associate the {gcs,s3}_blobstore handle with a container

### DIFF
--- a/dss/blobstore/gcs.py
+++ b/dss/blobstore/gcs.py
@@ -7,14 +7,7 @@ from . import BlobStore, BlobContainerNotFoundError, BlobStoreCredentialError
 
 
 class GCSBlobStore(BlobStore):
-    def __init__(self, container: str, json_keyfile: str) -> None:
+    def __init__(self, json_keyfile: str) -> None:
         super(GCSBlobStore, self).__init__()
 
         self.gcs_client = Client.from_service_account_json(json_keyfile)
-
-        try:
-            self.bucket = self.gcs_client.get_bucket(container)
-        except exceptions.NotFound as e:
-            raise BlobContainerNotFoundError(e)
-        except exceptions.Forbidden as e:
-            raise BlobStoreCredentialError(e)

--- a/dss/blobstore/s3.py
+++ b/dss/blobstore/s3.py
@@ -9,21 +9,17 @@ from . import BlobStore, BlobContainerNotFoundError, BlobStoreCredentialError
 
 
 class S3BlobStore(BlobStore):
-    def __init__(self, container: str) -> None:
+    def __init__(self) -> None:
         super(S3BlobStore, self).__init__()
 
-        self.s3_client = boto3.client("s3")
-
+        # verify that the credentials are valid.
         try:
-            self.s3_client.head_bucket(Bucket=container)
+            boto3.client('sts').get_caller_identity()
         except botocore.exceptions.ClientError as e:
-            # If a client error is thrown, then check that it was a 404 error.
-            # If it was a 404 error, then the bucket does not exist.
-            error_code = int(e.response['Error']['Code'])
-            if error_code == 404:
-                raise BlobContainerNotFoundError()
-            elif error_code == 403:
+            if e.response['Error']['Code'] == "InvalidClientTokenId":
                 raise BlobStoreCredentialError()
+
+        self.s3_client = boto3.client("s3")
 
     def list(self, prefix: str=None):
         pass

--- a/tests/test_gcsblobstore.py
+++ b/tests/test_gcsblobstore.py
@@ -24,8 +24,7 @@ class TestGCSBlobStore(unittest.TestCase):
         pass
 
     def test_connect(self):
-        gcsblobstore = GCSBlobStore(self.test_bucket, self.credentials)
-        print(gcsblobstore)
+        GCSBlobStore(self.credentials)
 
 
 if __name__ == '__main__':

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -23,8 +23,7 @@ class TestS3BlobStore(unittest.TestCase):
         pass
 
     def test_connect(self):
-        s3blobstore = S3BlobStore(self.test_bucket)
-        print(s3blobstore)
+        S3BlobStore()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There are methods that involve multiple buckets, so it doesn't make sense to tie the handle to a container.  Verify that the handle is sane through a sensible API.