### PR TITLE
Describe setup steps more completely in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,18 @@ environment variable `DSS_GS_BUCKET_TEST_FIXTURES` to the name of that bucket.
 #### Running the DSS API locally
 Run `./dss-api` in the top-level `data-store` directory.
 
+#### Check and install software required to test and deploy
+Check that software packages required to test and deploy are available, and install them if necessary.
+
+Run: `make --dry-run`
+
 #### Populate test data
 
 To run the tests, test fixture data must be setup using the following command.
 **This command will completely empty the given buckets** before populating them with test fixture data, please 
 ensure the correct bucket names are provided.
 
-    python tests/fixtures/populate.py --s3-bucket $DSS_S3_BUCKET_TEST_FIXTURES --gs-bucket $DSS_GS_BUCKET_TEST_FIXTURES
+    tests/fixtures/populate.py --s3-bucket $DSS_S3_BUCKET_TEST_FIXTURES --gs-bucket $DSS_GS_BUCKET_TEST_FIXTURES
 
 
 #### Running tests
@@ -85,14 +90,6 @@ Run `make test` in the top-level `data-store` directory.
 #### Deployment
 
 Assuming the tests have passed above, the next step is to manually deploy.  See the section below for information on CI/CD with Travis if continuous deployment is your goal.
-
-You will need to ensure you are ready for deployment refer to `.travis.yml` to ensure you have all needed requirements.  Currently, the Travis deployment uses Ubuntu Trusty (14.04) with the following packages apt-get installed:
-
-    sudo apt-get install jq moreutils gettext
-    
-For Mac OS, install these packages using Homebrew:
-
-    brew install jq moreutils gettext
 
 The AWS Elasticsearch Service is used for metadata indexing.
 Currently, the AWS Elasticsearch Service must be configured manually.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ The HCA DSS prototype requires Python 3.6+ to run. Run `pip install -r requireme
 Tests also use data from the data-bundle-examples subrepository.
 Run: `git submodule update --init`
 
+#### Environment Variables
+
+Environment variables are required for test and deployment.
+The required environment variables and their default values are in the file `environment`
+To customize the values of these environment variables:
+
+1. Copy `environment.local.example` to `environment.local`
+2. Edit `environment.local` to add custom entries that override the default values in `environment`
+    
+Run `source environment`  now and whenever these environment files are modified.
+
 #### Configuring cloud-specific access credentials
 
 **AWS**: Follow the instructions in
@@ -49,14 +60,17 @@ environment variable `DSS_GS_BUCKET_TEST_FIXTURES` to the name of that bucket.
 
 **Azure**: Set the environment variables `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY`.
 
-#### Running the prototype
-Run `./dss-api` in this directory.
+#### Running the DSS API locally
+Run `./dss-api` in the top-level `data-store` directory.
 
 #### Populate test data
 
-In order to run the tests below you need to have some test data staged into your buckets:
+To run the tests, test fixture data must be setup using the following command.
+**This command will completely empty the given buckets** before populating them with test fixture data, please 
+ensure the correct bucket names are provided.
 
-    python tests/fixtures/populate.py --s3-bucket $DSS_S3_TEST_SRC_DATA_BUCKET --gs-bucket $DSS_GS_TEST_SRC_DATA_BUCKET
+    python tests/fixtures/populate.py --s3-bucket $DSS_S3_BUCKET_TEST_FIXTURES --gs-bucket $DSS_GS_BUCKET_TEST_FIXTURES
+
 
 #### Running tests
 
@@ -66,69 +80,86 @@ Run: `elasticsearch`
 
 Then to perform the data store tests:
 
-Run `make test` in this directory.
+Run `make test` in the top-level `data-store` directory.
 
 #### Deployment
 
 Assuming the tests have passed above, the next step is to manually deploy.  See the section below for information on CI/CD with Travis if continuous deployment is your goal.
 
-You will need to ensure you are ready for deployment refer to `.travis.yml` to ensure you have all needed requirements.  Right now the deployment is designed for an Ubuntu Trusty (14.04) with the following packages apt-get installed:
+You will need to ensure you are ready for deployment refer to `.travis.yml` to ensure you have all needed requirements.  Currently, the Travis deployment uses Ubuntu Trusty (14.04) with the following packages apt-get installed:
 
     sudo apt-get install jq moreutils gettext
+    
+For Mac OS, install these packages using Homebrew:
 
-Currently you need to setup an Elasticsearch hosted instance on AWS for the indexer:
+    brew install jq moreutils gettext
 
-    # TODO
+The AWS Elasticsearch Service is used for metadata indexing.
+Currently, the AWS Elasticsearch Service must be configured manually.
+The AWS Eslasticsearch Service domain name must either:
+* have the value "dss-index-$DSS_DEPLOYMENT_STAGE"
+* or, the environment variable `DSS_ES_DOMAIN` must be set to the domain name of the AWS Elasticsearch Service instance to be used.
+
+Note, the Swagger API specification in `dss-api.yml` currently has the `host` set to `hca-dss.czi.technology`.
+This may be set to a value appropriate for your deployment (see AWS API Gateway setup below).
 
 Now deploy using make:
 
     make deploy
 
-Setup API gateway.  The gateway is automatically setup for you and associated with the Lambda.  However, to get a friendly domain name you need to follow the directions at this [page](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html). In summary:
+Setup AWS API Gateway.  The gateway is automatically setup for you and associated with the Lambda.
+However, to get a friendly domain name you need to follow the directions at this [page](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html). In summary:
 
 * generate a HTTPS certificate via AWS Certificate Manager, make sure it's in us-east-1
 * setup the domain name in the API gateway console
 * setup in Amazon Route 53 to point the domain to the API gateway
 * in the API gateway fill in the endpoints for the custom domain name e.g. Path=`/`, Destination=`dss` and `dev`.  These might be different based on the profile used (dev, stage, etc).
 
-If successful you should be able to see the API Swagger docs at:
+If successful, you should be able to see the Swagger API documentation at:
 
-    https://<domain_name>/v1/
+    https://<domain_name>
 
 And you should be able to list bundles like this:
 
     curl -X GET "https://<domain_name>/v1/bundles" -H  "accept: application/json"
 
-Note, the Swagger docs have a hard-coded path for the API endpoint in them.
 
-#### Using the Client
+#### Using the HCA Data Store CLI Client
 
-Now that you have deployed the data store, the next step will be to use the CLI to upload and download data to the system.
-
-The client requires you change `hca/api_spec.json` to point to the correct host, schemes, and, possibly, basePath. Note, the port should not be included if using https.
+Now that you have deployed the data store, the next step is to use the HCA Data Store CLI to upload and download data to the system.
+See [data-store-cli](https://github.com/HumanCellAtlas/data-store-cli) for installation instructions.
+The client requires you change `hca/api_spec.json` to point to the correct host, schemes, and, possibly, basePath.
+Examples CLI use:
 
     # list bundles
     hca get-bundles
     # upload full bundle
-    hca upload --replica aws --staging-bucket hca-demo-files paired_ends
-    # upload a new bundle
-    hca upload --replica aws --staging-bucket hca-demo-files paired_ends
-
-
-Make sure the temp location you're staging to on S3 is accessible to the Lambda IAM role.  Look at the IAM role policy.
+    hca upload --replica aws --staging-bucket staging_bucket_name data-bundle-examples/smartseq2/paired_ends
 
 #### Checking Indexing
 
-Now that you've uploaded data, the next step is to confirm the indexing is working properly and you can query on the hosted elasticsearch.
+Now that you've uploaded data, the next step is to confirm the indexing is working properly and you can query the indexed metadata.
 
-Make sure the IAM policy is right, there's a bug where the region is not setup properly:
-
-```
-    "Resource":
-    "arn:aws:es::719818754276:domain/dss-index-de/*"
-    # Becomes
-    arn:aws:es:us-west-2:719818754276:domain/dss-index-dev
-```
+    hca post-search --query '
+    {
+        "query": {
+            "bool": {
+                "must": [{
+                    "match": {
+                        "files.sample_json.donor.species": "Homo sapiens"
+                    }
+                }, {
+                    "match": {
+                        "files.assay_json.single_cell.method": "Fluidigm C1"
+                    }
+                }, {
+                    "match": {
+                        "files.sample_json.ncbi_biosample": "SAMN04303778"
+                    }
+                }]
+            }
+        }
+    }'
 
 #### CI/CD with Travis CI
 We use [Travis CI](https://travis-ci.org/HumanCellAtlas/data-store) for continuous integration testing and


### PR DESCRIPTION
Added more complete documentation of the steps to setup DSS.

A few notes to the reviewer:
Populate.py does not have execute permission (at least not on my system), so the instructions explicitly include 'python' in the command line. Is this the best way to handle this case?

Tony had mentioned not using environment variables in the sample command line for populate.py, to instead have the user type the bucket names explicitly given the buckets will be emptied by populate.py. I didn't find a good way in markdown to within the code block display portions of the command syntax that should be replaced by the user. Also, the risk seems lower than before given the environment variables are for explicit test fixture buckets. Please let me know if you would like something different here.

Would you rather use httpie or curl for the example command?