### PR TITLE
Clarifications of the swagger spec.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -68,21 +68,21 @@ paths:
               description: Content-type of the file.
               type: string
             X-DSS-CRC32C:
-              description: CRC32C of the file contents in hex.
+              description: CRC-32C (in hex format) of the file contents in hex.
               type: string
-              pattern: "^[A-Za-z0-9]{8}$"
+              pattern: "^[a-z0-9]{8}$"
             X-DSS-S3-ETAG:
-              description: S3 ETag of the file contents.
+              description: S3 ETag (in hex format) of the file contents.
               type: string
-              pattern: "^[A-Za-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
+              pattern: "^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
             X-DSS-SHA1:
-              description: SHA-1 of the file contents in hex.
+              description: SHA-1 (in hex format) of the file contents in hex.
               type: string
-              pattern: "^[A-Za-z0-9]{40}$"
+              pattern: "^[a-z0-9]{40}$"
             X-DSS-SHA256:
-              description: SHA-256 of the file contents in hex.
+              description: SHA-256 (in hex format) of the file contents in hex.
               type: string
-              pattern: "^[A-Za-z0-9]{64}$"
+              pattern: "^[a-z0-9]{64}$"
         default:
           description: Unexpected error
           schema:
@@ -120,21 +120,21 @@ paths:
               description: Content-type of the file.
               type: string
             X-DSS-CRC32C:
-              description: CRC32C of the file contents in hex.
+              description: CRC-32C (in hex format) of the file contents in hex.
               type: string
-              pattern: "^[A-Za-z0-9]{8}$"
+              pattern: "^[a-z0-9]{8}$"
             X-DSS-S3-ETAG:
-              description: S3 ETag of the file contents.
+              description: S3 ETag (in hex format) of the file contents.
               type: string
-              pattern: "^[A-Za-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
+              pattern: "^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
             X-DSS-SHA1:
-              description: SHA-1 of the file contents in hex.
+              description: SHA-1 (in hex format) of the file contents in hex.
               type: string
-              pattern: "^[A-Za-z0-9]{40}$"
+              pattern: "^[a-z0-9]{40}$"
             X-DSS-SHA256:
-              description: SHA-256 of the file contents in hex.
+              description: SHA-256 (in hex format) of the file contents in hex.
               type: string
-              pattern: "^[A-Za-z0-9]{64}$"
+              pattern: "^[a-z0-9]{64}$"
     put:
       summary: Create a file
       description: |
@@ -340,7 +340,7 @@ definitions:
       uuid:
         type: string
         description: File unique ID
-        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
       name:
         type: string
         description: Filename (unique within a bundle)
@@ -360,7 +360,7 @@ definitions:
       uuid:
         type: string
         description: A RFC4122-compliant ID for the file.
-        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
       version:
         type: string
         format: date-time
@@ -368,15 +368,19 @@ definitions:
       crc32c:
         type: string
         description: CRC-32C (in hex format) of the file contents in hex.
+        pattern: "^[a-z0-9]{8}$"
       s3_etag:
         type: string
         description: S3 ETag (in hex format) of the file contents.
+        pattern: "^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
       sha1:
         type: string
         description: SHA-1 (in hex format) of the file contents in hex.
+        pattern: "^[a-z0-9]{40}$"
       sha256:
         type: string
         description: SHA-256 (in hex format) of the file contents in hex.
+        pattern: "^[a-z0-9]{64}$"
     required:
       - uuid
       - version
@@ -413,7 +417,7 @@ definitions:
           bundle_uuid:
             type: string
             description: A RFC4122-compliant ID for the bundle that contains this file.
-            pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+            pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
           creator_uid:
             type: integer
             format: int64
@@ -428,7 +432,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
       versions:
         type: array
         items:
@@ -444,7 +448,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
       version:
         type: string
         format: date-time


### PR DESCRIPTION
1. Return values are always lower case.  Input values remain case-insensitive.
2. Add patterns in some places where they are missing.
3. Clarify that the checksums are in hex format.