### PR TITLE
Run unit tests in parallel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,15 @@ lint:
 mypy:
 	mypy --ignore-missing-imports $(MODULES)
 
+test_srcs := $(wildcard tests/test_*.py)
+
 test: lint mypy
 	PYTHONWARNINGS=ignore:ResourceWarning coverage run --source=dss -m unittest discover tests -v
+
+fast_test: lint mypy $(test_srcs)
+
+$(test_srcs): %.py :
+	PYTHONWARNINGS=ignore:ResourceWarning python -m unittest $@
 
 deploy:
 	$(MAKE) -C chalice deploy
@@ -19,4 +26,4 @@ clean:
 	git clean -df chalice/chalicelib daemons/*/domovoilib
 	git checkout {chalice,daemons/*}/.chalice/{config,deployed}.json
 
-.PHONY: test lint mypy
+.PHONY: test lint mypy $(test_srcs)


### PR DESCRIPTION
Create test targets for all the tests.  Then created a fast_test target that includes all of them.

Now you can run make -j fast_test and they are run in parallel and so so fast.