### PR TITLE
Refactor the presigned url API.

### DIFF
--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -67,10 +67,9 @@ def get(uuid: str, replica: str=None, version: str=None):
     ))
 
     if request.method == "GET":
-        response = redirect(handle.generate_presigned_url(
+        response = redirect(handle.generate_presigned_GET_url(
             bucket,
-            blob_path,
-            handle.get_blob_method()))
+            blob_path))
     else:
         response = make_response('', 200)
 

--- a/dss/blobstore/__init__.py
+++ b/dss/blobstore/__init__.py
@@ -24,11 +24,10 @@ class BlobStore(object):
     def get_blob_method(self) -> str:
         raise NotImplementedError()
 
-    def generate_presigned_url(
+    def generate_presigned_GET_url(
             self,
             bucket: str,
             object_name: str,
-            method: str,
             **kwargs) -> str:
         # TODO: things like http ranges need to be explicit parameters.
         # users of this API should not need to know the argument names presented

--- a/dss/blobstore/s3.py
+++ b/dss/blobstore/s3.py
@@ -48,10 +48,18 @@ class S3BlobStore(BlobStore):
                 filter(**kwargs)):
             yield item.key
 
-    def get_blob_method(self) -> str:
-        return "get_object"
+    def generate_presigned_GET_url(
+            self,
+            bucket: str,
+            object_name: str,
+            **kwargs) -> str:
+        return self._generate_presigned_url(
+            bucket,
+            object_name,
+            "get_object"
+        )
 
-    def generate_presigned_url(
+    def _generate_presigned_url(
             self,
             bucket: str,
             object_name: str,

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -108,10 +108,9 @@ class TestS3BlobStore(unittest.TestCase, BlobStoreTests):
     # TODO: this should be moved to BlobStoreTests once we build the GCS
     # equivalents out
     def testGetPresignedUrl(self):
-        presigned_url = self.handle.generate_presigned_url(
+        presigned_url = self.handle.generate_presigned_GET_url(
             self.test_src_data_bucket,
             "test_good_source_data/0",
-            method="get_object"
         )
 
         resp = requests.get(presigned_url)


### PR DESCRIPTION
I can't think of a good way to be simultaneously concise and retain the power of the underlying API.  Instead, we'll have explicit methods for each type of presigned urls we might want.