### PR TITLE
Get DSS running in Docker again

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 docker-compose.yml
 Dockerfile
 data-bundle-examples
+daemons

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #
 FROM python:3.6
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-  vim
+  vim jq moreutils gettext
 RUN pip install awscli --upgrade
 
 RUN sed 's/#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc > /root/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,8 @@ RUN sed 's/#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc > 
 ADD .dockerfiles/.vimrc /root/
 
 WORKDIR /code/data-store
-ADD requirements-dev.txt .
+ADD requirements-dev.txt requirements.txt ./
 RUN pip install --requirement requirements-dev.txt
-ADD requirements.txt .
-ADD packages packages
-RUN pip install --requirement requirements.txt
 ADD . /code/data-store
 
 # AWS cli binaries are installed in ~/.local/bin
@@ -30,4 +27,4 @@ ENV PATH=~/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/u
 
 EXPOSE 5000
 
-CMD ["python","dss-api"]
+CMD ["/bin/bash", "-c", "source environment ; python dss-api"]


### PR DESCRIPTION
requirements-dev.txt now calls requirements.txt so we need both before
running pip.
Add in sourcing of environment before execution of python script.
Ignore the 10,000 files in daemons - they're not useful in the image and
just slow down image building.