### PR TITLE
Delete operation should take a container and a key

### DIFF
--- a/dss/blobstore/__init__.py
+++ b/dss/blobstore/__init__.py
@@ -17,7 +17,12 @@ class BlobStore(object):
         """
         raise NotImplementedError()
 
-    def delete(self, object_name: str):
+    def delete(self, container: str, object_name: str):
+        """
+        Deletes an object in a container.  If the operation definitely did not
+        delete anything, return False.  Any other return value is treated as
+        something was possibly deleted.
+        """
         raise NotImplementedError()
 
 

--- a/dss/blobstore/s3.py
+++ b/dss/blobstore/s3.py
@@ -30,5 +30,8 @@ class S3BlobStore(BlobStore):
     def set(self, objname: str, src_file_handle: typing.BinaryIO):
         pass
 
-    def delete(self, objname: str):
-        pass
+    def delete(self, container: str, object_name: str):
+        self.s3_client.delete_object(
+            Bucket=container,
+            key=object_name
+        )


### PR DESCRIPTION
Implement S3's delete object method.  Since it doesn't seem to distinguish between an-object-was-deleted and no-object-was-deleted, it returns nothing.