### PR TITLE
Patch the tags into the metadata set.

### DIFF
--- a/dss/blobstore/s3.py
+++ b/dss/blobstore/s3.py
@@ -152,7 +152,17 @@ class S3BlobStore(BlobStore):
                 Bucket=bucket,
                 Key=object_name
             )
-            return response['Metadata']
+            metadata = response['Metadata'].copy()
+
+            response = self.s3_client.get_object_tagging(
+                Bucket=bucket,
+                Key=object_name,
+            )
+            for tag in response['TagSet']:
+                key, value = tag['Key'], tag['Value']
+                metadata[key] = value
+
+            return metadata
         except botocore.exceptions.ClientError as ex:
             if int(ex.response['Error']['Code']) == \
                     int(requests.codes.not_found):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -45,6 +45,26 @@ class TestFileApi(unittest.TestCase, DSSAsserts):
         )
         self.assertIn('version', response[2])
 
+    def test_file_put_metadata_from_tags(self):
+        file_uuid = uuid.uuid4()
+        response = self.assertPutResponse(
+            "/v1/files/" + str(file_uuid),
+            requests.codes.created,
+            json_request_body=dict(
+                source_url="s3://hca-dss-test-src/test_good_source_data/metadata_in_tags",
+                bundle_uuid=str(uuid.uuid4()),
+                creator_uid=4321,
+                content_type="text/html",
+            ),
+        )
+        self.assertHeaders(
+            response[0],
+            {
+                'content-type': "application/json",
+            }
+        )
+        self.assertIn('version', response[2])
+
     def test_file_head(self):
         file_uuid = "ce55fd51-7833-469b-be0b-5da88ebebfcd"
         version = "2017-06-16T19:36:04.240704Z"


### PR DESCRIPTION
Patch the tags into the metadata set.

For S3, metadata = metadata + tags.

Other cloud providers do not appear to have the notion of tags, so this is a S3-specific thing.
