### PR TITLE
Nicer error messages when we can't find a bundle or a file.

### DIFF
--- a/dss/api/bundles.py
+++ b/dss/api/bundles.py
@@ -35,11 +35,17 @@ def get(
         return make_response("Cannot find file!", 404)
 
     # retrieve the bundle metadata.
-    bundle_metadata = json.loads(
-        handle.get(
-            bucket,
-            "bundles/{}.{}".format(uuid, version)
-        ).decode("utf-8"))
+    try:
+        bundle_metadata = json.loads(
+            handle.get(
+                bucket,
+                "bundles/{}.{}".format(uuid, version)
+            ).decode("utf-8"))
+    except BlobNotFoundError as ex:
+        return jsonify(dict(
+            message="Cannot find bundle.",
+            exception=str(ex),
+            HTTPStatusCode=requests.codes.not_found)), requests.codes.not_found
 
     return dict(
         bundle=dict(

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -53,11 +53,17 @@ def get(uuid: str, replica: str=None, version: str=None):
         return make_response("Cannot find file!", 404)
 
     # retrieve the file metadata.
-    file_metadata = json.loads(
-        handle.get(
-            bucket,
-            "files/{}.{}".format(uuid, version)
-        ).decode("utf-8"))
+    try:
+        file_metadata = json.loads(
+            handle.get(
+                bucket,
+                "files/{}.{}".format(uuid, version)
+            ).decode("utf-8"))
+    except BlobNotFoundError as ex:
+        return jsonify(dict(
+            message="Cannot find file.",
+            exception=str(ex),
+            HTTPStatusCode=requests.codes.not_found)), requests.codes.not_found
 
     blob_path = "blobs/" + ".".join((
         file_metadata[FileMetadata.SHA256],


### PR DESCRIPTION
```
{
  "HTTPStatusCode": 404,
  "exception": "An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist.",
  "message": "Cannot find bundle."
}
```