### PR TITLE
Fix the policies set by the deployment script

### DIFF
--- a/iam/policy-templates/dss-index-lambda.json
+++ b/iam/policy-templates/dss-index-lambda.json
@@ -14,8 +14,8 @@
       "Effect": "Allow",
       "Action": "s3:*",
       "Resource": [
-        "arn:aws:s3:::$DSS_S3_BUCKET_TEST",
-        "arn:aws:s3:::$DSS_S3_BUCKET_TEST/*"
+        "arn:aws:s3:::$DSS_S3_BUCKET",
+        "arn:aws:s3:::$DSS_S3_BUCKET/*"
       ]
     },
     {

--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -21,6 +21,14 @@
     {
       "Effect": "Allow",
       "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "es:ESHttpGet",
         "es:ESHttpHead"
       ],


### PR DESCRIPTION
1. the indexer should use DSS_S3_BUCKET, which is set by daemons/build_deploy_config.sh.
2. the dss lambda should be able to read any bucket in order to ingest data.  NOTE: This means we need to disable read access on all other buckets owned by this account.