### PR TITLE
Update dss-api.yml to include subscriptions endpoints

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -269,6 +269,76 @@ paths:
                 format: date-time
             required:
               - version
+  /subscriptions:
+    get:
+      summary: Retrieve an user's event subscriptions.
+      description: |
+        Return a list of associated subscriptions, which contains the uuid,
+        replica, query, creator_uid, and callback_url.
+      operationId: dss.api.subscriptions.find
+      parameters:
+        - name: replica
+          in: query
+          description: Replica to fetch from. Can be one of aws, gcp, or azure.
+          required: true
+          type: string
+          enum: [aws, gcp, azure]
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              subscriptions:
+                type: array
+                items:
+                  $ref: "#/definitions/Subscription"
+            required:
+              - subscriptions
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Create a event subscription.
+      description: |
+        Create a new event subscription. Every time a new bundle version matches this query,
+        a request is sent to callback_url.
+      parameters:
+        - name: replica
+          in: query
+          description: Replica to write to. Can be one of aws, gcp, or azure.
+          required: true
+          type: string
+          enum: [aws, gcp, azure]
+        - name: extras
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              query:
+                description: Elasticsearch query that will trigger the callback.
+                type: object
+              callback_url:
+                description: Url to send request to when a bundle comes in that matches this query.
+                type: string
+                format: url # Seems that this is possible now because of https://github.com/swagger-api/swagger-core/issues/1045
+            required:
+              - query
+              - callback_url
+      responses:
+        201:
+          description: OK
+          schema:
+            type: object
+            properties:
+              uuid:
+                description: A RFC4122-compliant ID for the subscription.
+                type: string
+                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+            required:
+              - uuid
   /subscriptions/{uuid}:
     get:
       summary: Retrieve an event subscription given a UUID.
@@ -300,52 +370,6 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-    put:
-      summary: Create a event subscription.
-      description: |
-        Create a new event subscription. Every time a new bundle version matches this query,
-        a request is sent to callback_url.
-      parameters:
-        - name: uuid
-          in: path
-          description: A RFC4122-compliant ID for the subscription.
-          required: true
-          type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
-        - name: replica
-          in: query
-          description: Replica to write to. Can be one of aws, gcp, or azure.
-          required: true
-          type: string
-          enum: [aws, gcp, azure]
-        - name: extras
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              query:
-                description: Elasticsearch query that will trigger the callback.
-                type: object
-              callback_url:
-                description: Url to send request to when a bundle comes in that matches this query.
-                type: string # Seems that this is possible now because of https://github.com/swagger-api/swagger-core/issues/1045
-                format: url
-            required:
-              - query
-              - callback_url
-      responses:
-        201:
-          description: OK
-          schema:
-            type: object
-            properties:
-              timeAdded:
-                description: Timestamp of query subscription in RFC3339.
-                type: string
-                format: date-time
-            required:
-              - timeAdded
     delete:
       summary: Delete an event subscription.
       description: |

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -285,7 +285,7 @@ paths:
         - name: replica
           in: query
           description: Replica to fetch from. Can be one of aws, gcp, or azure.
-          required: false
+          required: true
           type: string
           enum: [aws, gcp, azure]
       responses:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -24,9 +24,6 @@ paths:
         Returns a list of bundles matching the given simple criteria
       summary: Find bundles by querying their metadata using simple criteria
       operationId: dss.api.search.find
-      security:
-        - googAuth:
-            - https://www.googleapis.com/auth/userinfo.email
       parameters:
         - name: query
           in: query
@@ -279,6 +276,9 @@ paths:
         Return a list of associated subscriptions, which contains the uuid,
         replica, query, creator_uid, and callback_url.
       operationId: dss.api.subscriptions.find
+      security:
+        - googAuth:
+            - https://www.googleapis.com/auth/userinfo.email
       parameters:
         - name: replica
           in: query
@@ -307,6 +307,9 @@ paths:
       description: |
         Create a new event subscription. Every time a new bundle version matches this query,
         a request is sent to callback_url.
+      security:
+        - googAuth:
+            - https://www.googleapis.com/auth/userinfo.email
       parameters:
         - name: replica
           in: query
@@ -348,6 +351,9 @@ paths:
       description: |
         Given a subscription UUID, return the associated subscription, which contains the uuid,
         replica, query, creator_uid, and callback_url.
+      security:
+        - googAuth:
+            - https://www.googleapis.com/auth/userinfo.email
       parameters:
         - name: uuid
           in: path
@@ -378,6 +384,9 @@ paths:
       description: |
         Delete a registered event subscription. The associated query will no longer trigger a callback
         if a matching document is added to the system.
+      security:
+        - googAuth:
+            - https://www.googleapis.com/auth/userinfo.email
       parameters:
         - name: uuid
           in: path

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -335,9 +335,9 @@ paths:
                 description: Url to send request to when a bundle comes in that matches this query.
                 type: string
             required:
-              - files
+              - query
               - creator_uid
-              - extras
+              - callback_url
       responses:
         201:
           description: OK
@@ -676,6 +676,7 @@ definitions:
         type: object
     required:
       - uuid
+      - replica
       - creator_uid
       - callback_url
       - query

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -269,7 +269,121 @@ paths:
                 format: date-time
             required:
               - version
