### PR TITLE
Update PUT /files to be async for AWS.

### DIFF
--- a/tests/infra.py
+++ b/tests/infra.py
@@ -227,14 +227,12 @@ class StorageTestSupport:
         self.create_bundle(bundle)
 
     def upload_file(self: Any, bundle_file: S3File) -> str:
-        response = self.assertPutResponse(
-            f"/v1/files/{bundle_file.uuid}",
-            requests.codes.created,
-            json_request_body=dict(
-                bundle_uuid=bundle_file.bundle.uuid,
-                creator_uid=0,
-                source_url=bundle_file.url
-            )
+        response = upload_file_wait(
+            typing.cast(DSSAsserts, self),
+            bundle_file.url,
+            "aws",
+            file_uuid=bundle_file.uuid,
+            bundle_uuid=bundle_file.bundle.uuid,
         )
         response_data = json.loads(response[1])
         self.assertIs(type(response_data), dict)

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -16,7 +16,7 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss.config import DeploymentStage, Config, override_bucket_config
 from dss.util import UrlBuilder
-from tests.infra import DSSAsserts, get_env
+from tests.infra import DSSAsserts, get_env, upload_file_wait
 
 
 class TestDSS(unittest.TestCase, DSSAsserts):
@@ -107,15 +107,12 @@ class TestDSS(unittest.TestCase, DSSAsserts):
 
         file_uuid = str(uuid.uuid4())
         bundle_uuid = str(uuid.uuid4())
-        resp_obj = self.assertPutResponse(
-            "/v1/files/" + file_uuid,
-            requests.codes.created,
-            json_request_body=dict(
-                source_url=f"{schema}://{fixtures_bucket}/test_good_source_data/0",
-                bundle_uuid=bundle_uuid,
-                creator_uid=4321,
-                content_type="text/html",
-            ),
+        resp_obj = upload_file_wait(
+            self,
+            f"{schema}://{fixtures_bucket}/test_good_source_data/0",
+            replica,
+            file_uuid,
+            bundle_uuid,
         )
         version = resp_obj.json['version']
 


### PR DESCRIPTION
1. PUT /files for AWS will now spawn a lambda to execute the copy.
2. tests are uploaded to use the `upload_file()` primitive that waits for completion.