### PR TITLE
Changes to indexing and query for the Boston Demo

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -10,6 +10,20 @@ basePath: /v1
 produces:
   - application/json
 paths:
+  /search:
+    get:
+      description: |
+        Returns a list of files matching given criteria.
+      summary: Find files and bundles by querying their metadata
+      parameters:
+        - name: query
+          in: query
+          description: Metadata query
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
   /files:
     get:
       summary: Query files

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -13,8 +13,8 @@ paths:
   /search:
     get:
       description: |
-        Returns a list of files matching given criteria.
-      summary: Find files and bundles by querying their metadata
+        Returns a list of bundles matching the given simple criteria
+      summary: Find bundles by querying their metadata using simple criteria
       parameters:
         - name: query
           in: query

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -24,6 +24,32 @@ paths:
       responses:
         200:
           description: OK
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      description: |
+        Accepts Elasticsearch JSON query and returns matching bundle identifiers
+      summary: |
+        Find bundles by searching their metadata with an Elasticsearch query
+      consumes:
+        - application/json
+      parameters:
+        - name: query
+          in: body
+          description: Elasticsearch query
+          schema:
+            type: object
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /files:
     get:
       summary: Query files

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -11,6 +11,10 @@ import connexion
 from connexion.resolver import RestyResolver
 from flask_failsafe import failsafe
 
+# Constants common to the indexer and query route.
+DSS_ELASTICSEARCH_INDEX_NAME = "hca"
+DSS_ELASTICSEARCH_DOC_TYPE = "hca"
+
 def get_logger():
     try:
         return flask.current_app.logger

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -1,0 +1,22 @@
+import json
+import os
+
+from elasticsearch_dsl import Search
+from flask import request
+
+from .. import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE
+from .. import get_logger
+from ..util import connect_elasticsearch
+
+
+def list():
+    es = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())  # TODO Use a connection manager
+    get_logger().debug("Searching for: %s", request.values["query"])
+
+    query = json.loads(request.values["query"])
+    s = Search(using=es, index=DSS_ELASTICSEARCH_INDEX_NAME, doc_type=DSS_ELASTICSEARCH_DOC_TYPE)\
+        .query("match", **query)
+    response = s.execute()
+    # TODO Format output
+    results = [{"id": hit.meta.id, "score": hit.meta.score} for hit in response]
+    return {"query": query, "results": results}

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -10,8 +10,9 @@ from ..util import connect_elasticsearch
 
 
 def list():
-    es_client = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())  # TODO Use a connection manager
     get_logger().debug("Searching for: %s", request.values["query"])
+    # TODO (mbaumann) Use a connection manager
+    es_client = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())
     query = json.loads(request.values["query"])
     response = Search(using=es_client,
                       index=DSS_ELASTICSEARCH_INDEX_NAME,
@@ -21,7 +22,8 @@ def list():
 
 def post(query: dict):
     get_logger().debug("Received posted query: %s", json.dumps(query, indent=4))
-    es_client = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())  # TODO Use a connection manager
+    # TODO (mbaumann) Use a connection manager
+    es_client = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())
     response = Search(using=es_client,
                       index=DSS_ELASTICSEARCH_INDEX_NAME,
                       doc_type=DSS_ELASTICSEARCH_DOC_TYPE).update_from_dict(query).execute()
@@ -29,7 +31,9 @@ def post(query: dict):
 
 
 def format_results(request, response):
-    bundles_url_base = request.host_url + request.full_path[1:].replace('search?', 'bundles/')
+    # TODO (mbaumann) extract version from the request path instead of hard-coding it here
+    # The previous code worked for post but incorrectly included the query string in the case of get.
+    bundles_url_base = request.host_url + 'v1/bundles/'
     result_list = []
     for hit in response:
         result = {

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -10,13 +10,32 @@ from ..util import connect_elasticsearch
 
 
 def list():
-    es = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())  # TODO Use a connection manager
+    es_client = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())  # TODO Use a connection manager
     get_logger().debug("Searching for: %s", request.values["query"])
-
     query = json.loads(request.values["query"])
-    s = Search(using=es, index=DSS_ELASTICSEARCH_INDEX_NAME, doc_type=DSS_ELASTICSEARCH_DOC_TYPE)\
-        .query("match", **query)
-    response = s.execute()
-    # TODO Format output
-    results = [{"id": hit.meta.id, "score": hit.meta.score} for hit in response]
-    return {"query": query, "results": results}
+    response = Search(using=es_client,
+                      index=DSS_ELASTICSEARCH_INDEX_NAME,
+                      doc_type=DSS_ELASTICSEARCH_DOC_TYPE).query("match", **query).execute()
+    return {"query": query, "results": format_results(request, response)}
+
+
+def post(query: dict):
+    get_logger().debug("Received posted query: %s", json.dumps(query, indent=4))
+    es_client = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())  # TODO Use a connection manager
+    response = Search(using=es_client,
+                      index=DSS_ELASTICSEARCH_INDEX_NAME,
+                      doc_type=DSS_ELASTICSEARCH_DOC_TYPE).update_from_dict(query).execute()
+    return {"query": query, "results": format_results(request, response)}
+
+
+def format_results(request, response):
+    bundles_url_base = request.host_url + request.full_path[1:].replace('search?', 'bundles/')
+    result_list = []
+    for hit in response:
+        result = {
+            'bundle_id': hit.meta.id,
+            'bundle_url': bundles_url_base + hit.meta.id,
+            'search_score': hit.meta.score
+        }
+        result_list.append(result)
+    return result_list

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -58,7 +58,7 @@ def create_index_data(s3, bucket_name, manifest, logger):
     for file_info in files_info:
         if file_info['indexed'] is True:
             if not file_info["name"].endswith(".json"):  # TODO Don't check filename, if file is 'indexed' load json
