### PR TITLE
Add missing dss.Config.set_config(..) to test_search.py

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,6 +17,7 @@ from tests.infra import DSSAsserts
 
 class TestSearch(unittest.TestCase, DSSAsserts):
     def setUp(self):
+        dss.Config.set_config(dss.DeploymentStage.TEST)
         self.app = dss.create_app().app.test_client()
 
     def test_search_get(self):


### PR DESCRIPTION
Now passes tests/test_search.py standalone.