### PR TITLE
catch cloud-specific exceptions for `get_metadata()`  and throw a dss exception.

### DIFF
--- a/dss/blobstore/__init__.py
+++ b/dss/blobstore/__init__.py
@@ -71,6 +71,10 @@ class BlobStoreError(Exception):
     pass
 
 
+class BlobStoreUnknownError(BlobStoreError):
+    pass
+
+
 class BlobStoreCredentialError(BlobStoreError):
     pass
 

--- a/dss/blobstore/gcs.py
+++ b/dss/blobstore/gcs.py
@@ -5,7 +5,7 @@ import typing
 from google.cloud.storage import Client
 from google.cloud.storage.bucket import Bucket
 
-from . import BlobStore
+from . import BlobNotFoundError, BlobStore
 
 
 class GCSBlobStore(BlobStore):
@@ -35,4 +35,6 @@ class GCSBlobStore(BlobStore):
         """
         bucket_obj = self._ensure_bucket_loaded(bucket)
         response = bucket_obj.get_blob(object_name)
+        if response is None:
+            raise BlobNotFoundError()
         return response.metadata

--- a/tests/test_blobstore.py
+++ b/tests/test_blobstore.py
@@ -1,3 +1,6 @@
+from dss.blobstore import BlobNotFoundError
+
+
 class BlobStoreTests(object):
     """
     Common blobstore tests.  We want to avoid repeating ourselves, so if we
@@ -13,3 +16,8 @@ class BlobStoreTests(object):
             self.test_src_data_bucket,
             "test_good_source_data")
         self.assertIn('hca-dss-content-type', metadata)
+
+        with self.assertRaises(BlobNotFoundError):
+            handle.get_metadata(
+                self.test_src_data_bucket,
+                "test_good_source_data_DOES_NOT_EXIST")


### PR DESCRIPTION
This way, we don't have to write cloud-specific error handling code everywhere.