### PR TITLE
Remove the top level GET /{files,bundles} endpoints.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -59,24 +59,6 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  /files:
-    get:
-      summary: Query files
-      description: |
-        Returns a list of files matching given criteria.
-      operationId: dss.api.files.find
-      responses:
-        200:
-          description: OK
-          schema:
-            type: object
-            properties:
-              files:
-                type: array
-                items:
-                  $ref: "#/definitions/File"
-            required:
-              - files
   /files/{uuid}:
     head:
       summary: Retrieve a file's metadata given an UUID and optionally a version.
@@ -456,47 +438,6 @@ paths:
                     enum: [unhandled_exception, Forbidden, OAuthResponseProblem, not_found]
                 required:
                   - code
-  /bundles:
-    get:
-      summary: Query bundles
-      description: |
-        Returns a list of bundles matching given criteria.
-      operationId: dss.api.bundles.find
-      responses:
-        200:
-          description: OK
-          schema:
-            type: object
-            properties:
-              bundles:
-                type: array
-                items:
-                  $ref: "#/definitions/Bundle"
-            required:
-              - bundles
-# TODO: this sort of thing actually belongs in the /bundles query interface.
-#    get:
-#      operationId: dss.api.bundles.list_versions
-#      parameters:
-#        - name: uuid
-#          in: path
-#          description: Bundle unique ID.
-#          required: true
-#          type: string
-#          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
-#      responses:
-#        200:
-#          description: OK
-#          schema:
-#            type: array
-#            items:
-#              type: string
-#              format: date-time
-#              description: Version of bundle creation in RFC3339.
-#        default:
-#          description: Unexpected error
-#          schema:
-#            $ref: '#/definitions/Error'
   /bundles/{uuid}:
     get:
       summary: Retrieve a bundle given a UUID and optionally a version.

--- a/dss/api/bundles.py
+++ b/dss/api/bundles.py
@@ -2,7 +2,6 @@ import datetime
 import io
 import json
 import typing
-import uuid
 
 import iso8601
 import requests
@@ -84,11 +83,6 @@ def get(
 @dss_handler
 def list_versions(uuid: str):
     return ["2014-10-23T00:35:14.800221Z"]
-
-
-@dss_handler
-def find():
-    return dict(bundles=[dict(uuid=str(uuid.uuid4()), versions=[])])
 
 
 @dss_handler

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -3,7 +3,6 @@ import io
 import json
 import re
 import typing
-import uuid
 
 import iso8601
 import requests
@@ -90,11 +89,6 @@ def get_helper(uuid: str, replica: typing.Optional[str]=None, version: str=None)
     headers['X-DSS-SHA256'] = file_metadata[FileMetadata.SHA256]
 
     return response
-
-
-@dss_handler
-def find():
-    return dict(files=[dict(uuid=str(uuid.uuid4()), name="", versions=[])])
 
 
 @dss_handler


### PR DESCRIPTION
It's confusing people.