### PR TITLE
Add hca service accounts to allowed email domains for cli testing

### DIFF
--- a/environment
+++ b/environment
@@ -36,7 +36,7 @@ DSS_GS_BUCKET_TEST_FIXTURES=org-humancellatlas-dss-test-fixtures
 GOOGLE_APPLICATION_CREDENTIALS="${DSS_HOME}/gcp-credentials.json"
 API_HOST=hca-dss.czi.technology
 TOKENINFO_URL=https://hca-dss.czi.technology/internal/tokeninfo
-DSS_SUBSCRIPTION_AUTHORIZED_DOMAINS="chanzuckerberg.com ucsc.edu broadinstitute.org ebi.ac.uk"
+DSS_SUBSCRIPTION_AUTHORIZED_DOMAINS="chanzuckerberg.com ucsc.edu broadinstitute.org ebi.ac.uk human-cell-atlas-travis-test.iam.gserviceaccount.com"
 DSS_SUBSCRIPTION_AUTHORIZED_DOMAINS_TEST="human-cell-atlas-travis-test.iam.gserviceaccount.com"
 set +a
 


### PR DESCRIPTION
When testing python bindings and cli in Travis, I get Forbidden errors because the requests are coming from an unauthorized domain. This will make testing possible. 