### PR TITLE
Separate get and head requests, but map it to the same code path.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -47,42 +47,8 @@ paths:
           type: string
           format: date-time
       responses:
-        200:
-          description: On a HEAD request, returns metadata
-          headers:
-            # edits to here should probably be reflected in the 302 section immediately below.
-            X-DSS-BUNDLE-UUID:
-              description: A RFC4122-compliant ID for the bundle that contains this file.
-              type: string
-            X-DSS-CREATOR-UID:
-              description: User ID who created this file.
-              type: integer
-              format: int64
-            X-DSS-TIMESTAMP:
-              description: Timestamp of file creation in RFC3339.
-              type: string
-              format: date-time
-            X-DSS-CONTENT-TYPE:
-              description: Content-type of the file.
-              type: string
-            X-DSS-CRC32C:
-              description: CRC32C of the file contents in hex.
-              type: string
-              pattern: "^[A-Za-z0-9]{8}$"
-            X-DSS-S3-ETAG:
-              description: S3 ETag of the file contents.
-              type: string
-              pattern: "^[A-Za-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
-            X-DSS-SHA1:
-              description: SHA-1 of the file contents in hex.
-              type: string
-              pattern: "^[A-Za-z0-9]{40}$"
-            X-DSS-SHA256:
-              description: SHA-256 of the file contents in hex.
-              type: string
-              pattern: "^[A-Za-z0-9]{64}$"
         302:
-          description: On a GET request, redirects to a signed URL.
+          description: Redirects to a signed URL with the data.
           headers:
             # edits to here should probably be reflected in the 302 section immediately below.
             X-DSS-BUNDLE-UUID:
@@ -119,6 +85,54 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+    head:
+      parameters:
+        - name: uuid
+          in: path
+          description: A RFC4122-compliant ID for the file.
+          required: true
+          type: string
+        - name: timestamp
+          in: query
+          description: Timestamp of file creation in RFC3339.  If this is not provided, the latest version is returned.
+          required: false
+          type: string
+          format: date-time
+      responses:
+        200:
+          description: Returns metadata
+          headers:
+            # edits to here should probably be reflected in the 302 section immediately below.
+            X-DSS-BUNDLE-UUID:
+              description: A RFC4122-compliant ID for the bundle that contains this file.
+              type: string
+            X-DSS-CREATOR-UID:
+              description: User ID who created this file.
+              type: integer
+              format: int64
+            X-DSS-TIMESTAMP:
+              description: Timestamp of file creation in RFC3339.
+              type: string
+              format: date-time
+            X-DSS-CONTENT-TYPE:
+              description: Content-type of the file.
+              type: string
+            X-DSS-CRC32C:
+              description: CRC32C of the file contents in hex.
+              type: string
+              pattern: "^[A-Za-z0-9]{8}$"
+            X-DSS-S3-ETAG:
+              description: S3 ETag of the file contents.
+              type: string
+              pattern: "^[A-Za-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
+            X-DSS-SHA1:
+              description: SHA-1 of the file contents in hex.
+              type: string
+              pattern: "^[A-Za-z0-9]{40}$"
+            X-DSS-SHA256:
+              description: SHA-256 of the file contents in hex.
+              type: string
+              pattern: "^[A-Za-z0-9]{64}$"
     put:
       summary: Create a file
       description: |

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -8,6 +8,19 @@ from werkzeug.exceptions import BadRequest
 
 from .. import get_logger
 
+
+def head(uuid: str, replica: str=None, timestamp: str=None):
+    # NOTE: THIS IS NEVER ACTUALLY CALLED DUE TO A BUG IN CONNEXION.
+    # HEAD requests always calls the same endpoint as get, even if we tell it to
+    # go to a different method.  However, connexion freaks out if:
+    # 1) there is no head() function defined in code.  *or*
+    # 2) we tell the head() function to hit the same method using operationId.
+    #
+    # So in short, do not expect that this function actually gets called.  This
+    # is only here to keep connexion from freaking out.
+    return get(uuid, replica, timestamp)
+
+
 def get(uuid: str, replica: str=None, timestamp: str=None):
     if request.method == "GET" and replica is None:
         # replica must be set when it's a GET request.


### PR DESCRIPTION
There's a connexion bug that results in some oddity.  Read the comment in files.py.head().

@Mackey22 needs this for the CLI.