### PR TITLE
refactor the test_verify_blob_checksum test

### DIFF
--- a/tests/test_gcshcablobstore.py
+++ b/tests/test_gcshcablobstore.py
@@ -8,14 +8,13 @@ import unittest
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
 sys.path.insert(0, pkg_root) # noqa
 
-from dss.blobstore import BlobNotFoundError
 from dss.blobstore.gcs import GCSBlobStore
-from dss.hcablobstore import HCABlobStore
 from dss.hcablobstore.gcs import GCSHCABlobStore
 from tests import utils
+from tests.test_hcablobstore import HCABlobStoreTests
 
 
-class TestGCSHCABlobStore(unittest.TestCase):
+class TestGCSHCABlobStore(unittest.TestCase, HCABlobStoreTests):
     def setUp(self):
         self.credentials = utils.get_env("GOOGLE_APPLICATION_CREDENTIALS")
         self.test_bucket = utils.get_env("DSS_GCS_TEST_BUCKET")
@@ -25,33 +24,6 @@ class TestGCSHCABlobStore(unittest.TestCase):
 
     def tearDown(self):
         pass
-
-    def test_verify_blob_checksum(self):
-        self.assertTrue(
-            self.hcahandle.verify_blob_checksum(
-                self.test_src_data_bucket, "test_good_source_data/0",
-                {
-                    HCABlobStore.MANDATORY_METADATA['CRC32C']['keyname']: "e16e07b9",
-                }
-            )
-        )
-
-        self.assertFalse(
-            self.hcahandle.verify_blob_checksum(
-                self.test_src_data_bucket, "test_good_source_data/1",
-                {
-                    HCABlobStore.MANDATORY_METADATA['CRC32C']['keyname']: "e16e07b9",
-                }
-            )
-        )
-
-        with self.assertRaises(BlobNotFoundError):
-            self.hcahandle.verify_blob_checksum(
-                self.test_src_data_bucket, "DOES_NOT_EXIST",
-                {
-                    HCABlobStore.MANDATORY_METADATA['CRC32C']['keyname']: "e16e07b9",
-                }
-            )
 
 
 if __name__ == '__main__':

--- a/tests/test_hcablobstore.py
+++ b/tests/test_hcablobstore.py
@@ -1,0 +1,27 @@
+from dss.blobstore import BlobNotFoundError
+
+
+class HCABlobStoreTests(object):
+    """
+    Common HCA blobstore tests.  We want to avoid repeating ourselves, so if we
+    built the abstractions correctly, common operations can all be tested here.
+    """
+
+    def test_verify_blob_checksum(self):
+        bucket = self.test_src_data_bucket
+        object_name = "test_good_source_data/0"
+        self.assertTrue(
+            self.hcahandle.verify_blob_checksum(
+                bucket, object_name,
+                self.blobhandle.get_metadata(bucket, object_name)))
+
+        object_name = "test_bad_source_data/incorrect_checksum"
+        self.assertFalse(
+            self.hcahandle.verify_blob_checksum(
+                bucket, object_name,
+                self.blobhandle.get_metadata(bucket, object_name)))
+
+        object_name = "DOES_NOT_EXIST"
+        with self.assertRaises(BlobNotFoundError):
+            self.hcahandle.verify_blob_checksum(
+                bucket, object_name, {})

--- a/tests/test_s3hcablobstore.py
+++ b/tests/test_s3hcablobstore.py
@@ -8,14 +8,13 @@ import unittest
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
 sys.path.insert(0, pkg_root) # noqa
 
-from dss.blobstore import BlobNotFoundError
 from dss.blobstore.s3 import S3BlobStore
-from dss.hcablobstore import HCABlobStore
 from dss.hcablobstore.s3 import S3HCABlobStore
 from tests import utils
+from tests.test_hcablobstore import HCABlobStoreTests
 
 
-class TestS3HCABlobStore(unittest.TestCase):
+class TestS3HCABlobStore(unittest.TestCase, HCABlobStoreTests):
     def setUp(self):
         self.test_bucket = utils.get_env("DSS_S3_TEST_BUCKET")
         self.test_src_data_bucket = utils.get_env("DSS_S3_TEST_SRC_DATA_BUCKET")
@@ -24,33 +23,6 @@ class TestS3HCABlobStore(unittest.TestCase):
 
     def tearDown(self):
         pass
-
-    def test_verify_blob_checksum(self):
-        self.assertTrue(
-            self.hcahandle.verify_blob_checksum(
-                self.test_src_data_bucket, "test_good_source_data/0",
-                {
-                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']['keyname']: "3b83ef96387f14655fc854ddc3c6bd57",
-                }
-            )
-        )
-
-        self.assertFalse(
-            self.hcahandle.verify_blob_checksum(
-                self.test_src_data_bucket, "test_good_source_data/1",
-                {
-                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']['keyname']: "3b83ef96387f14655fc854ddc3c6bd57",
-                }
-            )
-        )
-
-        with self.assertRaises(BlobNotFoundError):
-            self.hcahandle.verify_blob_checksum(
-                self.test_src_data_bucket, "test_good_source_data/0/DOES_NOT_EXIST",
-                {
-                    HCABlobStore.MANDATORY_METADATA['S3_ETAG']['keyname']: "3b83ef96387f14655fc854ddc3c6bd57",
-                }
-            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Use the checksums actually attached to the source files.  In the case of test_bad_source_data/incorrect_checksum, the checksums are intentionally set incorrectly so that the test will flag that as failures.

This should address #156.