### PR TITLE
Disable codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,4 @@ coverage:
       default:
         threshold: 2.5%
 
-comment:
-  require_changes: yes
+comment: off


### PR DESCRIPTION
Unfortunately, enabling "bot" comments has made codecov noisy and obnoxious, since it seems to lose track of its previous comments often. Disable its PR comments until they figure that out.