### PR TITLE
Remove ':' from the generated version names.

### DIFF
--- a/dss/api/bundles.py
+++ b/dss/api/bundles.py
@@ -3,7 +3,7 @@ import io
 import json
 import uuid
 
-import pyrfc3339
+import iso8601
 import requests
 from flask import jsonify, make_response, request
 
@@ -85,14 +85,10 @@ def put(uuid: str, replica: str, version: str=None):
     uuid = uuid.lower()
     if version is not None:
         # convert it to date-time so we can format exactly as the system requires (with microsecond precision)
-        timestamp = pyrfc3339.parse(version, utc=True)
+        timestamp = iso8601.parse_date(version)
     else:
         timestamp = datetime.datetime.utcnow()
-    version = pyrfc3339.generate(
-        timestamp,
-        accept_naive=True,
-        microseconds=True,
-        utc=True)
+    version = timestamp.strftime("%Y-%m-%dT%H%M%S.%fZ")
 
     handle, hca_handle, bucket = \
         Config.get_cloud_specific_handles("aws")

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -1,11 +1,12 @@
 import datetime
 import io
 import json
-import pyrfc3339
 import re
-import requests
 import typing
 import uuid
+
+import iso8601
+import requests
 
 from flask import jsonify, make_response, redirect, request
 from werkzeug.exceptions import BadRequest
@@ -101,14 +102,10 @@ def put(uuid: str, version: str=None):
     uuid = uuid.lower()
     if version is not None:
         # convert it to date-time so we can format exactly as the system requires (with microsecond precision)
-        timestamp = pyrfc3339.parse(version, utc=True)
+        timestamp = iso8601.parse_date(version)
     else:
         timestamp = datetime.datetime.utcnow()
-    version = pyrfc3339.generate(
-        timestamp,
-        accept_naive=True,
-        microseconds=True,
-        utc=True)
+    version = timestamp.strftime("%Y-%m-%dT%H%M%S.%fZ")
 
     # get the metadata to find out what the eventual file will be called.
     request_data = request.get_json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ elasticsearch
 elasticsearch_dsl
 flask-failsafe
 google-cloud-storage
-pyrfc3339
+iso8601
 urllib3


### PR DESCRIPTION
Use iso8601 to parse the timestamps, and datetime.datetime.strftime to format the dates.