### PR TITLE
reorder HEAD and GET

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -70,73 +70,6 @@ paths:
             required:
               - files
   /files/{uuid}:
-    get:
-      summary: Retrieve a file given a UUID and optionally a version.
-      description: |
-        Given a file UUID, return the latest version of that file.  If the version is provided, that version of the file
-        is returned instead.
-
-        Headers will contain the data store metadata for the file.
-
-        This endpoint will do a HTTP redirect to another HTTP endpoint with the file contents.
-      parameters:
-        - name: uuid
-          in: path
-          description: A RFC4122-compliant ID for the file.
-          required: true
-          type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
-        - name: replica
-          in: query
-          description: Replica to fetch from.
-          required: false
-          type: string
-          enum: [aws, gcp, azure]
-        - name: version
-          in: query
-          description: Timestamp of file creation in RFC3339.  If this is not provided, the latest version is returned.
-          required: false
-          type: string
-          format: date-time
-      responses:
-        302:
-          description: Redirects to a signed URL with the data.
-          headers:
-            # edits to here should probably be reflected in the 302 section immediately below.
-            X-DSS-BUNDLE-UUID:
-              description: A RFC4122-compliant ID for the bundle that contains this file.
-              type: string
-            X-DSS-CREATOR-UID:
-              description: User ID who created this file.
-              type: integer
-              format: int64
-            X-DSS-VERSION:
-              description: Timestamp of file creation in RFC3339.
-              type: string
-              format: date-time
-            X-DSS-CONTENT-TYPE:
-              description: Content-type of the file.
-              type: string
-            X-DSS-CRC32C:
-              description: CRC-32C (in hex format) of the file contents in hex.
-              type: string
-              pattern: "^[a-z0-9]{8}$"
-            X-DSS-S3-ETAG:
-              description: S3 ETag (in hex format) of the file contents.
-              type: string
-              pattern: "^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
-            X-DSS-SHA1:
-              description: SHA-1 (in hex format) of the file contents in hex.
-              type: string
-              pattern: "^[a-z0-9]{40}$"
-            X-DSS-SHA256:
-              description: SHA-256 (in hex format) of the file contents in hex.
-              type: string
-              pattern: "^[a-z0-9]{64}$"
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
     head:
       summary: Retrieve a file's metadata given an UUID and optionally a version.
       description: |
@@ -189,6 +122,73 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
+    get:
+      summary: Retrieve a file given a UUID and optionally a version.
+      description: |
+        Given a file UUID, return the latest version of that file.  If the version is provided, that version of the file
+        is returned instead.
+
+        Headers will contain the data store metadata for the file.
+
+        This endpoint will do a HTTP redirect to another HTTP endpoint with the file contents.
+      parameters:
+        - name: uuid
+          in: path
+          description: A RFC4122-compliant ID for the file.
+          required: true
+          type: string
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        - name: replica
+          in: query
+          description: Replica to fetch from.
+          required: false
+          type: string
+          enum: [aws, gcp, azure]
+        - name: version
+          in: query
+          description: Timestamp of file creation in RFC3339.  If this is not provided, the latest version is returned.
+          required: false
+          type: string
+          format: date-time
+      responses:
+        302:
+          description: Redirects to a signed URL with the data.
+          headers:
+            # edits to here should probably be reflected in the 200 section above.
+            X-DSS-BUNDLE-UUID:
+              description: A RFC4122-compliant ID for the bundle that contains this file.
+              type: string
+            X-DSS-CREATOR-UID:
+              description: User ID who created this file.
+              type: integer
+              format: int64
+            X-DSS-VERSION:
+              description: Timestamp of file creation in RFC3339.
+              type: string
+              format: date-time
+            X-DSS-CONTENT-TYPE:
+              description: Content-type of the file.
+              type: string
+            X-DSS-CRC32C:
+              description: CRC-32C (in hex format) of the file contents in hex.
+              type: string
+              pattern: "^[a-z0-9]{8}$"
+            X-DSS-S3-ETAG:
+              description: S3 ETag (in hex format) of the file contents.
+              type: string
+              pattern: "^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|10000))?$"
+            X-DSS-SHA1:
+              description: SHA-1 (in hex format) of the file contents in hex.
+              type: string
+              pattern: "^[a-z0-9]{40}$"
+            X-DSS-SHA256:
+              description: SHA-256 (in hex format) of the file contents in hex.
+              type: string
+              pattern: "^[a-z0-9]{64}$"
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
     put:
       summary: Create a new version of a file
       description: |

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -16,19 +16,15 @@ from ..config import Config
 from ..hcablobstore import FileMetadata, HCABlobStore
 
 
-def head(uuid: str, replica: str=None, version: str=None):
-    # NOTE: THIS IS NEVER ACTUALLY CALLED DUE TO A BUG IN CONNEXION.
-    # HEAD requests always calls the same endpoint as get, even if we tell it to
-    # go to a different method.  However, connexion freaks out if:
-    # 1) there is no head() function defined in code.  *or*
-    # 2) we tell the head() function to hit the same method using operationId.
-    #
-    # So in short, do not expect that this function actually gets called.  This
-    # is only here to keep connexion from freaking out.
-    return get(uuid, replica, version)
+def head(uuid: str, version: str=None):
+    return get(uuid, None, version)
 
 
-def get(uuid: str, replica: str=None, version: str=None):
+def get(uuid: str, replica: str, version: str=None):
+    return get_helper(uuid, replica, version)
+
+
+def get_helper(uuid: str, replica: typing.Optional[str]=None, version: str=None):
     if request.method == "GET" and replica is None:
         # replica must be set when it's a GET request.
         raise BadRequest()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 azure-storage
 boto3
-connexion==1.1.11
+connexion
 elasticsearch
 elasticsearch_dsl
 flask-failsafe


### PR DESCRIPTION
1. werkzeug does this thing where it automagically adds HEAD to any route that handles GET, and it annoyingly cannot be turned off.  This causes all HEAD requests actually to be handled by the GET spec.  Previously, I believed that the spec was correctly determined, just the wrong code path was being chosen.  It turns out it's validating the wrong spec, but I didn't know because connexion wasn't actually validating default specs at all. 
 https://github.com/zalando/connexion/commit/6668835420231c15095a71e264b2e2b0e1a68bf3 (ironically authored by me) exposed the issue because now the return values are actually properly validated.
2. move the HEAD first so it's added to the rules first.  This is probably not the right fix (the right fix is for werkzeug to evaluate *all* the rules on a HEAD request, and pick the most specific rule), but it seems to work for now.
3. undoes the (IMO) worse hotfix in https://github.com/HumanCellAtlas/data-store/commit/1ac2ab6a367ed77bb170f7062191b0d43e3b6d02