### PR TITLE
Implementation of ChunkedTask tailored for AWS Lambda.

### DIFF
--- a/daemons/Makefile
+++ b/daemons/Makefile
@@ -1,6 +1,6 @@
 include ../common.mk
 
-deploy: dss-sync dss-index
+deploy: dss-chunked-task dss-sync dss-index
 
 dss-sync dss-index:
 	git clean -df $@/domovoilib
@@ -10,4 +10,11 @@ dss-sync dss-index:
 	cd $@; domovoi deploy --stage $(DSS_DEPLOYMENT_STAGE)
 	./invoke_lambda.sh $@ $(DSS_DEPLOYMENT_STAGE) ../tests/daemons/sample_s3_bundle_created_event.json.template ../tests/daemons/a47b90b2-0967-4fbf-87bc-c6c12db3fedf.2017-07-12T055120.037644Z
 
-.PHONY: dss-sync dss-index
+dss-chunked-task:
+	git clean -df $@/domovoilib
+	cp -R ../dss ../dss-api.yml $@/domovoilib
+	cp "$(GOOGLE_APPLICATION_CREDENTIALS)" $@/domovoilib/gcp-credentials.json
+	./build_deploy_config.sh $@ $(DSS_DEPLOYMENT_STAGE)
+	cd $@; domovoi deploy --stage $(DSS_DEPLOYMENT_STAGE)
+
+.PHONY: dss-chunked-task dss-sync dss-index

--- a/daemons/dss-chunked-task/.chalice/config.json
+++ b/daemons/dss-chunked-task/.chalice/config.json
@@ -1,0 +1,15 @@
+{
+  "app_name": "dss-chunked-task",
+  "environment_variables": {
+    "GOOGLE_APPLICATION_CREDENTIALS": "/var/task/domovoilib/gcp-credentials.json"
+  },
+  "stages": {
+    "dev": {
+      "api_gateway_stage": "dev",
+      "environment_variables": {}
+    }
+  },
+  "version": "2.0",
+  "lambda_timeout": 300,
+  "lambda_memory_size": 1536
+}

--- a/daemons/dss-chunked-task/.chalice/deployed.json
+++ b/daemons/dss-chunked-task/.chalice/deployed.json
@@ -1,0 +1,11 @@
+{
+  "dev": {
+    "api_handler_name": "dss-chunked-task-dev",
+    "api_handler_arn": "",
+    "rest_api_id": null,
+    "region": "us-east-1",
+    "api_gateway_stage": null,
+    "backend": "api",
+    "chalice_version": "0.9.0"
+  }
+}

--- a/daemons/dss-chunked-task/.gitignore
+++ b/daemons/dss-chunked-task/.gitignore
@@ -1,0 +1,2 @@
+.chalice/deployments/
+.chalice/venv/

--- a/daemons/dss-chunked-task/app.py
+++ b/daemons/dss-chunked-task/app.py
@@ -1,0 +1,24 @@
+import json
+import os
+import sys
+
+import domovoi
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+import dss
+from dss.events.chunkedtask import aws
+from dss.events.chunkedtask import awsconstants
+
+app = domovoi.Domovoi()
+
+dss.Config.set_config(dss.DeploymentStage.NORMAL)
+
+worker_sns_topic = awsconstants.get_worker_sns_topic()
+
+
+@app.sns_topic_subscriber(worker_sns_topic)
+def process_work(event: dict, context) -> None:
+    payload = json.loads(event["Records"][0]["Sns"]["Message"])
+    aws.dispatch(context, payload)

--- a/daemons/dss-chunked-task/requirements.txt
+++ b/daemons/dss-chunked-task/requirements.txt
@@ -1,0 +1,1 @@
+../../requirements.txt

--- a/dss/events/chunkedtask/_awsimpl.py
+++ b/dss/events/chunkedtask/_awsimpl.py
@@ -1,0 +1,83 @@
+import typing
+
+import itertools
+
+from ...util.aws import ARN, send_sns_msg
+from . import awsconstants
+from .base import Task, Runtime
+from .constants import TIME_OVERHEAD_FACTOR
+
+
+class AWSRuntime(Runtime[dict]):
+    """
+    This is an implementation of `Runtime` specialized for AWS Lambda.  Work scheduling is done by posting a message
+    containing the serialized state to SNS.
+    """
+    def __init__(self, context, client_name: str) -> None:
+        self.context = context
+        self.client_name = client_name
+
+    def get_remaining_time_in_millis(self) -> int:
+        return self.context.get_remaining_time_in_millis()
+
+    def schedule_work(self, state: dict):
+        sns_arn = ARN(self.context.invoked_function_arn, service="sns", resource=awsconstants.get_worker_sns_topic())
+        send_sns_msg(
+            sns_arn,
+            {
+                awsconstants.CLIENT_KEY: self.client_name,
+                awsconstants.STATE_KEY: state,
+            })
+
+
+# The rest of this file is for unit tests.  The reason they are in this file is because they need to be deployed to the
+# lambda.  For production code, it may make sense to disable this, although it's pretty harmless.
+
+
+AWS_FAST_TEST_CLIENT_NAME = "fasttest"
+AWS_FAST_TEST_EST_TIME_MS = 100
+
+
+class AWSFastTestRuntime(AWSRuntime):
+    """
+    This is a modified variant of `AWSRuntime` that fakes less time being available than the system would otherwise
+    suggest.  The reason for this is to test the serialization and deserialization of state and the scheduling of work
+    without taking up the time fo a full lambda timeslice.  Furthermore, this reduces the risk that the test will
+    spuriously break at some future point in time if lambda lifetimes become longer.
+
+    This should only be used for the fast test.
+    """
+    def __init__(self, context) -> None:
+        super().__init__(context, AWS_FAST_TEST_CLIENT_NAME)
+        self.time_remaining_iterator = itertools.chain(
+            [int(AWS_FAST_TEST_EST_TIME_MS * TIME_OVERHEAD_FACTOR) + 1],
+            itertools.repeat(0)
+        )
+
+    def get_remaining_time_in_millis(self) -> int:
+        return self.time_remaining_iterator.__next__()
+
+
+class AWSFastTestTask(Task[typing.MutableSequence]):
+    """
+    This is a chunked task that counts from a number to another.  Once the counting is complete, it prints something to
+    console, which is detected by the unit test.
+    """
+    def __init__(self, state: typing.MutableSequence) -> None:
+        self.state = state
+
+    def get_state(self) -> typing.MutableSequence:
+        return self.state
+
+    @property
+    def expected_max_one_unit_runtime_millis(self) -> int:
+        return AWS_FAST_TEST_EST_TIME_MS
+
+    def run_one_unit(self) -> bool:
+        if self.state[1] >= self.state[2]:
+            # we're done!  print this message.  the unit test searches for this particular string, so don't change it!
+            print(f"{AWS_FAST_TEST_CLIENT_NAME}: Completed task {self.state[0]}")
+            return False
+        else:
+            self.state[1] += 1
+            return True  # more work to be done.

