### PR TITLE
Add a simple logging facility.

### DIFF
--- a/dss/util/aws/__init__.py
+++ b/dss/util/aws/__init__.py
@@ -1,6 +1,6 @@
 import json
 import botocore
-from . import resources, clients
+from . import clients, resources, logging
 
 class ARN:
     fields = "arn partition service region account_id resource".split()

--- a/dss/util/aws/logging.py
+++ b/dss/util/aws/logging.py
@@ -1,0 +1,56 @@
+import time
+
+import boto3
+import botocore.exceptions
+
+
+def log_message(log_group_name: str, log_stream_name: str, message: str):
+    """Logs a message to cloudwatch."""
+
+    logs_client = boto3.client("logs")
+
+    # An astute reader might notice that the exception handling is a bit wonky.  This is because exception classes for
+    # boto are dynamically created, and we cannot actually catch them. :(
+
+    def get_sequence_token():
+        # try to get the upload sequence token
+        paginator = logs_client.get_paginator('describe_log_streams')
+        for page in paginator.paginate(logGroupName=log_group_name, logStreamNamePrefix=log_stream_name):
+            for log_stream in page['logStreams']:
+                if log_stream['logStreamName'] == log_stream_name:
+                    return log_stream.get('uploadSequenceToken', None)
+
+        return None
+
+    while True:
+        try:
+            logs_client.create_log_group(logGroupName=log_group_name)
+        except botocore.exceptions.ClientError as ex:
+            if ex.__class__.__name__ != "ResourceAlreadyExistsException":
+                raise
+        try:
+            logs_client.create_log_stream(
+                logGroupName=log_group_name, logStreamName=log_stream_name)
+        except botocore.exceptions.ClientError as ex:
+            if ex.__class__.__name__ != "ResourceAlreadyExistsException":
+                raise
+
+        sequence_token = get_sequence_token()
+
+        try:
+            kwargs = dict(
+                logGroupName=log_group_name,
+                logStreamName=log_stream_name,
+                logEvents=[dict(
+                    timestamp=int(time.time() * 1000),
+                    message=message,
+                )],
+            )
+            if sequence_token is not None:
+                kwargs['sequenceToken'] = sequence_token
+
+            logs_client.put_log_events(**kwargs)
+            break
+        except botocore.exceptions.ClientError as ex:
+            if ex.__class__.__name__ != "InvalidSequenceTokenException":
+                raise

--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -73,6 +73,14 @@
       "Resource": "arn:aws:iam::$account_id:role/"
     },
     {
+      "Sid": "hcaDssCiCdTestLogging",
+      "Effect": "Allow",
+      "Action": [
+        "logs:*"
+      ],
+      "Resource": "arn:aws:logs:*:$account_id:log-group:test_logging*"
+    },
+    {
       "Sid": "hcaDssCiCdFilterLogEvents",
       "Effect": "Allow",
       "Action": [

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import time
+import unittest
+import uuid
+
+import boto3
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from dss.util.aws import logging
+from tests import infra
+
+infra.start_verbose_logging()
+
+
+class TestAwsLogging(unittest.TestCase):
+    def test_aws_logging_new_stream(self):
+        stream_name = str(uuid.uuid4())
+        logging.log_message("test_logging", stream_name, "hello world")
+
+        logs_client = boto3.client("logs")
+        starttime = time.time()
+        while time.time() < starttime + 30:
+            response = logs_client.filter_log_events(
+                logGroupName="test_logging", logStreamNames=[stream_name])
+
+            for event in response['events']:
+                if event['message'] == "hello world":
+                    break
+            else:
+                continue
+            break
+        else:
+            self.fail("Did not find message in logs")
+
+    def test_aws_logging_fixed_stream(self):
+        stream_name = "test_stream"
+        message1, message2 = str(uuid.uuid4()), str(uuid.uuid4())
+        logging.log_message("test_logging", stream_name, message1)
+
+        logs_client = boto3.client("logs")
+        starttime = time.time()
+        while time.time() < starttime + 30:
+            response = logs_client.filter_log_events(
+                logGroupName="test_logging", logStreamNames=[stream_name])
+
+            for event in response['events']:
+                if event['message'] == message1:
+                    break
+            else:
+                continue
+            break
+        else:
+            self.fail("Did not find message in logs")
+
+        logging.log_message("test_logging", stream_name, message2)
+
+        starttime = time.time()
+        while time.time() < starttime + 30:
+            response = logs_client.filter_log_events(
+                logGroupName="test_logging", logStreamNames=[stream_name])
+
+            for event in response['events']:
+                if event['message'] == message2:
+                    break
+            else:
+                continue
+            break
+        else:
+            self.fail("Did not find message in logs")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Logs to cloudwatch.
- Creates the group and stream, if necessary.
- Retrieves the uploadSequenceToken to log to existing streams.
- Adds test to verify most of the functionality.  The key functionality that is not tested is the creation of a logging group.  Rationale: There's a hard limit on the number of test groups.  If this test goes wild, it might do bad things to the account.