-                logger.warning("File %s is marked for indexing but is not of type JSON. It will not be indexed.",
+                logger.warning("File %s is marked for indexing but does not end in .json. It will not be indexed.",
                                file_info["name"])
                 continue
             logger.debug("Indexing file: %s", file_info["name"])

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -1,16 +1,12 @@
 import json
-import logging
 import os
 import re
 from urllib.parse import unquote
 
 import boto3
-from elasticsearch import Elasticsearch, RequestsHttpConnection
 
-from ...util import AWSV4Sign
-
-HCA_ES_INDEX_NAME = "hca-metadata"
-HCA_METADATA_DOC_TYPE = "hca"
+from ... import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE
+from ...util import connect_elasticsearch
 
 DSS_BUNDLE_KEY_REGEX = r"^bundles/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\..+$"
 
@@ -18,20 +14,17 @@ DSS_BUNDLE_KEY_REGEX = r"^bundles/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-
 # Lambda function for DSS indexing
 #
 
+
 def process_new_indexable_object(event, logger) -> None:
     try:
-        # Currently this function is only called for S3 creation events
-        validate_environment_variables("DSS_S3_TEST_BUCKET", "DSS_ES_ENDPOINT")
-
+        # This function is only called for S3 creation events
         key = unquote(event['Records'][0]["s3"]["object"]["key"])
         if is_bundle_to_index(key):
             logger.info("Received S3 creation event for bundle which will be indexed: %s", key)
-            bucket = boto3.resource("s3").Bucket(event['Records'][0]["s3"]["bucket"]["name"])
-            debug_log_object_info(bucket, key, logger)
-            check_for_tombstone(bucket, key, logger)
             s3 = boto3.resource('s3')
-            manifest = read_bundle_manifest(s3, bucket, key, logger)
-            index_data = create_index_data(s3, bucket, key, manifest, logger)
+            bucket_name = event['Records'][0]["s3"]["bucket"]["name"]
+            manifest = read_bundle_manifest(s3, bucket_name, key, logger)
+            index_data = create_index_data(s3, bucket_name, manifest, logger)
             add_index_data_to_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), key, index_data, logger)
             logger.debug("Finished index processing of S3 creation event for bundle: %s", key)
         else:
@@ -50,33 +43,41 @@ def is_bundle_to_index(key) -> bool:
     return result is not None
 
 
-# TODO Future - Identified in the spec yet not needed for current prototype.
-def check_for_tombstone(bucket, key, log):
-    pass
-
-
-def read_bundle_manifest(s3, bucket, bundle_key, log):
-    manifest_string = s3.Object(os.getenv("DSS_S3_TEST_BUCKET"), bundle_key).get()['Body'].read().decode("utf-8")
-    log.debug("Read bundle manifest from bucket %s with bundle key %s: %s", bucket.name, bundle_key, manifest_string)
+def read_bundle_manifest(s3, bucket_name, bundle_key, logger):
+    manifest_string = s3.Object(bucket_name, bundle_key).get()['Body'].read().decode("utf-8")
+    logger.debug("Read bundle manifest from bucket %s with bundle key %s: %s", bucket_name, bundle_key, manifest_string)
     manifest = json.loads(manifest_string, encoding="utf-8")
     return manifest
 
 
-def create_index_data(s3, bucket, bundle_key, manifest, log):
+def create_index_data(s3, bucket_name, manifest, logger):
     index = dict(state="new", manifest=manifest)
     files_info = manifest['files']
     index_files = {}
-    bucket = s3.Bucket(os.getenv("DSS_S3_TEST_BUCKET"))
+    bucket = s3.Bucket(bucket_name)
     for file_info in files_info:
         if file_info['indexed'] is True:
-            if not file_info["name"].endswith(".json"):
-                log.warning("File %s is marked for indexing but is not of type JSON. It will not be indexed.")
+            if not file_info["name"].endswith(".json"):  # TODO Don't check filename, if file is 'indexed' load json
+                logger.warning("File %s is marked for indexing but is not of type JSON. It will not be indexed.",
+                               file_info["name"])
                 continue
