### PR TITLE
Handle parameter mismatches and return 400.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -203,7 +203,7 @@ paths:
                   code:
                     type: string
                     description: Machine-readable error code.  The types of return values should not be changed lightly.
-                    enum: [unhandled_exception, not_found]
+                    enum: [unhandled_exception, illegal_arguments, not_found]
                 required:
                   - code
     put:
@@ -783,7 +783,7 @@ definitions:
         description: |
           Machine-readable error code.  The types of return values should not be changed lightly.  Individual endpoints
           should list an enumeration of possible return codes.  All endpoints should expect the possibility of the
-          return code `unhandled_exception`.
+          return code `unhandled_exception` and `illegal_arguments`.
       title:
         type: string
         description: Human-readable error code.

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -205,6 +205,24 @@ class TestFileApi(unittest.TestCase, DSSAsserts):
                     expect_stacktrace=True)
             )
 
+    def test_file_get_no_replica(self):
+        """
+        Verify we raise the correct error code when we provide no replica.
+        """
+        file_uuid = "ce55fd51-7833-469b-be0b-5da88ec0ffee"
+
+        url = str(UrlBuilder()
+                  .set(path="/v1/files/" + file_uuid))
+
+        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+            self.assertGetResponse(
+                url,
+                requests.codes.bad_request,
+                expected_error=ExpectedErrorFields(
+                    code="illegal_arguments",
+                    status=requests.codes.bad_request,
+                    expect_stacktrace=True)
+            )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Right now, parameter mismatches raise a generic TypeError.  We can't catch that because it could be an internal TypeError, and not necessarily tied to the parameters users send us.

Instead, we attempt to bind the functions to the args, and if that fails, then we know it's the arguments a user sends us.  If it passes, and some *other* TypeError is raised, we still send that to the generic exception handler.

Add test for this case.

Addresses issue #297, and thanks to @Mackey22 for finding this.