### PR TITLE
Clean up the bundle interface.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -204,9 +204,31 @@ paths:
                   $ref: "#/definitions/Bundle"
             required:
               - bundles
+# TODO: this sort of thing actually belongs in the /bundles query interface.
+#    get:
+#      operationId: dss.api.bundles.list_versions
+#      parameters:
+#        - name: uuid
+#          in: path
+#          description: Bundle unique ID.
+#          required: true
+#          type: string
+#          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+#      responses:
+#        200:
+#          description: OK
+#          schema:
+#            type: array
+#            items:
+#              type: string
+#              format: date-time
+#              description: Version of bundle creation in RFC3339.
+#        default:
+#          description: Unexpected error
+#          schema:
+#            $ref: '#/definitions/Error'
   /bundles/{uuid}:
     get:
-      operationId: dss.api.bundles.list_versions
       parameters:
         - name: uuid
           in: path
@@ -214,38 +236,18 @@ paths:
           required: true
           type: string
           pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
-      responses:
-        200:
-          description: OK
-          schema:
-            type: array
-            items:
-              type: string
-              format: date-time
-              description: Version of bundle creation in RFC3339.
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-  /bundles/{uuid}/{bundle_version}:
-    get:
-      parameters:
+        - name: version
+          in: query
+          description: Timestamp of bundle creation in RFC3339.
+          required: true
+          type: string
+          format: date-time
         - name: replica
           in: query
           description: Replica to fetch from.
           required: true
           type: string
-        - name: uuid
-          in: path
-          description: Bundle unique ID.
-          required: true
-          type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
-        - name: bundle_version
-          in: path
-          description: Version of the bundle.
-          required: true
-          type: string
+          enum: [aws, gc, azure]
       responses:
         200:
           description: OK

--- a/dss/api/bundles.py
+++ b/dss/api/bundles.py
@@ -1,15 +1,17 @@
 import uuid
 
-from flask import redirect
 
-def get(uuid: str, bundle_version: str, replica: str):
+def get(uuid: str, version: str, replica: str):
     return []
+
 
 def list_versions(uuid: str):
     return ["2014-10-23T00:35:14.800221Z"]
 
+
 def list():
     return dict(bundles=[dict(uuid=str(uuid.uuid4()), versions=[])])
+
 
 def post():
     pass

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -24,13 +24,10 @@ class TestDSS(unittest.TestCase, DSSAsserts):
     def test_bundle_api(self):
         self.assertGetResponse("/v1/bundles", requests.codes.ok)
         self.assertGetResponse(
-            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26",
-            requests.codes.ok)
-        self.assertGetResponse(
-            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26/55555",
+            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26?version=2017-06-16T19:36:04.240704Z",
             requests.codes.bad_request)
         self.assertGetResponse(
-            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26/55555?replica=foo",
+            "/v1/bundles/91839244-66ab-408f-9be5-c82def201f26?version=2017-06-16T19:36:04.240704Z&replica=aws",
             requests.codes.ok)
 
 


### PR DESCRIPTION
1) list operation should belong inside the /bundles uri.
2) timestamp -> version
3) enforce data formats such as version: date-time and replica: (AWS|GC|Azure)