### PR TITLE
Move es util functions into new es folder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 azure-storage
 boto3
-connexion
+connexion==1.1.11
 elasticsearch
 elasticsearch_dsl
 flask-failsafe

--- a/tests/es/__init__.py
+++ b/tests/es/__init__.py
@@ -4,8 +4,8 @@ from elasticsearch import Elasticsearch
 
 
 logging.basicConfig(level=logging.INFO)
-log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 # Check if the Elasticsearch service is running,
@@ -14,8 +14,8 @@ def check_start_elasticsearch_service():
     try:
         es_client = Elasticsearch()
         es_info = es_client.info()
-        log.debug("The Elasticsearch service is running.")
-        log.debug("Elasticsearch info: %s", es_info)
+        logger.debug("The Elasticsearch service is running.")
+        logger.debug("Elasticsearch info: %s", es_info)
         close_elasticsearch_connections(es_client)
     except Exception:
         raise Exception("The Elasticsearch service does not appear to be running on this system, "
@@ -28,7 +28,7 @@ def elasticsearch_delete_index(index_name: str):
         es_client.indices.delete(index=index_name, ignore=[404])
         close_elasticsearch_connections(es_client)  # Prevents end-of-test complaints about open sockets
     except Exception as e:
-        log.warning("Error occurred while removing Elasticsearch index:%s Exception: %s", index_name, e)
+        logger.warning("Error occurred while removing Elasticsearch index:%s Exception: %s", index_name, e)
 
 
 # This prevents open socket errors after the test is over.

--- a/tests/es/__init__.py
+++ b/tests/es/__init__.py
@@ -1,0 +1,37 @@
+import logging
+
+from elasticsearch import Elasticsearch
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+# Check if the Elasticsearch service is running,
+# and if not, raise and exception with instructions to start it.
+def check_start_elasticsearch_service():
+    try:
+        es_client = Elasticsearch()
+        es_info = es_client.info()
+        log.debug("The Elasticsearch service is running.")
+        log.debug("Elasticsearch info: %s", es_info)
+        close_elasticsearch_connections(es_client)
+    except Exception:
+        raise Exception("The Elasticsearch service does not appear to be running on this system, "
+                        "yet it is required for this test. Please start it by running: elasticsearch")
+
+
+def elasticsearch_delete_index(index_name: str):
+    try:
+        es_client = Elasticsearch()
+        es_client.indices.delete(index=index_name, ignore=[404])
+        close_elasticsearch_connections(es_client)  # Prevents end-of-test complaints about open sockets
+    except Exception as e:
+        log.warning("Error occurred while removing Elasticsearch index:%s Exception: %s", index_name, e)
+
+
+# This prevents open socket errors after the test is over.
+def close_elasticsearch_connections(es_client):
+    for conn in es_client.transport.connection_pool.connections:
+        conn.pool.close()


### PR DESCRIPTION
There were some utility functions in `tests/test_indexer.py` that I should be able to use in my tests.