### PR TITLE
Allow a completing task to return a value.

### DIFF
--- a/dss/events/chunkedtask/_awsimpl.py
+++ b/dss/events/chunkedtask/_awsimpl.py
@@ -9,7 +9,7 @@ from ...util.aws import ARN, send_sns_msg
 from .base import Runtime
 
 
-class AWSRuntime(Runtime[dict]):
+class AWSRuntime(Runtime[dict, typing.Any]):
     """
     This is an implementation of `Runtime` specialized for AWS Lambda.  Work scheduling is done by posting a message
     containing the serialized state to SNS.
@@ -41,11 +41,12 @@ class AWSRuntime(Runtime[dict]):
             )),
         )
 
-    def work_complete_callback(self):
+    def work_complete_callback(self, result: typing.Any):
         AWSRuntime.log(
             self.task_id,
             json.dumps(dict(
                 action=awsconstants.LogActions.COMPLETE,
+                message=result,
             )),
         )
 

--- a/dss/events/chunkedtask/_awstest.py
+++ b/dss/events/chunkedtask/_awstest.py
@@ -33,7 +33,7 @@ class AWSFastTestRuntime(AWSRuntime):
         return self.time_remaining_iterator.__next__()
 
 
-class AWSFastTestTask(Task[typing.MutableSequence]):
+class AWSFastTestTask(Task[typing.MutableSequence, bool]):
     """
     This is a chunked task that counts from a number to another.  Once the counting is complete, it prints something to
     console, which is detected by the unit test.
@@ -48,9 +48,9 @@ class AWSFastTestTask(Task[typing.MutableSequence]):
     def expected_max_one_unit_runtime_millis(self) -> int:
         return AWS_FAST_TEST_EST_TIME_MS
 
-    def run_one_unit(self) -> bool:
+    def run_one_unit(self) -> typing.Optional[bool]:
         if self.state[0] >= self.state[1]:
-            return False
+            return True
         else:
             self.state[0] += 1
-            return True  # more work to be done.
+            return None  # more work to be done.

--- a/dss/events/chunkedtask/awscopyclient.py
+++ b/dss/events/chunkedtask/awscopyclient.py
@@ -23,7 +23,7 @@ class S3CopyTaskKeys:
     PART_COUNT = "count"
 
 
-class S3CopyTask(Task[dict]):
+class S3CopyTask(Task[dict, typing.Any]):
     """
     This is a chunked task that does a multipart copy from one blob to another.
     """
@@ -94,7 +94,7 @@ class S3CopyTask(Task[dict]):
         # expect that in the worst case, we take 60 seconds to copy one part.
         return 60 * 1000
 
-    def run_one_unit(self) -> bool:
+    def run_one_unit(self) -> typing.Optional[typing.Any]:
         if len(self.queue) == 0 and self.next_part < self.part_count:
             self.queue.extend(
                 self.s3_blobstore.find_next_missing_parts(
@@ -128,7 +128,7 @@ class S3CopyTask(Task[dict]):
 
             mpu.complete(MultipartUpload=dict(Parts=parts_list))
 
-            return False
+            return True
 
         part_id = self.queue[0]
 
@@ -149,7 +149,7 @@ class S3CopyTask(Task[dict]):
 
         self.queue.popleft()
 
-        return True
+        return None
 
     def calculate_range_for_part(self, part_id) -> typing.Tuple[int, int]:
         """Calculate the byte range for `part_id`.  Assume these are S3 part IDs, which are 1-indexed."""

--- a/dss/events/chunkedtask/base.py
+++ b/dss/events/chunkedtask/base.py
@@ -1,13 +1,16 @@
 import typing
 
 TaskStateType = typing.TypeVar('TaskStateType')
+TaskResultType = typing.TypeVar('TaskResultType')
 RuntimeStateType = typing.TypeVar('RuntimeStateType')
+RuntimeResultType = typing.TypeVar('RuntimeResultType')
 
 
-class Task(typing.Generic[TaskStateType]):
-    def run_one_unit(self) -> bool:
+class Task(typing.Generic[TaskStateType, TaskResultType]):
+    def run_one_unit(self) -> typing.Optional[TaskResultType]:
         """
-        In implementations of `Task`, this should run one unit of work.  Returns true if there's more work to do.
+        In implementations of `Task`, this should run one unit of work.  Returns None if there's more work to do, or any
+        non-None value if the work is complete.  The returned value is passed to `Runtime.work_complete_callback(..)`.
         """
         raise NotImplementedError()
 
@@ -24,7 +27,7 @@ class Task(typing.Generic[TaskStateType]):
         raise NotImplementedError()
 
 
-class Runtime(typing.Generic[RuntimeStateType]):
+class Runtime(typing.Generic[RuntimeStateType, RuntimeResultType]):
     """
     This is the execution environment that the task is running in.
     """
@@ -42,7 +45,7 @@ class Runtime(typing.Generic[RuntimeStateType]):
         """
         raise NotImplementedError()
 
-    def work_complete_callback(self):
+    def work_complete_callback(self, result: RuntimeResultType):
         """
         Implementations of `Runtime` may implement this if they need to know that the task completed.
         """

--- a/tests/test_awscopyclient.py
+++ b/tests/test_awscopyclient.py
@@ -17,7 +17,7 @@ from dss.events.chunkedtask.awscopyclient import S3CopyTask
 from tests import infra
 
 
-class TestStingyRuntime(chunkedtask.Runtime[dict]):
+class TestStingyRuntime(chunkedtask.Runtime[dict, bool]):
     def __init__(self):
         self.complete = False
 
@@ -29,7 +29,7 @@ class TestStingyRuntime(chunkedtask.Runtime[dict]):
         assert state is not None
         self.rescheduled_state = state
 
-    def work_complete_callback(self):
+    def work_complete_callback(self, bool):
         self.complete = True
 
 


### PR DESCRIPTION
1. The existing `run_one_unit()` API has its contract changed to return None if there's more work, and the return value if it's done.
2. The return value is typed.
3. Updated the existing tests and code to reflect the change.
4. The return value, for the AWS runtime, is logged.