### PR TITLE
PUT /files should use random payload

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -4,6 +4,7 @@
 import hashlib
 import os
 import sys
+import tempfile
 import unittest
 import uuid
 
@@ -15,7 +16,8 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss.config import DeploymentStage, override_bucket_config
 from dss.util import UrlBuilder
-from tests.infra import DSSAsserts, ExpectedErrorFields, get_env
+from tests.fixtures.cloud_uploader import GSUploader, S3Uploader, Uploader
+from tests.infra import DSSAsserts, ExpectedErrorFields, get_env, generate_test_key
 
 
 class TestFileApi(unittest.TestCase, DSSAsserts):
@@ -24,30 +26,43 @@ class TestFileApi(unittest.TestCase, DSSAsserts):
         dss.Config.set_config(dss.DeploymentStage.TEST)
         self.s3_test_fixtures_bucket = get_env("DSS_S3_BUCKET_TEST_FIXTURES")
         self.gs_test_fixtures_bucket = get_env("DSS_GS_BUCKET_TEST_FIXTURES")
+        self.s3_test_bucket = get_env("DSS_S3_BUCKET_TEST")
+        self.gs_test_bucket = get_env("DSS_GS_BUCKET_TEST")
 
     def test_file_put(self):
-        self._test_file_put("s3", self.s3_test_fixtures_bucket)
-        self._test_file_put("gs", self.gs_test_fixtures_bucket)
+        tempdir = tempfile.gettempdir()
+        self._test_file_put("s3", self.s3_test_bucket, S3Uploader(tempdir, self.s3_test_bucket))
+        self._test_file_put("gs", self.gs_test_bucket, GSUploader(tempdir, self.gs_test_bucket))
 
-    def _test_file_put(self, scheme, fixtures_bucket):
-        file_uuid = uuid.uuid4()
-        resp_obj = self.assertPutResponse(
-            "/v1/files/" + str(file_uuid),
-            requests.codes.created,
-            json_request_body=dict(
-                source_url=f"{scheme}://{fixtures_bucket}/test_good_source_data/0",
-                bundle_uuid=str(uuid.uuid4()),
-                creator_uid=4321,
-                content_type="text/html",
-            ),
-        )
-        self.assertHeaders(
-            resp_obj.response,
-            {
-                'content-type': "application/json",
-            }
-        )
-        self.assertIn('version', resp_obj.json)
+    def _test_file_put(self, scheme: str, test_bucket: str, uploader: Uploader):
+        src_key = generate_test_key()
+        src_data = os.urandom(1024)
+        with tempfile.NamedTemporaryFile(delete=True) as fh:
+            fh.write(src_data)
+            fh.flush()
+
+            uploader.checksum_and_upload_file(
+                fh.name, src_key, {"hca-dss-content-type": "text/plain", })
+
+        # should be able to do this twice (i.e., same payload, different UUIDs)
+        for _ in range(2):
+            resp_obj = self.assertPutResponse(
+                "/v1/files/" + str(uuid.uuid4()),
+                requests.codes.created,
+                json_request_body=dict(
+                    source_url=f"{scheme}://{test_bucket}/{src_key}",
+                    bundle_uuid=str(uuid.uuid4()),
+                    creator_uid=4321,
+                    content_type="text/html",
+                ),
+            )
+            self.assertHeaders(
+                resp_obj.response,
+                {
+                    'content-type': "application/json",
+                }
+            )
+            self.assertIn('version', resp_obj.json)
 
     # This is a test specific to AWS since it has separate notion of metadata and tags.
     def test_file_put_metadata_from_tags(self):


### PR DESCRIPTION
This is to ensure that we exercise the file copy path.

To ensure that we exercise the identical-data path, we upload the same data twice.