### PR TITLE
Index daemon: Handle S3 test event without crashing

### DIFF
--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -19,4 +19,7 @@ s3_bucket = os.environ.get("DSS_S3_TEST_BUCKET")
 @app.s3_event_handler(bucket=s3_bucket, events=["s3:ObjectCreated:*"])
 def dispatch_indexer_event(event, context) -> None:
     app.log.setLevel(logging.DEBUG)
-    process_new_indexable_object(event, logger=app.log)
+    if event.get("Event") == "s3:TestEvent":
+        app.log.info("DSS index daemon received S3 test event")
+    else:
+        process_new_indexable_object(event, logger=app.log)


### PR DESCRIPTION
@mikebaumann, this makes the index daemon print a nice message on S3 test events (which get sent every time a deploy/event subscription happens) instead of an ugly stack trace. Please merge after review.