### PR TITLE
Switch to region wildcards for services that permit region wildcards.

### DIFF
--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -29,7 +29,6 @@ stage_policy_json="$(dirname $0)/.chalice/policy-${stage}.json"
 export app_name=$(cat "$config_json" | jq -r .app_name)
 policy_template="$(dirname $0)/../iam/policy-templates/${app_name}-lambda.json"
 export lambda_name="${app_name}-${stage}"
-export region_name=$(aws configure get region)
 export account_id=$(aws sts get-caller-identity | jq -r .Account)
 
 dss_es_domain=${DSS_ES_DOMAIN:-dss-index-$stage}
@@ -66,5 +65,5 @@ fi
 
 dss_s3_bucket_env_name=DSS_S3_BUCKET_${stage_ucase}
 export DSS_S3_BUCKET=${!dss_s3_bucket_env_name}
-cat "$policy_template" | envsubst '$DSS_S3_BUCKET $account_id $stage $region_name' > "$policy_json"
+cat "$policy_template" | envsubst '$DSS_S3_BUCKET $account_id $stage' > "$policy_json"
 cp "$policy_json" "$stage_policy_json"

--- a/daemons/build_deploy_config.sh
+++ b/daemons/build_deploy_config.sh
@@ -15,7 +15,6 @@ config_json="$(dirname $0)/${daemon_name}/.chalice/config.json"
 policy_json="$(dirname $0)/${daemon_name}/.chalice/policy.json"
 stage_policy_json="$(dirname $0)/${daemon_name}/.chalice/policy-${stage}.json"
 policy_template="$(dirname $0)/../iam/policy-templates/${daemon_name}-lambda.json"
-export region_name=$(aws configure get region)
 export account_id=$(aws sts get-caller-identity | jq -r .Account)
 
 dss_es_domain=${DSS_ES_DOMAIN:-dss-index-$stage}
@@ -50,5 +49,5 @@ fi
 
 dss_s3_bucket_env_name=DSS_S3_BUCKET_${stage_ucase}
 export DSS_S3_BUCKET=${!dss_s3_bucket_env_name}
-cat "$policy_template" | envsubst '$DSS_S3_BUCKET $account_id $stage $region_name' > "$policy_json"
+cat "$policy_template" | envsubst '$DSS_S3_BUCKET $account_id $stage' > "$policy_json"
 cp "$policy_json" "$stage_policy_json"

--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -80,10 +80,10 @@
         "sns:*"
       ],
       "Resource": [
-        "arn:aws:lambda:$region_name:$account_id:function:dss-*",
-        "arn:aws:es:$region_name:$account_id:domain/dss-index-dev",
-        "arn:aws:es:$region_name:$account_id:domain/dss-index-dev/*",
-        "arn:aws:sns:$region_name:$account_id:domovoi-s3-bucket-events-$DSS_S3_BUCKET_DEV"
+        "arn:aws:lambda:*:$account_id:function:dss-*",
+        "arn:aws:es:*:$account_id:domain/dss-index-dev",
+        "arn:aws:es:*:$account_id:domain/dss-index-dev/*",
+        "arn:aws:sns:*:$account_id:domovoi-s3-bucket-events-$DSS_S3_BUCKET_DEV"
       ],
       "Effect": "Allow"
     }

--- a/iam/policy-templates/dss-index-lambda.json
+++ b/iam/policy-templates/dss-index-lambda.json
@@ -27,7 +27,7 @@
         "es:ESHttpPost",
         "es:ESHttpPut"
       ],
-      "Resource": "arn:aws:es:$region_name:$account_id:domain/dss-index-$stage/*"
+      "Resource": "arn:aws:es:*:$account_id:domain/dss-index-$stage/*"
     }
   ]
 }

--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -24,7 +24,7 @@
         "es:ESHttpGet",
         "es:ESHttpHead"
       ],
-      "Resource": "arn:aws:es:$region_name:$account_id:domain/dss-index-$stage/*"
+      "Resource": "arn:aws:es:*:$account_id:domain/dss-index-$stage/*"
     }
   ]
 }

--- a/scripts/authorize_aws_deploy.sh
+++ b/scripts/authorize_aws_deploy.sh
@@ -15,10 +15,9 @@ if [[ $# != 2 ]]; then
 fi
 
 export iam_principal_type=$1 iam_principal_name=$2
-export region_name=$(aws configure get region)
 export account_id=$(aws sts get-caller-identity | jq -r .Account)
 policy_json="$(dirname $0)/../iam/policy-templates/ci-cd.json"
-envsubst_vars='$DSS_S3_BUCKET_DEV $DSS_S3_BUCKET_TEST $DSS_S3_BUCKET_TEST_FIXTURES $account_id $region_name'
+envsubst_vars='$DSS_S3_BUCKET_DEV $DSS_S3_BUCKET_TEST $DSS_S3_BUCKET_TEST_FIXTURES $account_id'
 
 aws iam put-${iam_principal_type}-policy \
     --${iam_principal_type}-name $iam_principal_name \


### PR DESCRIPTION
es, lambda, and sns all seem to accept region wildcards, so there's no need to determine them or assume anything.