### PR TITLE
[easy] assorted style fixes

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -4,8 +4,8 @@ import flask
 import chalice
 import boto3
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 from dss import BucketStage, Config, create_app
 from dss.events.handlers.sync import sync_blob

--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -1,14 +1,11 @@
 import os
 import sys
-import json
 import logging
-from urllib.parse import unquote
 
-import boto3
 import domovoi
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss.events.handlers.index import process_new_indexable_object

--- a/daemons/dss-sync/app.py
+++ b/daemons/dss-sync/app.py
@@ -1,14 +1,13 @@
 import os
 import sys
-import json
 import logging
 from urllib.parse import unquote
 
 import boto3
 import domovoi
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss.events.handlers.sync import sync_blob

--- a/dss/events/handlers/sync.py
+++ b/dss/events/handlers/sync.py
@@ -1,7 +1,4 @@
-import os
-import sys
 import datetime
-import json
 import time
 import hashlib
 from contextlib import closing

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -11,8 +11,8 @@ import uuid
 
 import requests
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss.config import BucketStage, override_bucket_config

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -12,8 +12,8 @@ import uuid
 
 import requests
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss.config import BucketStage, override_bucket_config

--- a/tests/test_gsblobstore.py
+++ b/tests/test_gsblobstore.py
@@ -7,8 +7,8 @@ import os
 import sys
 import unittest
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 from dss.blobstore.gs import GSBlobStore
 from dss.blobstore import BlobNotFoundError

--- a/tests/test_gshcablobstore.py
+++ b/tests/test_gshcablobstore.py
@@ -5,8 +5,8 @@ import os
 import sys
 import unittest
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 from dss.blobstore.gs import GSBlobStore
 from dss.hcablobstore.gs import GSHCABlobStore

--- a/tests/test_s3blobstore.py
+++ b/tests/test_s3blobstore.py
@@ -7,8 +7,8 @@ import os
 import sys
 import unittest
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 from dss.blobstore import BlobNotFoundError
 from dss.blobstore.s3 import S3BlobStore

--- a/tests/test_s3hcablobstore.py
+++ b/tests/test_s3hcablobstore.py
@@ -5,8 +5,8 @@ import os
 import sys
 import unittest
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 from dss.blobstore.s3 import S3BlobStore
 from dss.hcablobstore.s3 import S3HCABlobStore

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,8 +10,8 @@ import unittest
 
 import requests
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from tests.infra import DSSAsserts

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -18,8 +18,8 @@ import uuid
 import boto3
 import google.cloud.storage
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
-sys.path.insert(0, pkg_root) # noqa
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss.events.handlers import sync


### PR DESCRIPTION
1. remove unused imports
2. PEP8 requires two spaces before inline comment.