### PR TITLE
Generalize the mechanism for lower-casing the metadata fields.

### DIFF
--- a/dss/hcablobstore/__init__.py
+++ b/dss/hcablobstore/__init__.py
@@ -5,12 +5,30 @@ import typing
 
 class HCABlobStore(object):
     """Abstract base class for all HCA-specific logic for dealing with individual clouds."""
+
+    """
+    Metadata fields we expect the staging area to set.  Each field points to a metadata spec, which is a dictionary
+    consisting of the following fields:
+
+    keyname: the actual keyname that references the data on the object in the staging area.
+    downcase: True iff we are required to downcase the field.
+    """
     MANDATORY_METADATA = dict(
-        SHA1="hca-dss-sha1",
-        CRC32C="hca-dss-crc32c",
-        SHA256="hca-dss-sha256",
-        S3_ETAG="hca-dss-s3_etag",
-        CONTENT_TYPE="hca-dss-content-type",
+        SHA1=dict(
+            keyname="hca-dss-sha1",
+            downcase=True),
+        CRC32C=dict(
+            keyname="hca-dss-crc32c",
+            downcase=True),
+        SHA256=dict(
+            keyname="hca-dss-sha256",
+            downcase=True),
+        S3_ETAG=dict(
+            keyname="hca-dss-s3_etag",
+            downcase=True),
+        CONTENT_TYPE=dict(
+            keyname="hca-dss-content-type",
+            downcase=False),
     )
 
     def verify_blob_checksum(self, bucket: str, object_name: str, metadata: typing.Dict[str, str]) -> bool:

--- a/dss/hcablobstore/s3.py
+++ b/dss/hcablobstore/s3.py
@@ -21,4 +21,5 @@ class S3HCABlobStore(HCABlobStore):
         :return: True iff the checksum is correct.
         """
         checksum = self.handle.get_cloud_checksum(bucket, object_name)
-        return checksum.lower() == metadata[HCABlobStore.MANDATORY_METADATA['S3_ETAG']].lower()
+        metadata_checksum_key = typing.cast(str, HCABlobStore.MANDATORY_METADATA['S3_ETAG']['keyname'])
+        return checksum.lower() == metadata[metadata_checksum_key].lower()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -65,6 +65,26 @@ class TestFileApi(unittest.TestCase, DSSAsserts):
         )
         self.assertIn('version', response[2])
 
+    def test_file_put_upper_case_checksums(self):
+        file_uuid = uuid.uuid4()
+        response = self.assertPutResponse(
+            "/v1/files/" + str(file_uuid),
+            requests.codes.created,
+            json_request_body=dict(
+                source_url="s3://hca-dss-test-src/test_good_source_data/incorrect_case_checksum",
+                bundle_uuid=str(uuid.uuid4()),
+                creator_uid=4321,
+                content_type="text/html",
+            ),
+        )
+        self.assertHeaders(
+            response[0],
+            {
+                'content-type': "application/json",
+            }
+        )
+        self.assertIn('version', response[2])
+
     def test_file_head(self):
         file_uuid = "ce55fd51-7833-469b-be0b-5da88ebebfcd"
         version = "2017-06-16T19:36:04.240704Z"

--- a/tests/test_s3hcablobstore.py
+++ b/tests/test_s3hcablobstore.py
@@ -30,7 +30,7 @@ class TestS3HCABlobStore(unittest.TestCase):
             self.hcahandle.verify_blob_checksum(
                 self.test_src_data_bucket, "test_good_source_data/0",
                 {
-                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']: "3b83ef96387f14655fc854ddc3c6bd57",
+                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']['keyname']: "3b83ef96387f14655fc854ddc3c6bd57",
                 }
             )
         )
@@ -39,7 +39,7 @@ class TestS3HCABlobStore(unittest.TestCase):
             self.hcahandle.verify_blob_checksum(
                 self.test_src_data_bucket, "test_good_source_data/1",
                 {
-                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']: "3b83ef96387f14655fc854ddc3c6bd57",
+                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']['keyname']: "3b83ef96387f14655fc854ddc3c6bd57",
                 }
             )
         )
@@ -48,7 +48,7 @@ class TestS3HCABlobStore(unittest.TestCase):
             self.hcahandle.verify_blob_checksum(
                 self.test_src_data_bucket, "test_good_source_data/0/DOES_NOT_EXIST",
                 {
-                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']: "3b83ef96387f14655fc854ddc3c6bd57",
+                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']['keyname']: "3b83ef96387f14655fc854ddc3c6bd57",
                 }
             )
 


### PR DESCRIPTION
Removed the hackery we put in for the integration meeting.

Also added a test where a file with upper cased checksums get processed properly.