### PR TITLE
Add Travis CI cron job driven entry point

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
 - for i in {0..60}; do nc -z localhost 9200 && break; sleep 1; [[ $i == 60 ]] && exit 1; done
 script:
 - make test
+- if [[ $TRAVIS_EVENT_TYPE == cron ]]; then echo "FIXME (sampierson) insert integration test entry point here"; fi
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 deploy:


### PR DESCRIPTION
@sampierson: I have enabled Travis CI to run a cron job daily. I'm not sure yet what time it gets triggered or whether it tries to deploy from the cron job (something we may want to disable). We'll see in 24 hours.

This change is a placeholder for you to add your integration test entry point when you're ready.

Fixes #198 