### PR TITLE
hideous abstraction layer for get_presigned_url

### DIFF
--- a/dss/blobstore/__init__.py
+++ b/dss/blobstore/__init__.py
@@ -21,6 +21,9 @@ class BlobStore(object):
         """
         raise NotImplementedError()
 
+    def get_blob_method(self) -> str:
+        raise NotImplementedError()
+
     def generate_presigned_url(
             self,
             bucket: str,

--- a/dss/blobstore/s3.py
+++ b/dss/blobstore/s3.py
@@ -48,6 +48,9 @@ class S3BlobStore(BlobStore):
                 filter(**kwargs)):
             yield item.key
 
+    def get_blob_method(self) -> str:
+        return "get_object"
+
     def generate_presigned_url(
             self,
             bucket: str,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+import sys
+import unittest
+
+import requests
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, pkg_root)
+
+import dss  # noqa
+from tests.infra import DSSAsserts  # noqa
+
+
+class TestDSS(unittest.TestCase, DSSAsserts):
+    def setUp(self):
+        DSSAsserts.setup(self)
+        self.app = dss.create_app().app.test_client()
+
+    def test_bundle_api(self):
+        self.assertGetResponse("/v1/bundles", requests.codes.ok)
+        self.assertGetResponse(
+            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26",
+            requests.codes.ok)
+        self.assertGetResponse(
+            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26/55555",
+            requests.codes.bad_request)
+        self.assertGetResponse(
+            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26/55555?replica=foo",
+            requests.codes.ok)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -17,7 +17,7 @@ import dss  # noqa
 from tests.infra import DSSAsserts  # noqa
 
 
-class TestDSS(unittest.TestCase, DSSAsserts):
+class TestFileApi(unittest.TestCase, DSSAsserts):
     def setUp(self):
         DSSAsserts.setup(self)
         self.app = dss.create_app().app.test_client()
@@ -55,18 +55,6 @@ class TestDSS(unittest.TestCase, DSSAsserts):
             }
         )
         self.assertIn('timestamp', response[2])
-
-    def test_bundle_api(self):
-        self.assertGetResponse("/v1/bundles", requests.codes.ok)
-        self.assertGetResponse(
-            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26",
-            requests.codes.ok)
-        self.assertGetResponse(
-            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26/55555",
-            requests.codes.bad_request)
-        self.assertGetResponse(
-            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26/55555?replica=foo",
-            requests.codes.ok)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
get_presigned_url requires a method name, and that is not the same in each cloud.  I want to revisit this hideous hack later when time is less pressing.