### PR TITLE
[EASY] Add standardized index and type names for queries es index.

### DIFF
--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -18,14 +18,14 @@ from .config import BucketStage, Config
 # ES index containing all docs
 DSS_ELASTICSEARCH_INDEX_NAME = "hca"
 # ES type within DSS_ELASTICSEARCH_INDEX_NAME with docs
-DSS_ELASTICSEARCH_DOC_TYPE = "docs"
+DSS_ELASTICSEARCH_DOC_TYPE = "doc"
 # ES type within DSS_ELASTICSEARCH_INDEX_NAME with percolate queries
-DSS_ELASTICSEARCH_QUERIES_TYPE = "queries"
+DSS_ELASTICSEARCH_QUERY_TYPE = "query"
 
 # ES index with all registered percolate queries
 DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME = "subscriptions"
 # ES type in DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME with subscriptions
-DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE = "subscription_type"
+DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE = "subscription"
 
 def get_logger():
     try:

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -16,6 +16,8 @@ from .config import BucketStage, Config
 # Constants common to the indexer and query route.
 DSS_ELASTICSEARCH_INDEX_NAME = "hca"
 DSS_ELASTICSEARCH_DOC_TYPE = "hca"
+DSS_ELASTICSEARCH_QUERIES_INDEX_NAME = "queries"
+DSS_ELASTICSEARCH_QUERIES_DOC_TYPE = "queries_type"
 
 def get_logger():
     try:

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -13,11 +13,19 @@ from flask_failsafe import failsafe
 
 from .config import BucketStage, Config
 
-# Constants common to the indexer and query route.
+# CONSTANTS COMMON TO THE INDEXER AND QUERY ROUTE.
+
+# ES index containing all docs
 DSS_ELASTICSEARCH_INDEX_NAME = "hca"
-DSS_ELASTICSEARCH_DOC_TYPE = "hca"
-DSS_ELASTICSEARCH_QUERIES_INDEX_NAME = "queries"
-DSS_ELASTICSEARCH_QUERIES_DOC_TYPE = "queries_type"
+# ES type within DSS_ELASTICSEARCH_INDEX_NAME with docs
+DSS_ELASTICSEARCH_DOC_TYPE = "docs"
+# ES type within DSS_ELASTICSEARCH_INDEX_NAME with percolate queries
+DSS_ELASTICSEARCH_QUERIES_TYPE = "queries"
+
+# ES index with all registered percolate queries
+DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME = "subscriptions"
+# ES type in DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME with subscriptions
+DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE = "subscription_type"
 
 def get_logger():
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 azure-storage
 boto3
-connexion
+connexion==1.1.11
 elasticsearch
 elasticsearch_dsl
 flask-failsafe

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -17,10 +17,8 @@ from dss.events.handlers.index import process_new_indexable_object
 from tests import infra
 from tests.sample_data_loader import load_sample_data_bundle
 
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
-
-from dss import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE  # noqa
+DSS_ELASTICSEARCH_INDEX_NAME = "hca"
+DSS_ELASTICSEARCH_DOC_TYPE = "hca"
 
 USE_AWS_S3_MOCK = os.environ.get("USE_AWS_S3_MOCK", True)
 
@@ -28,6 +26,9 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, pkg_root)
 
 #
 # Basic test for DSS indexer:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -17,8 +17,10 @@ from dss.events.handlers.index import process_new_indexable_object
 from tests import infra
 from tests.sample_data_loader import load_sample_data_bundle
 
-DSS_ELASTICSEARCH_INDEX_NAME = "hca"
-DSS_ELASTICSEARCH_DOC_TYPE = "hca"
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, pkg_root)
+
+from dss import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE  # noqa
 
 USE_AWS_S3_MOCK = os.environ.get("USE_AWS_S3_MOCK", True)
 
@@ -26,9 +28,6 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
-
-pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, pkg_root)
 
 #
 # Basic test for DSS indexer:


### PR DESCRIPTION
@mikebaumann common place for us to be grabbing our queries index names and doc types. 

There will be two indices, `DSS_ELASTICSEARCH_INDEX_NAME` and `DSS_ELASTICSEARCH_QUERIES_INDEX_NAME`. 

`DSS_ELASTICSEARCH_QUERIES_INDEX_NAME` will only have one type, `DSS_ELASTICSEARCH_QUERIES_DOC_TYPE`, that contains callback info, creator_uid, and query.

`DSS_ELASTICSEARCH_INDEX_NAME` will have two types:
* `DSS_ELASTICSEARCH_DOC_TYPE` will hold all the metadata that the blue box inputs
* `DSS_ELASTICSEARCH_QUERIES_DOC_TYPE` will hold all of the percolate queries. The ids of these percolate queries will match up with the ids in `DSS_ELASTICSEARCH_QUERIES_INDEX_NAME/DSS_ELASTICSEARCH_QUERIES_DOC_TYPE`

Wasn't sure about how efficient keeping the percolate queries in the same index as the documents was, but it seems to be common practice in all of Elasticsearches documentation (see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-percolate-query.html and https://www.elastic.co/blog/percolator-redesign-blog-post).