### PR TITLE
add copy methods to BlobStore and S3BlobStore

### DIFF
--- a/dss/blobstore/__init__.py
+++ b/dss/blobstore/__init__.py
@@ -37,6 +37,13 @@ class BlobStore(object):
         """
         raise NotImplementedError()
 
+    def copy(
+            self,
+            src_container: str, src_object_name: str,
+            dst_container: str, dst_object_name: str,
+            **kwargs):
+        raise NotImplementedError()
+
 
 class BlobStoreError(Exception):
     pass

--- a/dss/blobstore/s3.py
+++ b/dss/blobstore/s3.py
@@ -51,3 +51,19 @@ class S3BlobStore(BlobStore):
             Key=object_name
         )
         return response['Metadata']
+
+    def copy(
+            self,
+            src_container: str, src_object_name: str,
+            dst_container: str, dst_object_name: str,
+            **kwargs
+    ):
+        self.s3_client.copy(
+            dict(
+                Bucket=src_container,
+                Key=src_object_name,
+            ),
+            Bucket=dst_container,
+            Key=dst_object_name,
+            ExtraArgs=kwargs,
+        )


### PR DESCRIPTION
This is the same as #64, except it uses the managed `copy` interface.