-            log.debug("Indexing file: %s", file_info["name"])
+            logger.debug("Indexing file: %s", file_info["name"])
             file_key = create_file_key(file_info)
             file_string = bucket.Object(file_key).get()['Body'].read().decode("utf-8")
             file_json = json.loads(file_string)
-            index_files[file_info["name"]] = file_json
+            # There are two reasons in favor of not using dot in the name of the individual
+            # files in the index document, and instead replacing it with an underscore.
+            # 1. Ambiguity regarding interpretation/processing of dots in field names,
+            #    which could potentially change between Elasticsearch versions. For example, see:
+            #       https://github.com/elastic/elasticsearch/issues/15951
+            # 2. The ES DSL queries are easier to read when there is no abiguity regarding
+            #    dot as a field separator, as may be seen in the Boston demo query.
+            # The Boston demo query spec uses underscore instead of dot in the filename portion
+            # of the query spec, so go with that, at least for now. Do so by substituting
+            # dot for underscore in the key filename portion of the index.
+            # As due diligence, additional investigation should be performed.
+            index_filename = file_info["name"].replace(".", "_")
+            index_files[index_filename] = file_json
     index['files'] = index_files
     return index
 
@@ -85,76 +86,34 @@ def create_file_key(file_info) -> str:
     return "blobs/{}.{}.{}.{}".format(file_info['sha256'], file_info['sha1'], file_info['s3-etag'], file_info['crc32c'])
 
 
-def add_index_data_to_elasticsearch(elasticsearchEndpoint, bundle_key, index_data, log) -> None:
-    es_client = connect_elasticsearch(elasticsearchEndpoint, log)
-    create_elasticsearch_index(es_client, log)
-    log.debug("Adding index data to Elasticsearch: %s", json.dumps(index_data, indent=4))
-    add_data_to_elasticsearch(es_client, bundle_key, index_data, log)
+def add_index_data_to_elasticsearch(elasticsearch_endpoint, bundle_key, index_data, logger) -> None:
+    es_client = connect_elasticsearch(elasticsearch_endpoint, logger)
+    create_elasticsearch_index(es_client, logger)
+    logger.debug("Adding index data to Elasticsearch: %s", json.dumps(index_data, indent=4))
+    add_data_to_elasticsearch(es_client, bundle_key, index_data, logger)
 
 
-def connect_elasticsearch(elasticsearch_endpoint: str, log) -> Elasticsearch:
-    log.debug('Connecting to the ES Endpoint: %s', elasticsearch_endpoint)
+def create_elasticsearch_index(es_client, logger):
     try:
-        if (elasticsearch_endpoint is None or elasticsearch_endpoint == ""):
-            raise Exception("The Elasticsearch endpoint is null or empty. " +
-                            "Set environment variable DSS_ES_ENDPOINT to the Elasticsearch endpoint.")
-
-        if elasticsearch_endpoint.endswith(".amazonaws.com"):
-            log.debug("Connecting to AWS Elasticsearch service with endpoint: %s", elasticsearch_endpoint)
-            session = boto3.session.Session()
-            es_auth = AWSV4Sign(session.get_credentials(), session.region_name, service="es")
-            es_client = Elasticsearch(
-                hosts=[{'host': elasticsearch_endpoint, 'port': 443}],
-                use_ssl=True,
-                verify_certs=True,
-                connection_class=RequestsHttpConnection,
-                http_auth=es_auth)
-        else:
-            log.debug("Connecting to local Elasticsearch service.")
-            es_client = Elasticsearch()  # Connect to local Elasticsearch
-        return es_client
-    except Exception as ex:
-        log.error("Unable to connect to Elasticsearch endpoint %s. Exception: %s", elasticsearch_endpoint, ex)
-        raise ex
-
-
-def create_elasticsearch_index(es_client, log):
-    try:
-        response = es_client.indices.exists(HCA_ES_INDEX_NAME)
+        response = es_client.indices.exists(DSS_ELASTICSEARCH_INDEX_NAME)
         if response is False:
-            log.debug("Creating new Elasticsearch index: %s", HCA_ES_INDEX_NAME)
-            response = es_client.indices.create(HCA_ES_INDEX_NAME, body=None)
-            log.debug("Index creation response: %s", json.dumps(response, indent=4))
+            logger.debug("Creating new Elasticsearch index: %s", DSS_ELASTICSEARCH_INDEX_NAME)
+            response = es_client.indices.create(DSS_ELASTICSEARCH_INDEX_NAME, body=None)
+            logger.debug("Index creation response: %s", json.dumps(response, indent=4))
         else:
-            log.debug("Using existing Elasticsearch index: %s", HCA_ES_INDEX_NAME)
+            logger.debug("Using existing Elasticsearch index: %s", DSS_ELASTICSEARCH_INDEX_NAME)
     except Exception as ex:
-        log.critical("Unable to create index %s  Exception: %s", HCA_ES_INDEX_NAME, ex)
+        logger.critical("Unable to create index %s  Exception: %s", DSS_ELASTICSEARCH_INDEX_NAME, ex)
 
 
-def add_data_to_elasticsearch(es_client, bundle_key, index_data, log) -> None:
+def add_data_to_elasticsearch(es_client, bundle_key, index_data, logger) -> None:
     try:
