### PR TITLE
Fix bugs in how we deal with time-remaining.

### DIFF
--- a/tests/test_s3copyclient.py
+++ b/tests/test_s3copyclient.py
@@ -93,7 +93,7 @@ class TestAWSCopy(unittest.TestCase):
             self.test_bucket, self.test_src_key, self.test_bucket, dest_key, lambda blob_size: (5 * 1024 * 1024))
 
         while True:
-            env = TestStingyRuntime(seq=itertools.repeat(sys.maxsize, 9))
+            env = TestStingyRuntime(seq=itertools.repeat(sys.maxsize, 7))
             task = S3CopyTask(current_state, fetch_size=4)
             runner = chunkedtask.Runner(task, env)
 


### PR DESCRIPTION
1. In the constructor of `Runner`, we should not consider the time-remaining-to-run in calculating the estimated time for how long a block takes.  This is an artifact from when I structured the code differently, to ensure that we at least process one unit of work.
2. Update the stats about how long a work unit takes before we decide if we want to run more work.
3. Time overhead factor on the wrong side of the equation.