### PR TITLE
HCA-specific copy clients.

### DIFF
--- a/dss/events/chunkedtask/aws.py
+++ b/dss/events/chunkedtask/aws.py
@@ -6,6 +6,7 @@ import uuid
 
 import boto3
 
+from . import awscopyclient
 from . import _awstest, awsconstants
 from ._awsimpl import AWSRuntime
 from .runner import Runner
@@ -13,6 +14,8 @@ from .runner import Runner
 # this is the authoritative mapping between client names and Task classes.
 CLIENTS = {
     _awstest.AWS_FAST_TEST_CLIENT_NAME: _awstest.AWSFastTestTask,
+    awscopyclient.AWS_S3_COPY_CLIENT_NAME: awscopyclient.S3CopyTask,
+    awscopyclient.AWS_S3_COPY_AND_WRITE_METADATA_CLIENT_NAME: awscopyclient.S3CopyWriteBundleTask,
 }
 
 logger = logging.getLogger()

--- a/dss/events/chunkedtask/awscopyclient.py
+++ b/dss/events/chunkedtask/awscopyclient.py
@@ -6,7 +6,12 @@ import typing
 import boto3
 
 from . import Task
+from ...api import files
 from ...blobstore.s3 import S3BlobStore
+
+
+AWS_S3_COPY_CLIENT_NAME = "s3_copy"
+AWS_S3_COPY_AND_WRITE_METADATA_CLIENT_NAME = "s3_copy_write_metadata"
 
 
 # intuitively, this ought to be an enum, but serializing an enum is way too complicated.
@@ -175,3 +180,47 @@ class S3CopyTask(Task[dict, typing.Any]):
         end -= 1
 
         return start, end
+
+
+class S3CopyWriteBundleTaskKeys(S3CopyTaskKeys):
+    METADATA = "metadata"
+    FILE_UUID = "file_uuid"
+    FILE_VERSION = "file_version"
+
+
+class S3CopyWriteBundleTask(S3CopyTask):
+    """
+    This is a chunked task that does a multipart copy from one blob to another and writes a bundle manifest.
+    """
+    def __init__(self, state: dict) -> None:
+        super().__init__(state)
+        self.metadata = state[S3CopyWriteBundleTaskKeys.METADATA]
+        self.file_uuid = state[S3CopyWriteBundleTaskKeys.FILE_UUID]
+        self.file_version = state[S3CopyWriteBundleTaskKeys.FILE_VERSION]
+
+    def get_state(self) -> dict:
+        state = super().get_state()
+        state[S3CopyWriteBundleTaskKeys.METADATA] = self.metadata
+        state[S3CopyWriteBundleTaskKeys.FILE_UUID] = self.file_uuid
+        state[S3CopyWriteBundleTaskKeys.FILE_VERSION] = self.file_version
+        return state
+
+    @property
+    def expected_max_one_unit_runtime_millis(self) -> int:
+        # expect that in the worst case, we take 60 seconds to copy one part.
+        return 60 * 1000
+
+    def run_one_unit(self) -> typing.Optional[dict]:
+        result = super().run_one_unit()
+        if result is None:
+            return result
+
+        # subtask is done!  let's write the file metadata.
+        handle = S3BlobStore()
+
+        files.write_file_metadata(handle, self.destination_bucket, self.file_uuid, self.file_version, self.metadata)
+
+        return {
+            S3CopyWriteBundleTaskKeys.FILE_UUID: self.file_uuid,
+            S3CopyWriteBundleTaskKeys.FILE_VERSION: self.file_version,
+        }


### PR DESCRIPTION
This is like a normal S3 copy client, except it has extra bits of state to manage writing the file manifest once the copy is complete. 