### PR TITLE
Avoid the list() keyword.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -15,6 +15,7 @@ paths:
       description: |
         Returns a list of bundles matching the given simple criteria
       summary: Find bundles by querying their metadata using simple criteria
+      operationId: dss.api.search.find
       parameters:
         - name: query
           in: query
@@ -55,6 +56,7 @@ paths:
       summary: Query files
       description: |
         Returns a list of files matching given criteria.
+      operationId: dss.api.files.find
       responses:
         200:
           description: OK
@@ -256,6 +258,7 @@ paths:
       summary: Query bundles
       description: |
         Returns a list of bundles matching given criteria.
+      operationId: dss.api.bundles.find
       responses:
         200:
           description: OK

--- a/dss/api/bundles.py
+++ b/dss/api/bundles.py
@@ -72,7 +72,7 @@ def list_versions(uuid: str):
     return ["2014-10-23T00:35:14.800221Z"]
 
 
-def list():
+def find():
     return dict(bundles=[dict(uuid=str(uuid.uuid4()), versions=[])])
 
 

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -93,7 +93,7 @@ def get(uuid: str, replica: str=None, version: str=None):
     return response
 
 
-def list():
+def find():
     return dict(files=[dict(uuid=str(uuid.uuid4()), name="", versions=[])])
 
 

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -9,7 +9,7 @@ from .. import get_logger
 from ..util import connect_elasticsearch
 
 
-def list():
+def find():
     get_logger().debug("Searching for: %s", request.values["query"])
     # TODO (mbaumann) Use a connection manager
     es_client = connect_elasticsearch(os.getenv("DSS_ES_ENDPOINT"), get_logger())


### PR DESCRIPTION
Use `operationId` to set the function name to something other than `list`.