### PR TITLE
Start up an elasticsearch instance per test instance.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ install:
 - pip install -r requirements-dev.txt
 - wget -q ${ES_DOWNLOAD_URL}
 - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
-- ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
-before_script:
-- for i in {0..60}; do nc -z localhost 9200 && break; sleep 1; [[ $i == 60 ]] && exit 1; done
 script:
 - set -eo pipefail
 - make test
@@ -45,5 +42,6 @@ env:
   global:
   - ES_VERSION=5.4.2
   - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - DSS_TEST_ES_PATH=./elasticsearch-${ES_VERSION}/bin/elasticsearch
   - secure: xibprEOcRoaijcM0E1q9Mbol+J0hqOdJQyx+5dsKQd2JQFFubRJ6I63aMLKrz7CzY9XJLioegn2Tpi6qFMHZteEPOzGe/HPh75f2bDgkZ53YNTbJHjNXDEVVwWaYaJ2A3QFGHelgNBSw+64PtlGUjcMTs23HWMAFi0ZK8ZY8zjdEuEzBedYLyIGVrlJJuZLrZOha9RQipPqMxZP6tQzmRgVGoxDRvodIQzvWjXu79i6T+4Vrknba5X2QHJu/bP/djhl8nb37/3tXnxUDaaE4PoahOkffntJ+ZqSLPBxkVMYQpn3/lfhxuBd/SaVPCbL365f5eHsiY0bN+0gn/0pNHhkftgU65jo5iWA0SMbiX2lhn6DR9NA2b3mgCbRyMIkcoruAswU6zySQ0BwwWwEVCcpm3qQmcA7hW3XO9HPSm0ddysxzo/bAfEYVL/j77M1WTbm+OgeVQe9ugKvsGzaXP9vfHoDKe00BlOv2zIvuC2XW3zi2W2/ZfeyYO9BQhM1vEOwb4R3RDGKdWMskp5FZjCltNT0InBOjC2VbALzvOoT7uqNtT9xiGY6n5PnrAI30zThgn6becwe/x4cMVEcdYmHZDwUWkZGmFJC/oIBcV/Gh6ReDyCSla+C87Dwl6jW/BQWGAr8qs/FM9KjlSKcancOh6yB8qwf3wqWdHHJ/2fo=
   - secure: RU6oLlCR9YWtQVTbi+VGrdwBgNoJuZHhXioKr8dPRrIimLNtGbNha/6iRliNOB8aq3qiANSptFxSoMDk63cGuNlzJlJenPoLBCWb0n7XiSIjZv0sOSRJSDxKGN5YGX8mUeBzF7VYBUBJ8cS7gql00fSvVmlKZvIwCd2qJ8bz/Y5RUXnS9mlIv3sqja5kA2StacCH7WmMP1WLUKiXQH0I5ONCgVxzCtdiyDwyee33eR94hKmieuwT95R9lGRy/ZcE58ek3rOp3lYmhzWbf7/i0qapmQIizBelN/Dqt/8h1MSw61MizPizcffZ/5d3MXsKoGNVt/Md8+os6ksBiimTy4KGouRE8UQj9YtpfiraXN+s9JBpbZJR26pMbpeUuhjSiFz3QNKcGLHXkJXRkNNz3cBg4lusDVHbCvEOfNnzik3jpvJN3GJJ2VqbPoxWKSAUYfAg1QQNSkEWE6vJfOQxMoLglcy8bV5CyKCVPdKPyXZSL/Hd6c16e0rHzXAub81jB1aneljNVL8+Vkd4Df/UfWuPKYacIt32wEIoo2IHZLpy60CJwFx2fZOnYL4Myk+Bqti4IB5AyLIrBZwt3XgXHiJeJL5+EcT8EpEohFYbfY18EwO+D94MOPlSEjPNIX+GchQEP12CavkjBMReM+Gu1yJ3Qsmk4pKiqMVqARxkzBI=

--- a/tests/es/__init__.py
+++ b/tests/es/__init__.py
@@ -1,32 +1,16 @@
 import logging
 
-from elasticsearch import Elasticsearch
-
+from dss.util.es import ElasticsearchClient
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-# Check if the Elasticsearch service is running,
-# and if not, raise and exception with instructions to start it.
-def check_start_elasticsearch_service():
-    try:
-        es_client = Elasticsearch()
-        es_info = es_client.info()
-        logger.debug("The Elasticsearch service is running.")
-        logger.debug("Elasticsearch info: %s", es_info)
-        close_elasticsearch_connections(es_client)
-    except Exception:
-        raise Exception("The Elasticsearch service does not appear to be running on this system, "
-                        "yet it is required for this test. Please start it by running: elasticsearch")
-
-
 def elasticsearch_delete_index(index_name: str):
     try:
-        es_client = Elasticsearch()
+        es_client = ElasticsearchClient.get(logger)
         es_client.indices.delete(index=index_name, ignore=[404])
-        close_elasticsearch_connections(es_client)  # Prevents end-of-test complaints about open sockets
     except Exception as e:
         logger.warning("Error occurred while removing Elasticsearch index:%s Exception: %s", index_name, e)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -14,10 +14,20 @@ sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss.events.handlers.index import create_elasticsearch_index
+from dss.util.es import ElasticsearchServer
 from tests.infra import DSSAsserts
 
 
 class TestSearch(unittest.TestCase, DSSAsserts):
+    @classmethod
+    def setUpClass(cls):
+        cls.es_server = ElasticsearchServer()
+        os.environ['DSS_ES_PORT'] = str(cls.es_server.port)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.es_server.shutdown()
+
     def setUp(self):
         dss.Config.set_config(dss.DeploymentStage.TEST)
         self.app = dss.create_app().app.test_client()

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -20,10 +20,8 @@ sys.path.insert(0, pkg_root) # noqa
 
 import dss
 from dss import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE, DSS_ELASTICSEARCH_QUERY_TYPE
-from dss.config import DeploymentStage
 from dss.util import UrlBuilder
-from dss.util.es import ElasticsearchClient, get_elasticsearch_index
-from tests.es import check_start_elasticsearch_service, close_elasticsearch_connections, elasticsearch_delete_index
+from dss.util.es import ElasticsearchClient, ElasticsearchServer, get_elasticsearch_index
 from tests.infra import DSSAsserts
 
 logging.basicConfig(level=logging.INFO)
@@ -32,6 +30,14 @@ logger.setLevel(logging.INFO)
 
 
 class TestSubscriptions(unittest.TestCase, DSSAsserts):
+    @classmethod
+    def setUpClass(cls):
+        cls.es_server = ElasticsearchServer()
+        os.environ['DSS_ES_PORT'] = str(cls.es_server.port)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.es_server.shutdown()
 
     def setUp(self):
         os.environ['DSS_ES_ENDPOINT'] = os.getenv('DSS_ES_ENDPOINT', "localhost")


### PR DESCRIPTION
This way the test does not rely on any global state.  Adds a new required argument (only for tests) that DSS_TEST_ES_PATH be set to a valid elasticsearch binary.