### PR TITLE
Add a work_complete_callback() for runtimes to be notified when work is complete.

### DIFF
--- a/dss/events/chunkedtask/base.py
+++ b/dss/events/chunkedtask/base.py
@@ -41,3 +41,9 @@ class Runtime(typing.Generic[RuntimeStateType]):
         In implementations of `Runtime` should, this should schedule a task given its serialized state.
         """
         raise NotImplementedError()
+
+    def work_complete_callback(self):
+        """
+        Implementations of `Runtime` may implement this if they need to know that the task completed.
+        """
+        pass

--- a/dss/events/chunkedtask/runner.py
+++ b/dss/events/chunkedtask/runner.py
@@ -32,6 +32,7 @@ class Runner(typing.Generic[RunnerStateType]):
         while True:
             before = self.runtime.get_remaining_time_in_millis()
             if not self.chunkedtask.run_one_unit():
+                self.runtime.work_complete_callback()
                 return
             after = self.runtime.get_remaining_time_in_millis()
 


### PR DESCRIPTION
This way, the AWS runtime can log a message indicating that its work is complete.