-
+  /subscriptions/{uuid}:
+    get:
+      summary: Retrieve an event subscription given a UUID.
+      description: |
+        Given a subscription UUID, return the latest version of that bundle.  If the version is provided, that version of the
+        bundle is returned instead.
+      parameters:
+        - name: uuid
+          in: path
+          description: Subscription unique ID.
+          required: true
+          type: string
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        - name: replica
+          in: query
+          description: Replica to fetch from. Can be one of aws, gcp, or azure.
+          required: false
+          type: string
+          enum: [aws, gcp, azure]
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              subscription:
+                $ref: "#/definitions/Subscription"
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Create a event subscription.
+      description: |
+        Create a new event subscription. Every time an added bundle matches this query, 
+        a request is sent to callback_url.
+      parameters:
+        - name: uuid
+          in: path
+          description: A RFC4122-compliant ID for the subscription.
+          required: true
+          type: string
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        - name: replica
+          in: query
+          description: Replica to write to. Can be one of aws, gcp, or azure.
+          required: true
+          type: string
+          enum: [aws, gcp, azure]
+        - name: extras
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              query:
+                description: Elasticsearch query that will trigger the callback.
+                type: object
+              creator_uid:
+                description: User ID who is creating this subscription.
+                type: integer
+                format: int64
+              callback_url:
+                description: Url to send request to when a bundle comes in that matches this query.
+                type: string
+            required:
+              - files
+              - creator_uid
+              - extras
+      responses:
+        201:
+          description: OK
+          schema:
+            type: object
+            properties:
+              timeAdded:
+                description: Timestamp of query subscription in RFC3339.
+                type: string
+                format: date-time
+            required:
+              - timeAdded
+    delete:
+      summary: Delete an event subscription.
+      description: |
+        Delete a registered event subscription. The associated query will no longer trigger a callback
+        if a matching document is added to the system.
+      parameters:
+        - name: uuid
+          in: path
+          description: A RFC4122-compliant ID for the subscription.
+          required: true
+          type: string
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        - name: replica
+          in: query
+          description: Replica to delete from. Can be one of aws, gcp, or azure.
+          required: true
+          type: string
+          enum: [aws, gcp, azure]
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              timeDeleted:
+                description: Timestamp of query subscription deletion in RFC3339.
+                type: string
+                format: date-time
+            required:
+              - timeDeleted
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /bundles:
     get:
       summary: Query bundles
@@ -539,6 +653,32 @@ definitions:
     required:
       - uuid
       - versions
+  Subscription:
+    type: object
+    properties:
+      uuid:
+        type: string
+        description: Subscription unique ID
+        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+      replica:
+        description: Replica this query is monitoring. One of aws, gcp, or azure.
+        type: string
+        enum: [aws, gcp, azure]
+      creator_uid:
+        type: integer
+        format: int
+        description: User ID who created this subscription.
+      callback_url:
+        description: Url to send request to when a bundle comes in that matches this query.
+        type: string
+      query:
+        description: Elasticsearch query that will trigger the callback.
+        type: object
+    required:
+      - uuid
+      - creator_uid
+      - callback_url
+      - query
   bundle_version:
     type: object
     properties:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -24,6 +24,9 @@ paths:
         Returns a list of bundles matching the given simple criteria
       summary: Find bundles by querying their metadata using simple criteria
       operationId: dss.api.search.find
+      security:
+        - googAuth:
+            - https://www.googleapis.com/auth/userinfo.email
       parameters:
         - name: query
           in: query

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -273,12 +273,12 @@ paths:
     get:
       summary: Retrieve an event subscription given a UUID.
       description: |
-        Given a subscription UUID, return the latest version of that bundle.  If the version is provided, that version of the
-        bundle is returned instead.
+        Given a subscription UUID, return the associated subscription, which contains the uuid,
+        replica, query, creator_uid, and callback_url.
       parameters:
         - name: uuid
           in: path
-          description: Subscription unique ID.
+          description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
           pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
@@ -303,7 +303,7 @@ paths:
     put:
       summary: Create a event subscription.
       description: |
-        Create a new event subscription. Every time an added bundle matches this query, 
+        Create a new event subscription. Every time a new bundle version matches this query,
         a request is sent to callback_url.
       parameters:
         - name: uuid
@@ -327,16 +327,12 @@ paths:
               query:
                 description: Elasticsearch query that will trigger the callback.
                 type: object
-              creator_uid:
-                description: User ID who is creating this subscription.
-                type: integer
-                format: int64
               callback_url:
                 description: Url to send request to when a bundle comes in that matches this query.
-                type: string
+                type: string # Seems that this is possible now because of https://github.com/swagger-api/swagger-core/issues/1045
+                format: url
             required:
               - query
-              - creator_uid
               - callback_url
       responses:
         201:

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -19,7 +19,11 @@ def get(uuid: str, replica: str):
     pass
 
 
-def put(uuid: str, extras: dict, replica: str):
+def find(replica: str):
+    pass
+
+
+def put(extras: dict, replica: str):
     pass
 
 

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -1,0 +1,27 @@
+import datetime
+import io
+import json
+import re
+import typing
+
+import iso8601
+import requests
+
+from flask import jsonify, make_response, redirect, request
+from werkzeug.exceptions import BadRequest
+
+from ..blobstore import BlobNotFoundError
+from ..config import Config
+from ..hcablobstore import FileMetadata, HCABlobStore
+
+
+def get(uuid: str, replica: str):
+    pass
+
+
+def put(uuid: str, extras: dict, replica: str):
+    pass
+
+
+def delete(uuid: str, replica: str):
+    pass


### PR DESCRIPTION
See #248 

Only parameter there might be conversation about is replica. Replica isn't required as when getting bundles/files, but it is here because each subscription only lives on one replica, per https://docs.google.com/document/d/193u4w_gQzWNy1OK442KRApKF7hncckowvkNWGGCVRO4/edit#heading=h.ykmrpkea3e15