-        if bundle_key.startswith("bundle/"):
-            bundle_key = bundle_key[7:]
-        es_client.index(index=HCA_ES_INDEX_NAME,
-                        doc_type=HCA_METADATA_DOC_TYPE,
+        if bundle_key.startswith("bundles/"):
+            bundle_key = bundle_key[8:]
+        es_client.index(index=DSS_ELASTICSEARCH_INDEX_NAME,
+                        doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
                         id=bundle_key,
                         body=json.dumps(index_data, indent=4))
 
     except Exception as ex:
-        log.error("Document not indexed. Exception: %s  Index data: %s", ex, json.dumps(index_data, indent=4))
-
-
-def validate_environment_variables(*environment_variable_names):
-    invalid_variables = set()
-    for environment_variable_name in environment_variable_names:
-        variable_value = os.getenv(environment_variable_name)
-        if variable_value is None or variable_value == "":
-            invalid_variables.add(environment_variable_name)
-    if invalid_variables:
-        raise Exception("These required environment variables are unset or empty: {}".format(invalid_variables))
-
-
-def debug_log_object_info(bucket, key, log) -> None:
-    if log.isEnabledFor(logging.DEBUG):
-        obj = bucket.Object(key)
-        log.debug("Received an event from S3, object head: %s", obj.get(Range='bytes=0-80')["Body"].read())
+        logger.error("Document not indexed. Exception: %s  Index data: %s", ex, json.dumps(index_data, indent=4))

--- a/dss/util/__init__.py
+++ b/dss/util/__init__.py
@@ -4,6 +4,8 @@ import boto3
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.vendored import requests
+from elasticsearch import RequestsHttpConnection, Elasticsearch
+
 
 class AWSV4Sign(requests.auth.AuthBase):
     """
@@ -29,8 +31,31 @@ class AWSV4Sign(requests.auth.AuthBase):
         r.headers.update(dict(request.headers.items()))
         return r
 
+
 def paginate(boto3_paginator, *args, **kwargs):
     for page in boto3_paginator.paginate(*args, **kwargs):
         for result_key in boto3_paginator.result_keys:
             for value in page.get(result_key.parsed.get("value"), []):
                 yield value
+
+
+def connect_elasticsearch(elasticsearch_endpoint, logger) -> Elasticsearch:
+    try:
+        if elasticsearch_endpoint is None:
+            elasticsearch_endpoint = "localhost"
+        logger.debug("Connecting to Elasticsearch at host: %s", elasticsearch_endpoint)
+        if elasticsearch_endpoint.endswith(".amazonaws.com"):
+            session = boto3.session.Session()
+            es_auth = AWSV4Sign(session.get_credentials(), session.region_name, service="es")
+            es_client = Elasticsearch(
+                hosts=[{'host': elasticsearch_endpoint, 'port': 443}],
+                use_ssl=True,
+                verify_certs=True,
+                connection_class=RequestsHttpConnection,
+                http_auth=es_auth)
+        else:
+            es_client = Elasticsearch([elasticsearch_endpoint], use_ssl=False, port=9200)
+        return es_client
+    except Exception as ex:
+        logger.error("Unable to connect to Elasticsearch endpoint %s. Exception: %s", elasticsearch_endpoint, ex)
+        raise ex

--- a/tests/expected_index_document.json
+++ b/tests/expected_index_document.json
@@ -1,46 +1,46 @@
 {
     "state": "new",
     "manifest": {
-        "version": "0.0.0",
-        "timestamp": "1498097754",
+        "format": "0.0.1",
+        "version": "2017-06-25T004508.521426Z",
         "files": [
             {
                 "name": "assay.json",
-                "uuid": "1268b2d2-52cd-4348-bf71-5ce84a03d0d3",
-                "timestamp": "1498088347",
+                "uuid": "246f0d84-8a37-4b38-b24f-48e3d3caf5cc",
+                "version": "2017-06-25T004508.518443Z",
                 "content-type": "metadata",
                 "indexed": true,
-                "sha256": "7a900ce44e7ce7eb3daebef8baf402596c9533f74f5a06f1d191c2e4391d9e06",
-                "sha1": "e9f08d8e7856d09ce2d68c0abb0909615cf44365",
-                "s3-etag": "7edf489368f8a5ce72d7665c97155ba8",
-                "crc32c": "1600867755"
+                "sha256": "90648706a325a059966f026783a2a4494dcaaf304182df7bff424fb051d8e378",
+                "sha1": "f9ec5bec08d09a7c0a4aff8eeb08cfcdda55192b",
+                "s3-etag": "7b794fa0ecd2d9d05316291c8b9ff818",
+                "crc32c": "3914627142"
             },
             {
                 "name": "project.json",
-                "uuid": "d88b74d8-301e-4f52-97a7-949582730d46",
-                "timestamp": "1498088347",
+                "uuid": "a78cb6eb-0a21-4151-a6b5-7b553a51077f",
+                "version": "2017-06-25T004508.518684Z",
                 "content-type": "metadata",
                 "indexed": true,
-                "sha256": "c155a0762eb2b270eb024b517fe90aa2a922f9cf4cc2d4a7be7073fde36c8d8d",
-                "sha1": "7d6852f696488d681b0e9053b83e2441737bb8bd",
-                "s3-etag": "e3417cd5c70b43201849965192f1ab54",
-                "crc32c": "4224375424"
+                "sha256": "90cdd049c9654e5048a73c3f9ce575d805b72f6c66e6dbacfc3789a7d0b29e4e",
+                "sha1": "99d9ab9b83d900b23af4916677130e54197f9082",
+                "s3-etag": "f2a84e3cc346735eb43cb50010ba583a",
+                "crc32c": "4288412515"
             },
             {
                 "name": "sample.json",
-                "uuid": "5bc89fbb-7f6f-4390-9bbe-132cfbf215aa",
-                "timestamp": "1498088347",
+                "uuid": "aadc1eac-39c7-4e74-aacc-160b1bc468ad",
+                "version": "2017-06-25T004508.518863Z",
                 "content-type": "metadata",
                 "indexed": true,
-                "sha256": "9836291e0be8d0a542c8d5445798bf4075571fc273eb7ed7df30a6653db5ba82",
-                "sha1": "d1c4b9a5b382797849a8a1c1abe8e750f3e4a661",
-                "s3-etag": "dfb861e512bd25157eebeb0415c4f71a",
-                "crc32c": "483430158"
+                "sha256": "38641578ab2343c31dbb56b114f6e4060862c01fde2f84395d3b99f64423afd9",
+                "sha1": "1e2068289735e8b30e75822b6a66660ffdfc57a4",
+                "s3-etag": "ecbaee942c4c617d764f971ab8e6b85c",
+                "crc32c": "240698295"
             },
             {
                 "name": "tmp_test_nonindexed_file1.txt",
-                "uuid": "fa75c7c0-9a4d-4715-9e38-7d156f88c0d9",
-                "timestamp": "1498097754",
+                "uuid": "44617b9a-dee9-4ff2-9cdd-dea8c38b6c79",
+                "version": "2017-06-25T004508.519469Z",
                 "content-type": "metadata",
                 "indexed": false,
                 "sha256": "c9e68d982364f171aa80199d88ee6c938cedb4f374576cf892a9de48a351bf01",
@@ -50,8 +50,8 @@
             },
             {
                 "name": "tmp_test_nonindexed_file2.txt",
-                "uuid": "ff259726-dfd5-4bd6-aa55-23b60edfe92c",
-                "timestamp": "1498097754",
+                "uuid": "dc9d1364-388e-4375-a9ca-062cfb9300d8",
+                "version": "2017-06-25T004508.521263Z",
                 "content-type": "metadata",
                 "indexed": false,
                 "sha256": "1e085356099f660686fa7b5401d35015bd9ea8bf9eecdaa9675125daae9ed893",
@@ -60,109 +60,116 @@
                 "crc32c": "59270288"
             }
         ],
-        "creator_uid": 5
+        "creator_uid": 12345
     },
     "files": {
-        "assay.json": {
+        "assay_json": {
             "files": [
                 {
                     "format": ".fastq.gz",
-                    "name": "SRR3587500_1.fastq.gz",
+                    "name": "SRR2967608_1.fastq.gz",
                     "lane": "1",
-                    "type": "index"
+                    "type": "read1"
                 },
                 {
                     "format": ".fastq.gz",
-                    "name": "SRR3587500_2.fastq.gz",
+                    "name": "SRR2967608_2.fastq.gz",
                     "lane": "1",
-                    "type": "reads"
+                    "type": "read2"
                 }
             ],
             "rna": {
-                "primer": "poly-dt"
+                "primer": "random",
+                "spike_in": "ERCC"
             },
             "seq": {
-                "machine": "Illumina NextSeq 500",
+                "machine": "Illumina HiSeq 2500",
                 "molecule": "total RNA",
-                "paired_ends": "index1_reads2",
-                "prep": "modified Nextera XT",
-                "umi_barcode_offset": "12",
-                "umi_barcode_size": "8",
-                "umi_barcode_read": "index"
+                "paired_ends": "yes"
             },
             "single_cell": {
-                "cell_barcode_offset": "0",
-                "cell_barcode_size": "12",
-                "cell_barcode_read": "index",
-                "method": "drop-seq"
+                "method": "Fluidigm C1"
             },
-            "sra_experiment": "SRX1800075",
-            "sra_run": "SRR3587500"
+            "sra_experiment": "SRX1457054",
+            "sra_run": "SRR2967608"
         },
-        "project.json": {
-            "array_express": {
-                "accession": "E-MTAB-81904"
-            },
+        "project_json": {
             "contact": {
-                "address": "415 Main St.; Cambridge, MA 02142 USA",
-                "city": "Cambridge",
-                "country": "USA",
-                "email": "karthik@broadinstitute.org",
-                "institute": "Broad Institute",
-                "name": "Karthik,,Shekhar",
-                "phone": "217-979-9852",
-                "postal_code": "02142",
-                "state": "MA",
-                "street_address": "415 Main St."
+                "address": "Deutscher Pl. 6; Leipzig,  04103 Germany",
+                "city": "Leipzig",
+                "country": "Germany",
+                "department": "Evolutionary Genetics",
+                "email": "graycamp@gmail.com",
+                "institute": "Max Planck Institute for Evolutionary Anthropology",
+                "name": "Gray,,Camp",
+                "postal_code": "04103",
+                "street_address": "Deutscher Pl. 6"
             },
-            "contributor": "Karthik,,Shekhar",
-            "geo_parent_series": "GSE81905",
-            "geo_series": "GSE81904",
-            "last_update_date": "2017-05-26",
-            "ncbi_bioproject": "PRJNA323370",
-            "overall_design": "Drop-Seq was performed on two different batches. Bipolar1-Bipolar4 are replicates from batch 1 and Bipolar5-6 are replicates from Batch 2",
-            "pmid": "27565351",
-            "release_status": "Public on Aug 25 2016",
-            "sra_project": "SRP075719",
-            "submission_date": "2016-05-25",
-            "summary": "Vsx2-GFP mouse retinas were dissected, FACS sorted for GFP+ cells and single-cell mRNAseq libraries generated with Drop-Seq",
-            "supplementary_files": [
-                "ftp://ftp.ncbi.nlm.nih.gov/pub/geo/DATA/supplementary/series/GSE81904/GSE81904_BipolarUMICounts_Cell2016.txt.gz",
-                "ftp://ftp.ncbi.nlm.nih.gov/pub/geo/DATA/supplementary/series/GSE81904/GSE81904_RAW.tar",
-                "ftp://ftp.ncbi.nlm.nih.gov/pub/geo/DATA/supplementary/series/GSE81904/GSE81904_bipolar_data_Cell2016.Rdata.gz",
-                "ftp://ftp.ncbi.nlm.nih.gov/pub/geo/DATA/supplementary/series/GSE81904/GSE81904_class.R.gz",
-                "ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP/SRP075/SRP075719"
+            "contributor": [
+                "Gray,,Camp",
+                "Barbara,,Treutlein"
             ],
-            "title": "Drop-Seq analysis of  P17 FACS sorted retinal cells from the Tg(Chx10-EGFP/cre,-ALPP)2Clc or Vsx2-GFP transgenic line",
-            "uuid": "f35c2bce-a4a7-4e1e-a8a6-8637e65d19a7"
+            "geo_series": "GSE75140",
+            "last_update_date": "2017-06-02",
+            "ncbi_bioproject": "PRJNA304502",
+            "overall_design": "734 single-cell transcriptomes from human fetal neocortex or human cerebral organoids from multiple time points were analyzed in this study. All single cell samples were processed on the microfluidic Fluidigm C1 platform and contain 92 external RNA spike-ins. Fetal neocortex data were generated at 12 weeks post conception (chip 1: 81 cells; chip 2: 83 cells) and 13 weeks post conception (62 cells). Cerebral organoid data were generated from dissociated whole organoids derived from induced pluripotent stem cell line 409B2 (iPSC 409B2) at 33 days (40 cells), 35 days (68 cells), 37 days (71 cells), 41 days (74 cells), and 65 days (80 cells) after the start of embryoid body culture. Cerebral organoid data were also generated from microdissected cortical-like regions from H9 embryonic stem cell derived organoids at 53 days (region 1, 48 cells; region 2, 48 cells) or from iPSC 409B2 organoids at 58 days (region 3, 43 cells; region 4, 36 cells).",
+            "pmid": "26644564",
+            "release_status": "Public on Dec 07 2015",
+            "sra_project": "SRP066834",
+            "submission_date": "2015-11-18",
+            "summary": "Cerebral organoids \u2013 three-dimensional cultures of human cerebral tissue derived from pluripotent stem cells \u2013 have emerged as models of human cortical development. However, the extent to which in vitro organoid systems recapitulate neural progenitor cell proliferation and neuronal differentiation programs observed in vivo remains unclear. Here we use single-cell RNA sequencing (scRNA-seq) to dissect and compare cell composition and progenitor-to-neuron lineage relationships in human cerebral organoids and fetal neocortex. Covariation network analysis using the fetal neocortex data reveals known and novel interactions among genes central to neural progenitor proliferation and neuronal differentiation. In the organoid, we detect diverse progenitors and differentiated cell types of neuronal and mesenchymal lineages, and identify cells that derived from regions resembling the fetal neocortex. We find that these organoid cortical cells use gene expression programs remarkably similar to those of the fetal tissue in order to organize into cerebral cortex-like regions. Our comparison of in vivo and in vitro cortical single cell transcriptomes illuminates the genetic features underlying human cortical development that can be studied in organoid cultures.",
+            "supplementary_files": [
+                "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE75nnn/GSE75140/suppl/GSE75140_hOrg.fetal.master.data.frame.txt.gz",
+                "ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP/SRP066/SRP066834"
+            ],
+            "title": "Human cerebral organoids recapitulate gene expression programs of fetal neocortex development.",
+            "uuid": "15fe881c-f4b8-4d15-a270-092b8e5d850a"
         },
-        "sample.json": {
+        "sample_json": {
             "body_part": {
-                "name": "retina",
-                "ontology": "UBERON:0000966",
-                "organ": "eye"
+                "name": "neocortex",
+                "organ": "brain"
             },
+            "data_processing": [
+                "\"freeIbis\" was used as an efficient basecaller with calibrated quality scores for Illumina sequencers. (Bioinformatics. 2013 May 1;29(9):1208-9. doi: 10.1093/bioinformatics/btt117. Epub 2013 Mar 6.)",
+                "\"leeHom\" was used to trim adapters and merge Illumina sequencing reads. (Nucleic Acids Res. 2014 Oct;42(18):e141. doi: 10.1093/nar/gku699. Epub 2014 Aug 6.)",
+                "\"deML\" was used for robust demultiplexing of Illumina sequences using a likelihood-based approach. (Bioinformatics. 2015 Mar 1;31(5):770-2. doi: 10.1093/bioinformatics/btu719. Epub 2014 Oct 30.)",
+                "Reads were aligned against the human genome (build GRCh38.77 from ENSEMBLE) using TopHat v2.0.14. The genome was indexed using Bowtie v2.2.6",
+                "Fragments Per Kilobase of transcript Per Million mapped reads (FPKM) values were computed using cufflinks v2.2.1",
+                "Genome_build: GRCh38",
+                "Supplementary_files_format_and_content: Master data frame including sample name, gene ID, and FPKM values for each single cell."
+            ],
             "donor": {
-                "age": "17",
-                "age_unit": "day",
-                "genotype": "Vsx2-GFP",
-                "life_stage": "postpartum",
-                "ncbi_taxon": "10090",
-                "species": "Mus musculus"
+                "age": "12",
+                "age_unit": "week",
+                "id": "fetus 1",
+                "uuid": "6860fb7c-6167-4b6c-9bae-58098f35cc05",
+                "life_stage": "embryo",
+                "ncbi_taxon": "9606",
+                "species": "Homo sapiens"
             },
-            "geo_sample": "GSM2177570",
-            "last_update_date": "2016-08-25",
-            "long_label": "P17 Vsx2-GFP sorted mouse bipolar retina cells 1 (Batch 1)",
-            "ncbi_biosample": "SAMN05177285",
+            "geo_sample": "GSM1957573",
+            "last_update_date": "2015-12-07",
+            "long_label": "12 week post conception fetal neocortex",
+            "ncbi_biosample": "SAMN04303778",
             "protocols": [
                 {
-                    "description": "suspensions were processed through Drop-Seq to generate single-cell cDNA libraries attached to microbeads. Microbeads were counted, and amplified by PCR, and the 3' end of the cDNA prepared for sequencing using a modified Nextera XT protocol.",
+                    "description": "Fetuses were 12 to 13 wpc as assessed by ultrasound measurements of crown-rump length and other standard criteria of developmental stage determination.",
+                    "type": "growth protocol"
+                },
+                {
+                    "description": "Fetal cortices were digested with papain (Miltenyi Biotec, 1ml) for 15 min at 37\u00b0C on a rotating wheel, followed by addition of a papain inhibitor. Dissociated cells were filtered through 40, 30, and 20 \u03bcm diameter strainers to create a single cell suspension.",
+                    "type": "treatment protocol"
+                },
+                {
+                    "description": "Cells were loaded into the Fluidigm C1 microfluidic platform, where single cells were captured. Lysis of single cells, reverse-transcription of mRNA into cDNA as well as preamplification of cDNA occured within the microfluidic device using reagents provided by Fluidigm as well as the SMARTer Ultra Low RNA kit for Illumina (Clontech). External RNA spike-in transcripts (ERCC spike-in Mix, Ambion) were added to all single cell lysis reactions at a dilution of 1:40,000.",
                     "type": "nucleic acid library construction protocol"
                 }
             ],
-            "short_label": "retina bipolar 1",
-            "submission_date": "2016-05-25",
-            "uuid": "5aca931f-9c88-4483-ba46-685b70c08a73"
+            "short_label": "12w fetal neocortex",
+            "submission_date": "2015-11-30",
+            "supplementary_files": "ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByExp/sra/SRX/SRX145/SRX1457054",
+            "uuid": "c440e605-51fe-4420-ad32-eed24e88fe9d"
         }
     }
 }

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -86,28 +86,28 @@ class TestEventHandlers(unittest.TestCase):
 
     def verify_search_results(self, expected_hit_count):
         es_client = Elasticsearch()
-        query = "\
-            { \
-                \"query\": { \
-                    \"bool\": { \
-                        \"must\": [{ \
-                            \"match\": { \
-                                \"files.sample_json.donor.species\": \"Homo sapiens\" \
-                            } \
-                        }, { \
-                            \"match\": { \
-                                \"files.assay_json.single_cell.method\": \"Fluidigm C1\" \
-                            } \
-                        }, { \
-                            \"match\": { \
-                                \"files.sample_json.ncbi_biosample\": \"SAMN04303778\" \
-                            } \
-                        }] \
-                    } \
-                } \
-            }"
+        query = \
+            {
+                "query": {
+                    "bool": {
+                        "must": [{
+                            "match": {
+                                "files.sample_json.donor.species": "Homo sapiens"
+                            }
+                        }, {
+                            "match": {
+                                "files.assay_json.single_cell.method": "Fluidigm C1"
+                            }
+                        }, {
+                            "match": {
+                                "files.sample_json.ncbi_biosample": "SAMN04303778"
+                            }
+                        }]
+                    }
+                }
+            }
         response = es_client.search(index=DSS_ELASTICSEARCH_INDEX_NAME, doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
-                                    body=query)
+                                    body=json.dumps(query))
         self.assertEqual(expected_hit_count, response['hits']['total'])
         with open(os.path.join(os.path.dirname(__file__), "expected_index_document.json"), "r") as fh:
             expected_index_document = json.load(fh)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+import os
+import sys
+import unittest
+
+import requests
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, pkg_root)
+
+import dss  # noqa
+from tests.infra import DSSAsserts  # noqa
+
+
+class TestSearch(unittest.TestCase, DSSAsserts):
+    def setUp(self):
+        DSSAsserts.setup(self)
+        self.app = dss.create_app().app.test_client()
+
+    def test_search(self):
+        self.assertGetResponse(
+            '/v1/search',
+            query_string=dict(query=json.dumps(dict(foo=1))),
+            expected_code=requests.codes.ok)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -22,8 +22,34 @@ class TestSearch(unittest.TestCase, DSSAsserts):
         DSSAsserts.setup(self)
         self.app = dss.create_app().app.test_client()
 
-    def test_search(self):
+    def test_search_get(self):
         self.assertGetResponse(
             '/v1/search',
             query_string=dict(query=json.dumps(dict(foo=1))),
+            expected_code=requests.codes.ok)
+
+    def test_search_post(self):
+        query = "\
+            { \
+                \"query\": { \
+                    \"bool\": { \
+                        \"must\": [{ \
+                            \"match\": { \
+                                \"files.sample_json.donor.species\": \"Homo sapiens\" \
+                            } \
+                        }, { \
+                            \"match\": { \
+                                \"files.assay_json.single_cell.method\": \"Fluidigm C1\" \
+                            } \
+                        }, { \
+                            \"match\": { \
+                                \"files.sample_json.ncbi_biosample\": \"SAMN04303778\" \
+                            } \
+                        }] \
+                    } \
+                } \
+            }"
+        self.assertPostResponse(
+            '/v1/search',
+            json_request_body=(json.loads(query)),
             expected_code=requests.codes.ok)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -29,27 +29,27 @@ class TestSearch(unittest.TestCase, DSSAsserts):
             expected_code=requests.codes.ok)
 
     def test_search_post(self):
-        query = "\
-            { \
-                \"query\": { \
-                    \"bool\": { \
-                        \"must\": [{ \
-                            \"match\": { \
-                                \"files.sample_json.donor.species\": \"Homo sapiens\" \
-                            } \
-                        }, { \
-                            \"match\": { \
-                                \"files.assay_json.single_cell.method\": \"Fluidigm C1\" \
-                            } \
-                        }, { \
-                            \"match\": { \
-                                \"files.sample_json.ncbi_biosample\": \"SAMN04303778\" \
-                            } \
-                        }] \
-                    } \
-                } \
-            }"
+        query = \
+            {
+                "query": {
+                    "bool": {
+                        "must": [{
+                            "match": {
+                                "files.sample_json.donor.species": "Homo sapiens"
+                            }
+                        }, {
+                            "match": {
+                                "files.assay_json.single_cell.method": "Fluidigm C1"
+                            }
+                        }, {
+                            "match": {
+                                "files.sample_json.ncbi_biosample": "SAMN04303778"
+                            }
+                        }]
+                    }
+                }
+            }
         self.assertPostResponse(
             '/v1/search',
-            json_request_body=(json.loads(query)),
+            json_request_body=(query),
             expected_code=requests.codes.ok)


### PR DESCRIPTION
The two key changes here are:

- Indexer: replacing dot with underscore in the filename field of the index document

- Search API, both get (as Andrey provided) and post (as needed for the Boston demo)

Related changes include some refactoring for the indexer and search API to share common constants and code. There is some general code clean-up too, mostly to index.py, which adds to the diffs below.