### PR TITLE
Checksum-based mechanism for determining whether we copy.

### DIFF
--- a/dss/hcablobstore/__init__.py
+++ b/dss/hcablobstore/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import typing
+
 
 class HCABlobStore(object):
     """Abstract base class for all HCA-specific logic for dealing with individual clouds."""
@@ -14,8 +16,20 @@ class HCABlobStore(object):
     def copy_blob_from_staging(
         self,
         src_bucket: str, src_object_name: str,
-        dst_bucket: str, dst_object_name: str,
+        bucket: str, object_name: str,
     ):
+        raise NotImplementedError()
+
+    def verify_blob_checksum(self, bucket: str, object_name: str, metadata: typing.Dict[str, str]) -> bool:
+        """
+        Given a blob, verify that the checksum on the cloud store matches the checksum in the metadata dictionary.  The
+        keys to the metadata dictionary will be the items in ``COPIED_METADATA``.  Each cloud-specific implementation
+        of ``HCABlobStore`` should extract the correct field and check it against the cloud-provided checksum.
+        :param bucket:
+        :param object_name:
+        :param metadata:
+        :return: True iff the checksum is correct.
+        """
         raise NotImplementedError()
 
 

--- a/dss/hcablobstore/s3.py
+++ b/dss/hcablobstore/s3.py
@@ -31,3 +31,16 @@ class S3HCABlobStore(HCABlobStore):
             src_bucket, src_object_name,
             dst_bucket, dst_object_name,
             **kwargs)
+
+    def verify_blob_checksum(self, bucket: str, object_name: str, metadata: typing.Dict[str, str]) -> bool:
+        """
+        Given a blob, verify that the checksum on the cloud store matches the checksum in the metadata dictionary.  The
+        keys to the metadata dictionary will be the items in ``COPIED_METADATA``.  Each cloud-specific implementation
+        of ``HCABlobStore`` should extract the correct field and check it against the cloud-provided checksum.
+        :param bucket:
+        :param object_name:
+        :param metadata:
+        :return: True iff the checksum is correct.
+        """
+        checksum = self.handle.get_cloud_checksum(bucket, object_name)
+        return checksum == metadata[HCABlobStore.MANDATORY_METADATA['S3_ETAG']]

--- a/tests/test_s3hcablobstore.py
+++ b/tests/test_s3hcablobstore.py
@@ -9,9 +9,12 @@ import uuid
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, pkg_root)
 
+from dss.blobstore import BlobNotFoundError  # noqa
 from dss.blobstore.s3 import S3BlobStore  # noqa
+from dss.hcablobstore import HCABlobStore  # noqa
 from dss.hcablobstore.s3 import S3HCABlobStore  # noqa
 from tests import TESTOUTPUT_PREFIX, utils  # noqa
+
 
 class TestS3HCABlobStore(unittest.TestCase):
     def setUp(self):
@@ -36,6 +39,33 @@ class TestS3HCABlobStore(unittest.TestCase):
         dst_metadata = self.blobhandle.get_metadata(
             self.test_bucket, dst_blob_name)
         self.assertEqual(src_metadata, dst_metadata)
+
+    def test_verify_blob_checksum(self):
+        self.assertTrue(
+            self.hcahandle.verify_blob_checksum(
+                self.test_src_data_bucket, "test_good_source_data/0",
+                {
+                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']: "3b83ef96387f14655fc854ddc3c6bd57",
+                }
+            )
+        )
+
+        self.assertFalse(
+            self.hcahandle.verify_blob_checksum(
+                self.test_src_data_bucket, "test_good_source_data/1",
+                {
+                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']: "3b83ef96387f14655fc854ddc3c6bd57",
+                }
+            )
+        )
+
+        with self.assertRaises(BlobNotFoundError):
+            self.hcahandle.verify_blob_checksum(
+                self.test_src_data_bucket, "test_good_source_data/0/DOES_NOT_EXIST",
+                {
+                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']: "3b83ef96387f14655fc854ddc3c6bd57",
+                }
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now the new approach is:

1. Does the checksum on disk match our expectations?  If so, skip the copy.
2. Do the copy and verify that the copy was done correctly.