--- a/dss/events/chunkedtask/aws.py
+++ b/dss/events/chunkedtask/aws.py
@@ -1,0 +1,36 @@
+import logging
+
+from . import _awsimpl, awsconstants
+from .runner import Runner
+
+# this is the authoritative mapping between client names and Task classes.
+CLIENTS = {
+    _awsimpl.AWS_FAST_TEST_CLIENT_NAME: _awsimpl.AWSFastTestTask,
+}
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def dispatch(context, payload):
+    # look up by client name
+    try:
+        client_name = payload[awsconstants.CLIENT_KEY]
+        client_class = CLIENTS[client_name]
+        state = payload[awsconstants.STATE_KEY]
+    except KeyError as ex:
+        logger.error(f"Could not resolve payload {payload} exc {ex}")
+        # TODO: clean up logging.
+        return
+
+    # special case: if the client name is `AWS_FAST_TEST_CLIENT_NAME`, we use a special runtime environment so we don't
+    # take forever running the test.
+    if client_name == _awsimpl.AWS_FAST_TEST_CLIENT_NAME:
+        runtime = _awsimpl.AWSFastTestRuntime(context)
+    else:
+        runtime = _awsimpl.AWSRuntime(context, client_name)
+
+    task = client_class(state)
+
+    runner = Runner(task, runtime)
+    runner.run()

--- a/dss/events/chunkedtask/awsconstants.py
+++ b/dss/events/chunkedtask/awsconstants.py
@@ -1,0 +1,12 @@
+import os
+
+TASK_SNS_TOPIC_PREFIX = "dss-chunked-task-"
+TASK_RETRY_QUEUE_PREFIX = "dss-chunked-task-"
+
+CLIENT_KEY = "chunked_worker_client"
+STATE_KEY = "payload"
+
+
+def get_worker_sns_topic():
+    deployment_stage = os.getenv("DSS_DEPLOYMENT_STAGE")
+    return TASK_SNS_TOPIC_PREFIX + deployment_stage

--- a/iam/policy-templates/dss-chunked-task-lambda.json
+++ b/iam/policy-templates/dss-chunked-task-lambda.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "sns:Publish",
+      "Resource": [
+        "arn:aws:sns:*:$account_id:*"
+      ]
+    }
+  ]
+}

--- a/tests/test_chunkedtask.py
+++ b/tests/test_chunkedtask.py
@@ -4,15 +4,22 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import itertools
+import json
 import os
 import sys
+import time
 import typing
 import unittest
+from uuid import uuid4
+
+import boto3
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from dss.events import chunkedtask
+from dss.events.chunkedtask import awsconstants
+from dss.events.chunkedtask._awsimpl import AWS_FAST_TEST_CLIENT_NAME
 
 
 class TestChunkedTaskRuntime(chunkedtask.Runtime[tuple]):
@@ -91,6 +98,42 @@ class TestChunkedTaskRunner(unittest.TestCase):
             else:
                 serialize_count += 1
                 current_state = rescheduled_state
+
+
+class TestAWSChunkedTask(unittest.TestCase):
+    def test_fast(self):
+        uuid = uuid4()
+        payload = {
+            awsconstants.CLIENT_KEY: AWS_FAST_TEST_CLIENT_NAME,
+            awsconstants.STATE_KEY: (str(uuid), 0, 5),
+        }
+
+        sts_client = boto3.client('sts')
+        accountid = sts_client.get_caller_identity()['Account']
+
+        sns_client = boto3.client('sns')
+        region = os.environ['AWS_DEFAULT_REGION']
+        topic = awsconstants.get_worker_sns_topic()
+        arn = f"arn:aws:sns:{region}:{accountid}:{topic}"
+        sns_client.publish(
+            TopicArn=arn,
+            Message=json.dumps(payload),
+        )
+
+        logs_client = boto3.client('logs')
+        starttime = time.time()
+        while time.time() < starttime + 30:
+            response = logs_client.filter_log_events(
+                logGroupName="/aws/lambda/" + awsconstants.get_worker_sns_topic(),
+                filterPattern="Completed task"
+            )
+
+            for event in response['events']:
+                if event['message'].find(str(uuid)) != -1:
+                    return
+
+        self.fail("Did not find success marker in logs")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The unit test fakes a more restrictive environment in order to run the test in a reasonable time (~15-20s).  There will be a test that runs against the standard `AWSRuntime` I will build that will run on the cron'ed test run.

This is the same as #287, but github most helpfully closed that for no apparent reason.