### PR TITLE
Clean up task scheduling and logging.

### DIFF
--- a/dss/events/chunkedtask/_awsimpl.py
+++ b/dss/events/chunkedtask/_awsimpl.py
@@ -1,9 +1,12 @@
+import itertools
+import json
+import logging
 import typing
 
-import itertools
+import watchtower
 
-from ...util.aws import ARN, send_sns_msg
 from . import awsconstants
+from ...util.aws import ARN, send_sns_msg
 from .base import Task, Runtime
 from .constants import TIME_OVERHEAD_FACTOR
 
@@ -13,21 +16,63 @@ class AWSRuntime(Runtime[dict]):
     This is an implementation of `Runtime` specialized for AWS Lambda.  Work scheduling is done by posting a message
     containing the serialized state to SNS.
     """
-    def __init__(self, context, client_name: str) -> None:
+    def __init__(self, context, client_name: str, task_id: str) -> None:
         self.context = context
         self.client_name = client_name
+        self.task_id = task_id
 
     def get_remaining_time_in_millis(self) -> int:
         return self.context.get_remaining_time_in_millis()
 
     def schedule_work(self, state: dict):
+        payload = {
+            awsconstants.CLIENT_KEY: self.client_name,
+            awsconstants.REQUEST_VERSION_KEY: awsconstants.CURRENT_VERSION,
+            awsconstants.TASK_ID_KEY: self.task_id,
+            awsconstants.STATE_KEY: state,
+        }
+
         sns_arn = ARN(self.context.invoked_function_arn, service="sns", resource=awsconstants.get_worker_sns_topic())
-        send_sns_msg(
-            sns_arn,
-            {
-                awsconstants.CLIENT_KEY: self.client_name,
-                awsconstants.STATE_KEY: state,
-            })
+        send_sns_msg(sns_arn, payload)
+
+        AWSRuntime.log(
+            self.task_id,
+            json.dumps(dict(
+                action=awsconstants.LogActions.RESCHEDULED,
+                payload=payload,
+            )),
+        )
+
+    def work_complete_callback(self):
+        AWSRuntime.log(
+            self.task_id,
+            json.dumps(dict(
+                action=awsconstants.LogActions.COMPLETE,
+            )),
+        )
+
+    logger = dict()  # type: typing.Mapping[str, logging.Logger]
+
+    @staticmethod
+    def log(task_id: str, message: str):
+        logger_name = f"chunkedtasklogger-{task_id}"
+
+        logger = AWSRuntime.logger.get(logger_name, AWSRuntime._make_logger(logger_name, task_id))
+        logger.info(message)
+
+    @staticmethod
+    def _make_logger(logger_name: str, task_id: str) -> logging.Logger:
+        logger = logging.getLogger(logger_name)
+        logger.propagate = False
+        handler = watchtower.CloudWatchLogHandler(
+            log_group=awsconstants.LOG_GROUP_NAME,
+            stream_name=task_id,
+            use_queues=False)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+
+        return logger
 
 
 # The rest of this file is for unit tests.  The reason they are in this file is because they need to be deployed to the
@@ -47,8 +92,8 @@ class AWSFastTestRuntime(AWSRuntime):
 
     This should only be used for the fast test.
     """
