### PR TITLE
Rename metadata list and make it more useful.

### DIFF
--- a/dss/hcablobstore/__init__.py
+++ b/dss/hcablobstore/__init__.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+
 class HCABlobStore(object):
     """Abstract base class for all HCA-specific logic for dealing with individual clouds."""
-    COPIED_METADATA = (
-        "hca-dss-sha1",
-        "hca-dss-crc32c",
-        "hca-dss-sha256",
-        "hca-dss-s3_etag",
-        "hca-dss-content-type",
+    MANDATORY_METADATA = dict(
+        SHA1="hca-dss-sha1",
+        CRC32C="hca-dss-crc32c",
+        SHA256="hca-dss-sha256",
+        S3_ETAG="hca-dss-s3_etag",
+        CONTENT_TYPE="hca-dss-content-type",
     )
 
     def copy_blob_from_staging(

--- a/dss/hcablobstore/s3.py
+++ b/dss/hcablobstore/s3.py
@@ -23,7 +23,7 @@ class S3HCABlobStore(HCABlobStore):
         kwargs = dict()  # type: typing.Dict[str, typing.Any]
         kwargs['CopySourceIfMatch'] = source_metadata['hca-dss-s3_etag']
         kwargs['Metadata'] = dict()
-        for metadata_key in HCABlobStore.COPIED_METADATA:
+        for metadata_key in HCABlobStore.MANDATORY_METADATA.values():
             kwargs['Metadata'][metadata_key] = source_metadata[metadata_key]
         kwargs['MetadataDirective'] = "REPLACE"
 


### PR DESCRIPTION
1. Make it a dict so other code can reference it more easily.
2. It's not going to be copied any more, just going to be mandatory to be present.