### PR TITLE
Enable use of populate.py with moto S3 mock

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,5 @@ chalice >= 0.9.0, < 0.10.0
 coverage
 awscli
 moto
+crcmod
 -r requirements.txt

--- a/tests/fixtures/populate.py
+++ b/tests/fixtures/populate.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 
+import typing
 from cloud_uploader import GSUploader, S3Uploader, Uploader
 
 
@@ -114,7 +115,8 @@ def upload(uploader: Uploader):
             },
         )
 
-def populate(s3_bucket: str, gs_bucket: str):
+
+def populate(s3_bucket: typing.Optional[str], gs_bucket: typing.Optional[str]):
     # find the 'datafiles' subdirectory.
     root_dir = os.path.dirname(__file__)
     datafiles_dir = os.path.join(root_dir, "datafiles")

--- a/tests/fixtures/populate.py
+++ b/tests/fixtures/populate.py
@@ -114,11 +114,21 @@ def upload(uploader: Uploader):
             },
         )
 
-
-if __name__ == '__main__':
+def populate(s3_bucket: str, gs_bucket: str):
     # find the 'datafiles' subdirectory.
     root_dir = os.path.dirname(__file__)
     datafiles_dir = os.path.join(root_dir, "datafiles")
+
+    uploaders = []
+    if s3_bucket is not None:
+        uploaders.append(S3Uploader(datafiles_dir, s3_bucket))
+    if gs_bucket is not None:
+        uploaders.append(GSUploader(datafiles_dir, gs_bucket))
+
+    for uploader in uploaders:
+        upload(uploader)
+
+if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description="Set up test fixtures in cloud storage buckets")
     parser.add_argument("--s3-bucket", type=str)
@@ -126,11 +136,4 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    uploaders = []
-    if args.s3_bucket is not None:
-        uploaders.append(S3Uploader(datafiles_dir, args.s3_bucket))
-    if args.gs_bucket is not None:
-        uploaders.append(GSUploader(datafiles_dir, args.gs_bucket))
-
-    for uploader in uploaders:
-        upload(uploader)
+    populate(args.s3_bucket, args.gs_bucket)

--- a/tests/sample_data_loader.py
+++ b/tests/sample_data_loader.py
@@ -30,7 +30,7 @@ log.setLevel(logging.INFO)
 
 def load_sample_data_bundle() -> str:
     # Needed when using moto S3 mock, in which case the required bucket does not yet exist.
-    create_s3_test_bucket()
+    create_s3_bucket(infra.get_env("DSS_S3_BUCKET_TEST"))
 
     # Load sample-data-bundles dropseq
     data_bundle_examples_path = path_to_data_bundle_examples()
@@ -40,9 +40,8 @@ def load_sample_data_bundle() -> str:
     return bundle_key
 
 
-def create_s3_test_bucket() -> None:
+def create_s3_bucket(bucket_name) -> None:
     conn = boto3.resource('s3')
-    bucket_name = infra.get_env("DSS_S3_BUCKET_TEST")
     try:
         conn.create_bucket(Bucket=bucket_name)
     except ClientError as e:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -147,7 +147,7 @@ class TestEventHandlers(unittest.TestCase):
                 self.normalize_inherently_different_values_in_dict(expected_list[i], actual_list[i])
 
 def populate_moto_test_fixture_data():
-    s3_bucket_test_fixtures = (infra.get_env("DSS_S3_BUCKET_TEST_FIXTURES"))
+    s3_bucket_test_fixtures = infra.get_env("DSS_S3_BUCKET_TEST_FIXTURES")
     create_s3_bucket(s3_bucket_test_fixtures)
     populate(s3_bucket_test_fixtures, None)
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -9,13 +9,18 @@ import time
 import unittest
 from typing import Dict
 
+import boto3
 import moto
 from elasticsearch import Elasticsearch
-from elasticsearch_dsl import Search
 
 from dss.events.handlers.index import process_new_indexable_object
 from tests import infra
-from tests.sample_data_loader import load_sample_data_bundle
+
+fixtures_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'fixtures'))  # noqa
+sys.path.insert(0, fixtures_root)  # noqa
+
+from tests.fixtures.populate import populate
+from tests.sample_data_loader import load_sample_data_bundle, create_s3_bucket
 
 DSS_ELASTICSEARCH_INDEX_NAME = "hca"
 DSS_ELASTICSEARCH_DOC_TYPE = "hca"
@@ -25,7 +30,6 @@ USE_AWS_S3_MOCK = os.environ.get("USE_AWS_S3_MOCK", True)
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
-
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, pkg_root)
@@ -41,6 +45,10 @@ sys.path.insert(0, pkg_root)
 #   4. Perform as simple search to verify the index is in Elasticsearch.
 #
 
+def populate_moto_test_fixture_data():
+    s3_bucket_test_fixtures = (infra.get_env("DSS_S3_BUCKET_TEST_FIXTURES"))
+    create_s3_bucket(s3_bucket_test_fixtures)
+    populate(s3_bucket_test_fixtures, None)
 
 class TestEventHandlers(unittest.TestCase):
 
@@ -49,6 +57,7 @@ class TestEventHandlers(unittest.TestCase):
         if USE_AWS_S3_MOCK is True:
             cls.mock_s3 = moto.mock_s3()
             cls.mock_s3.start()
+            populate_moto_test_fixture_data()
 
         if "DSS_ES_ENDPOINT" not in os.environ:
             os.environ["DSS_ES_ENDPOINT"] = "localhost"


### PR DESCRIPTION
Changed cloud_uploader.py support for S3 and GS to use the APIs directly
rather than running CLI commands. This enables populate.py to be
used in unit tests with the moto S3 mock. It also runs much faster
than it did before.

Populate.py was modified slightly to enable convenient programmatic
use, in addition to CLI use.

This was tested both in the context of moto unit tests as well as
with actual S3 through the CLI. The amount of logging output is 
similar to before, which is useful for verifying operation when
run from the CLI. It currently does, however, increase the amount
of logging from a unit test run, now that it is being used in the 
unit tests as well. We may want to adjust that.
