### PR TITLE
Capture exceptions and format them to the standard fields for errors.

### DIFF
--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -3,16 +3,19 @@
 """
 DSS description FIXME: elaborate
 """
+import traceback
 
 import os
 import logging
 
-import flask
 import connexion
+import flask
+import requests
 from connexion.resolver import RestyResolver
 from flask_failsafe import failsafe
 
 from .config import BucketStage, Config
+from .error import DSSException, dss_handler
 
 # CONSTANTS COMMON TO THE INDEXER AND QUERY ROUTE.
 
@@ -28,15 +31,44 @@ DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME = "subscriptions"
 # ES type in DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME with subscriptions
 DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE = "subscription"
 
+
 def get_logger():
     try:
         return flask.current_app.logger
     except RuntimeError:
         return logging.getLogger(__name__)
 
+
+class DSSApp(connexion.App):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def common_error_handler(exception):
+        """
+        Generally, each route handler should be decorated with @dss_handler, which manages exceptions.  The two cases
+        that fails are:
+
+        1. handlers that are not decorated.
+        2. handlers that return a code that is not in the swagger spec.
+
+        In both cases, the exception would be punted here, and we return this very generic error that also happens to
+        bypass all validation.
+        """
+        return (
+            flask.jsonify({
+                'http-error-code': requests.codes.server_error,
+                'code': "unhandled_exception",
+                'message': str(exception),
+                'stacktrace': traceback.format_exc(),
+            }),
+            requests.codes.server_error,
+        )
+
+
 @failsafe
 def create_app():
-    app = connexion.App(__name__)
+    app = DSSApp(__name__)
     resolver = RestyResolver("dss.api", collection_endpoint_name="list")
     app.add_api('../dss-api.yml', resolver=resolver, validate_responses=True, arguments=os.environ)
     return app

--- a/dss/error.py
+++ b/dss/error.py
@@ -1,0 +1,48 @@
+import traceback
+
+import flask
+import functools
+import requests
+import werkzeug.exceptions
+
+
+class DSSException(Exception):
+    def __init__(self, http_error_code: int, code: str, message: str, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.http_error_code = http_error_code
+        self.code = code
+        self.message = message
+
+
+def dss_handler(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except werkzeug.exceptions.HTTPException as ex:
+            http_error_code = ex.code
+            code = ex.name
+            message = str(ex)
+            stacktrace = traceback.format_exc()
+        except DSSException as ex:
+            http_error_code = ex.http_error_code
+            code = ex.code
+            message = ex.message
+            stacktrace = traceback.format_exc()
+        except Exception as ex:
+            http_error_code = requests.codes.server_error
+            code = "unhandled_exception"
+            message = str(ex)
+            stacktrace = traceback.format_exc()
+
+        return (
+            flask.jsonify({
+                'http-error-code': http_error_code,
+                'code': code,
+                'message': message,
+                'stacktrace': stacktrace,
+            }),
+            http_error_code
+        )
+
+    return wrapper


### PR DESCRIPTION
There's now a DSSException type that has all the fields we want.
Additionally, there's a fallback exception handler which captures the uncaught exception and formats it in a safe way (although it's not verified).

This should address #221 