### PR TITLE
Invert noqa marker on import/path mangle lines where E402 is raised

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -11,12 +11,12 @@ import uuid
 
 import requests
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
+sys.path.insert(0, pkg_root) # noqa
 
-import dss  # noqa
-from dss.config import BucketConfig, override_bucket_config  # noqa
-from tests.infra import DSSAsserts, UrlBuilder  # noqa
+import dss
+from dss.config import BucketConfig, override_bucket_config
+from tests.infra import DSSAsserts, UrlBuilder
 
 
 class TestDSS(unittest.TestCase, DSSAsserts):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -12,12 +12,12 @@ import uuid
 
 import requests
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
+sys.path.insert(0, pkg_root) # noqa
 
-import dss  # noqa
-from dss.config import BucketConfig, override_bucket_config  # noqa
-from tests.infra import DSSAsserts, UrlBuilder  # noqa
+import dss
+from dss.config import BucketConfig, override_bucket_config
+from tests.infra import DSSAsserts, UrlBuilder
 
 
 class TestFileApi(unittest.TestCase, DSSAsserts):

--- a/tests/test_gcsblobstore.py
+++ b/tests/test_gcsblobstore.py
@@ -7,13 +7,13 @@ import os
 import sys
 import unittest
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
+sys.path.insert(0, pkg_root) # noqa
 
-from dss.blobstore.gcs import GCSBlobStore  # noqa
-from dss.blobstore import BlobNotFoundError  # noqa
-from tests import utils  # noqa
-from tests.test_blobstore import BlobStoreTests  # noqa
+from dss.blobstore.gcs import GCSBlobStore
+from dss.blobstore import BlobNotFoundError
+from tests import utils
+from tests.test_blobstore import BlobStoreTests
 
 
 class TestGCSBlobStore(unittest.TestCase, BlobStoreTests):

--- a/tests/test_gcshcablobstore.py
+++ b/tests/test_gcshcablobstore.py
@@ -5,14 +5,14 @@ import os
 import sys
 import unittest
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
+sys.path.insert(0, pkg_root) # noqa
 
-from dss.blobstore import BlobNotFoundError  # noqa
-from dss.blobstore.gcs import GCSBlobStore  # noqa
-from dss.hcablobstore import HCABlobStore  # noqa
-from dss.hcablobstore.gcs import GCSHCABlobStore  # noqa
-from tests import utils  # noqa
+from dss.blobstore import BlobNotFoundError
+from dss.blobstore.gcs import GCSBlobStore
+from dss.hcablobstore import HCABlobStore
+from dss.hcablobstore.gcs import GCSHCABlobStore
+from tests import utils
 
 
 class TestGCSHCABlobStore(unittest.TestCase):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -13,7 +13,7 @@ import moto
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 
-from dss.events.handlers.index import process_new_indexable_object  # noqa
+from dss.events.handlers.index import process_new_indexable_object
 from tests import utils
 from tests.sample_data_loader import load_sample_data_bundle
 

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -7,13 +7,13 @@ import os
 import sys
 import unittest
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
+sys.path.insert(0, pkg_root) # noqa
 
-from dss.blobstore import BlobNotFoundError # noqa
-from dss.blobstore.s3 import S3BlobStore # noqa
-from tests import utils # noqa
-from tests.test_blobstore import BlobStoreTests # noqa
+from dss.blobstore import BlobNotFoundError
+from dss.blobstore.s3 import S3BlobStore
+from tests import utils
+from tests.test_blobstore import BlobStoreTests
 
 
 class TestS3BlobStore(unittest.TestCase, BlobStoreTests):

--- a/tests/test_s3hcablobstore.py
+++ b/tests/test_s3hcablobstore.py
@@ -5,14 +5,14 @@ import os
 import sys
 import unittest
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
+sys.path.insert(0, pkg_root) # noqa
 
-from dss.blobstore import BlobNotFoundError  # noqa
-from dss.blobstore.s3 import S3BlobStore  # noqa
-from dss.hcablobstore import HCABlobStore  # noqa
-from dss.hcablobstore.s3 import S3HCABlobStore  # noqa
-from tests import utils  # noqa
+from dss.blobstore import BlobNotFoundError
+from dss.blobstore.s3 import S3BlobStore
+from dss.hcablobstore import HCABlobStore
+from dss.hcablobstore.s3 import S3HCABlobStore
+from tests import utils
 
 
 class TestS3HCABlobStore(unittest.TestCase):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,11 +10,11 @@ import unittest
 
 import requests
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
+sys.path.insert(0, pkg_root) # noqa
 
-import dss  # noqa
-from tests.infra import DSSAsserts  # noqa
+import dss
+from tests.infra import DSSAsserts
 
 
 class TestSearch(unittest.TestCase, DSSAsserts):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -19,11 +19,11 @@ import uuid
 import boto3
 import google.cloud.storage
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
+sys.path.insert(0, pkg_root) # noqa
 
-from dss.events.handlers import sync # noqa
-from tests import infra  # noqa
+from dss.events.handlers import sync
+from tests import infra
 
 infra.start_verbose_logging()
 


### PR DESCRIPTION
It turns out you can avoid E402 either by ignoring the import lines,
or the statement lines. In all our cases, the fixed-function import
hack is much less dangerous to ignore than the varied import lines
where we might make typos, etc.