### PR TITLE
Separate fixtures buckets for S3 and GS.

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -23,7 +23,8 @@ class TestDSS(unittest.TestCase, DSSAsserts):
     def setUp(self):
         DSSAsserts.setup(self)
         self.app = dss.create_app().app.test_client()
-        self.test_src_data_bucket = get_env("DSS_S3_TEST_SRC_DATA_BUCKET")
+        self.s3_test_src_data_bucket = get_env("DSS_S3_TEST_SRC_DATA_BUCKET")
+        self.gs_test_src_data_bucket = get_env("DSS_GS_TEST_SRC_DATA_BUCKET")
 
     def test_bundle_get(self):
         self._test_bundle_get("aws")
@@ -57,10 +58,10 @@ class TestDSS(unittest.TestCase, DSSAsserts):
         self.assertEqual(response[2]['bundle']['files'][0]['version'], "2017-06-16T193604.240704Z")
 
     def test_bundle_put(self):
-        self._test_bundle_put("aws")
-        self._test_bundle_put("gcp")
+        self._test_bundle_put("aws", self.s3_test_src_data_bucket)
+        self._test_bundle_put("gcp", self.gs_test_src_data_bucket)
 
-    def _test_bundle_put(self, replica):
+    def _test_bundle_put(self, replica, fixtures_bucket):
         if replica == "aws":
             schema = "s3"
         elif replica == "gcp":
@@ -72,7 +73,7 @@ class TestDSS(unittest.TestCase, DSSAsserts):
             "/v1/files/" + file_uuid,
             requests.codes.created,
             json_request_body=dict(
-                source_url=f"{schema}://{self.test_src_data_bucket}/test_good_source_data/0",
+                source_url=f"{schema}://{fixtures_bucket}/test_good_source_data/0",
                 bundle_uuid=bundle_uuid,
                 creator_uid=4321,
                 content_type="text/html",

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -24,19 +24,20 @@ class TestFileApi(unittest.TestCase, DSSAsserts):
     def setUp(self):
         DSSAsserts.setup(self)
         self.app = dss.create_app().app.test_client()
-        self.test_src_data_bucket = get_env("DSS_S3_TEST_SRC_DATA_BUCKET")
+        self.s3_test_src_data_bucket = get_env("DSS_S3_TEST_SRC_DATA_BUCKET")
+        self.gs_test_src_data_bucket = get_env("DSS_GS_TEST_SRC_DATA_BUCKET")
 
     def test_file_put(self):
-        self._test_file_put("s3")
-        self._test_file_put("gs")
+        self._test_file_put("s3", self.s3_test_src_data_bucket)
+        self._test_file_put("gs", self.gs_test_src_data_bucket)
 
-    def _test_file_put(self, scheme):
+    def _test_file_put(self, scheme, fixtures_bucket):
         file_uuid = uuid.uuid4()
         response = self.assertPutResponse(
             "/v1/files/" + str(file_uuid),
             requests.codes.created,
             json_request_body=dict(
-                source_url=f"{scheme}://{self.test_src_data_bucket}/test_good_source_data/0",
+                source_url=f"{scheme}://{fixtures_bucket}/test_good_source_data/0",
                 bundle_uuid=str(uuid.uuid4()),
                 creator_uid=4321,
                 content_type="text/html",
@@ -57,7 +58,7 @@ class TestFileApi(unittest.TestCase, DSSAsserts):
             "/v1/files/" + str(file_uuid),
             requests.codes.created,
             json_request_body=dict(
-                source_url=f"s3://{self.test_src_data_bucket}/test_good_source_data/metadata_in_tags",
+                source_url=f"s3://{self.s3_test_src_data_bucket}/test_good_source_data/metadata_in_tags",
                 bundle_uuid=str(uuid.uuid4()),
                 creator_uid=4321,
                 content_type="text/html",
@@ -72,16 +73,16 @@ class TestFileApi(unittest.TestCase, DSSAsserts):
         self.assertIn('version', response[2])
 
     def test_file_put_upper_case_checksums(self):
-        self._test_file_put_upper_case_checksums("s3")
-        self._test_file_put_upper_case_checksums("gs")
+        self._test_file_put_upper_case_checksums("s3", self.s3_test_src_data_bucket)
+        self._test_file_put_upper_case_checksums("gs", self.gs_test_src_data_bucket)
 
-    def _test_file_put_upper_case_checksums(self, scheme):
+    def _test_file_put_upper_case_checksums(self, scheme, fixtures_bucket):
         file_uuid = uuid.uuid4()
         response = self.assertPutResponse(
             "/v1/files/" + str(file_uuid),
             requests.codes.created,
             json_request_body=dict(
-                source_url=f"{scheme}://{self.test_src_data_bucket}/test_good_source_data/incorrect_case_checksum",
+                source_url=f"{scheme}://{fixtures_bucket}/test_good_source_data/incorrect_case_checksum",
                 bundle_uuid=str(uuid.uuid4()),
                 creator_uid=4321,
                 content_type="text/html",


### PR DESCRIPTION
This was a code path that was still using the same fixtures bucket name for both clouds, which is incorrect.  It has basically been a coincidence (i.e., people use the same name for their S3 bucket and their GS fixtures bucket) that this hasn't broken yet. :)