-    def __init__(self, context) -> None:
-        super().__init__(context, AWS_FAST_TEST_CLIENT_NAME)
+    def __init__(self, context, task_id: str) -> None:
+        super().__init__(context, AWS_FAST_TEST_CLIENT_NAME, task_id)
         self.time_remaining_iterator = itertools.chain(
             [int(AWS_FAST_TEST_EST_TIME_MS * TIME_OVERHEAD_FACTOR) + 1],
             itertools.repeat(0)
@@ -74,10 +119,8 @@ class AWSFastTestTask(Task[typing.MutableSequence]):
         return AWS_FAST_TEST_EST_TIME_MS
 
     def run_one_unit(self) -> bool:
-        if self.state[1] >= self.state[2]:
-            # we're done!  print this message.  the unit test searches for this particular string, so don't change it!
-            print(f"{AWS_FAST_TEST_CLIENT_NAME}: Completed task {self.state[0]}")
+        if self.state[0] >= self.state[1]:
             return False
         else:
-            self.state[1] += 1
+            self.state[0] += 1
             return True  # more work to be done.

--- a/dss/events/chunkedtask/aws.py
+++ b/dss/events/chunkedtask/aws.py
@@ -1,4 +1,10 @@
+import json
 import logging
+import os
+import typing
+import uuid
+
+import boto3
 
 from . import _awsimpl, awsconstants
 from .runner import Runner
@@ -12,23 +18,98 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def dispatch(context, payload):
+def schedule_task(client_name: str, state: typing.Any):
+    task_id = str(uuid.uuid4())
+
+    payload = {
+        awsconstants.CLIENT_KEY: client_name,
+        awsconstants.REQUEST_VERSION_KEY: awsconstants.CURRENT_VERSION,
+        awsconstants.TASK_ID_KEY: task_id,
+        awsconstants.STATE_KEY: state,
+    }
+
+    sts_client = boto3.client("sts")
+    accountid = sts_client.get_caller_identity()['Account']
+
+    sns_client = boto3.client("sns")
+    region = boto3.Session().region_name
+    topic = awsconstants.get_worker_sns_topic()
+    arn = f"arn:aws:sns:{region}:{accountid}:{topic}"
+    sns_client.publish(
+        TopicArn=arn,
+        Message=json.dumps(payload),
+    )
+
+    _awsimpl.AWSRuntime.log(
+        task_id,
+        json.dumps(dict(
+            action=awsconstants.LogActions.SCHEDULED,
+            payload=payload,
+        )),
+    )
+
+    return task_id
+
+
+def get_payload(payload):
+    try:
+        task_id = payload[awsconstants.TASK_ID_KEY]
+    except KeyError as ex:
+        _awsimpl.AWSRuntime.log(
+            awsconstants.FALLBACK_LOG_STREAM_NAME,
+            json.dumps(dict(
+                action=awsconstants.LogActions.EXCEPTION,
+                message="Could not find task_id",
+                payload=payload,
+                exception=str(ex),
+            )),
+        )
+        return None
+
     # look up by client name
     try:
         client_name = payload[awsconstants.CLIENT_KEY]
         client_class = CLIENTS[client_name]
+        version = payload[awsconstants.REQUEST_VERSION_KEY]
         state = payload[awsconstants.STATE_KEY]
     except KeyError as ex:
-        logger.error(f"Could not resolve payload {payload} exc {ex}")
-        # TODO: clean up logging.
+        _awsimpl.AWSRuntime.log(
+            task_id,
+            json.dumps(dict(
+                action=awsconstants.LogActions.EXCEPTION,
+                message="Request payload missing required data",
+                payload=payload,
+                exception=str(ex),
+            )),
+        )
+        return None
+
+    if version < awsconstants.MIN_SUPPORTED_VERSION or version > awsconstants.MAX_SUPPORTED_VERSION:
+        _awsimpl.AWSRuntime.log(
+            task_id,
+            json.dumps(dict(
+                action=awsconstants.LogActions.EXCEPTION,
+                message="Message version not supported",
+                payload=payload,
+            )),
+        )
+        return None
+
+    return task_id, client_name, client_class, state
+
+
+def dispatch(context, payload):
+    decoded_payload = get_payload(payload)
+    if decoded_payload is None:
         return
+    task_id, client_name, client_class, state = decoded_payload
 
     # special case: if the client name is `AWS_FAST_TEST_CLIENT_NAME`, we use a special runtime environment so we don't
     # take forever running the test.
     if client_name == _awsimpl.AWS_FAST_TEST_CLIENT_NAME:
-        runtime = _awsimpl.AWSFastTestRuntime(context)
+        runtime = _awsimpl.AWSFastTestRuntime(context, task_id)
     else:
-        runtime = _awsimpl.AWSRuntime(context, client_name)
+        runtime = _awsimpl.AWSRuntime(context, client_name, task_id)
 
     task = client_class(state)
 

--- a/dss/events/chunkedtask/awsconstants.py
+++ b/dss/events/chunkedtask/awsconstants.py
@@ -4,7 +4,24 @@ TASK_SNS_TOPIC_PREFIX = "dss-chunked-task-"
 TASK_RETRY_QUEUE_PREFIX = "dss-chunked-task-"
 
 CLIENT_KEY = "chunked_worker_client"
-STATE_KEY = "payload"
+REQUEST_VERSION_KEY = "request_version"
+TASK_ID_KEY = "chunked_worker_task_id"
+STATE_KEY = "state"
+
+LOG_GROUP_NAME = "chunked_task_worker"
+FALLBACK_LOG_STREAM_NAME = "fallback"
+
+CURRENT_VERSION = 1
+MIN_SUPPORTED_VERSION = 1
+MAX_SUPPORTED_VERSION = 1
+
+
+# This should be an enum, but doing so makes it cumbersome to serialize to json.
+class LogActions:
+    SCHEDULED = "scheduled"
+    RESCHEDULED = "rescheduled"
+    EXCEPTION = "exception"
+    COMPLETE = "complete"
 
 
 def get_worker_sns_topic():

--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -73,6 +73,14 @@
       "Resource": "arn:aws:iam::$account_id:role/"
     },
     {
+      "Sid": "hcaDssCiCdTestLogging",
+      "Effect": "Allow",
+      "Action": [
+        "logs:*"
+      ],
+      "Resource": "arn:aws:logs:*:$account_id:log-group:chunked_task_worker*"
+    },
+    {
       "Sid": "hcaDssCiCdFilterLogEvents",
       "Effect": "Allow",
       "Action": [

--- a/iam/policy-templates/dss-chunked-task-lambda.json
+++ b/iam/policy-templates/dss-chunked-task-lambda.json
@@ -6,6 +6,7 @@
       "Action": [
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
+        "logs:DescribeLogStreams",
         "logs:PutLogEvents"
       ],
       "Resource": "arn:aws:logs:*:*:*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ flask-failsafe
 google-cloud-storage
 iso8601
 urllib3
+watchtower


### PR DESCRIPTION
1. Task scheduling happens through a `schedule_task()` method.
2. Work scheduling uses a versioned message now.  Therefore, it's future-proofed against message format changes.
3. Log each key event in the task lifecycle into a unique CloudWatch stream.
4. Updated test to watch these logged events rather than some hacky print statement at the end of a job.
5. Use watchtower to log messages.