### PR TITLE
move file-put tests to its own module.

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import sys
-import uuid
 import unittest
 
 import requests
@@ -35,26 +34,6 @@ class TestDSS(unittest.TestCase, DSSAsserts):
         self.assertGetResponse(
             "/v1/files/91839244-66ab-408f-9be5-c82def201f26?replica=aws",
             requests.codes.found)
-
-    def test_file_put(self):
-        file_uuid = uuid.uuid4()
-        response = self.assertPutResponse(
-            "/v1/files/" + str(file_uuid),
-            requests.codes.created,
-            json_request_body=dict(
-                source_url="s3://hca-dss-test-src/test_good_source_data",
-                bundle_uuid=str(uuid.uuid4()),
-                creator_uid=4321,
-                content_type="text/html",
-            ),
-        )
-        self.assertHeaders(
-            response[0],
-            {
-                'content-type': "application/json",
-            }
-        )
-        self.assertIn('timestamp', response[2])
 
     def test_bundle_api(self):
         self.assertGetResponse("/v1/bundles", requests.codes.ok)

--- a/tests/test_file_put.py
+++ b/tests/test_file_put.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+import sys
+import uuid
+import unittest
+
+import requests
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, pkg_root)
+
+import dss  # noqa
+from tests.infra import DSSAsserts  # noqa
+
+
+class TestFilePut(unittest.TestCase, DSSAsserts):
+    def setUp(self):
+        DSSAsserts.setup(self)
+        self.app = dss.create_app().app.test_client()
+
+    def test_file_put(self):
+        file_uuid = uuid.uuid4()
+        response = self.assertPutResponse(
+            "/v1/files/" + str(file_uuid),
+            requests.codes.created,
+            json_request_body=dict(
+                source_url="s3://hca-dss-test-src/test_good_source_data",
+                bundle_uuid=str(uuid.uuid4()),
+                creator_uid=4321,
+                content_type="text/html",
+            ),
+        )
+        self.assertHeaders(
+            response[0],
+            {
+                'content-type': "application/json",
+            }
+        )
+        self.assertIn('timestamp', response[2])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Rationale: file-get tests should refer to an immutable data set. Therefore, we need to point our bucket setup at a different location. Since the client is set up in `setUp`, we need to have a different `setUp` method for read and write tests.