### PR TITLE
switch the /files not found message to the standard message format.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -188,7 +188,16 @@ paths:
         default:
           description: Unexpected error
           schema:
-            $ref: '#/definitions/Error'
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [unhandled_exception, not_found]
+                required:
+                  - code
     put:
       summary: Create a new version of a file
       description: |

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -11,15 +11,18 @@ import requests
 from flask import jsonify, make_response, redirect, request
 from werkzeug.exceptions import BadRequest
 
+from .. import DSSException, dss_handler
 from ..blobstore import BlobNotFoundError
 from ..config import Config
 from ..hcablobstore import FileMetadata, HCABlobStore
 
 
+@dss_handler
 def head(uuid: str, version: str=None):
     return get(uuid, None, version)
 
 
+@dss_handler
 def get(uuid: str, replica: str, version: str=None):
     return get_helper(uuid, replica, version)
 
@@ -47,7 +50,7 @@ def get_helper(uuid: str, replica: typing.Optional[str]=None, version: str=None)
 
     if version is None:
         # no matches!
-        return make_response("Cannot find file!", 404)
+        raise DSSException(404, "not_found", "Cannot find file!")
 
     # retrieve the file metadata.
     try:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -184,6 +184,31 @@ class TestFileApi(unittest.TestCase, DSSAsserts):
 
             # TODO: (ttung) verify more of the headers
 
+    def test_file_get_not_found(self):
+        self._test_file_get_not_found("aws")
+        self._test_file_get_not_found("gcp")
+
+    def _test_file_get_not_found(self, replica):
+        """
+        Verify we can successfully fetch the latest version of a file UUID.
+        """
+        file_uuid = "ce55fd51-7833-469b-be0b-5da88ec0ffee"
+
+        url = str(UrlBuilder()
+                  .set(path="/v1/files/" + file_uuid)
+                  .add_query("replica", replica))
+
+        with override_bucket_config(BucketStage.TEST_FIXTURE):
+            response = self.assertGetResponse(
+                url,
+                requests.codes.not_found
+            )
+
+            self.assertEqual(response[2]['code'], "not_found")
+            self.assertEqual(response[2]['http-error-code'], requests.codes.not_found)
+            self.assertIn('message', response[2])
+            self.assertIn('stacktrace', response[2])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a test for the error reporting.  This is an example to help facilitate discussion of #258 and #259.