### PR TITLE
Fixups for sync engine

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -60,14 +60,7 @@ def get_chalice_app(flask_app):
     def handle_notification():
         event = app.current_request.json_body
         if event["kind"] == "storage#object" and event["selfLink"].startswith("https://www.googleapis.com/storage"):
-            # FIXME: (akislyuk) authenticate the message
-            gs_key_name = event["name"]
-            sync_result = sync_blob(source_platform="gs",
-                                    source_key=gs_key_name,
-                                    dest_platform="s3",
-                                    logger=app.log,
-                                    context=app.lambda_context)
-            return sync_result
+            app.log.info("Ignoring Google Object Change Notification")
         else:
             raise NotImplementedError()
 


### PR DESCRIPTION
- Fix SNS topic names to be per-stage (and also to match the per-stage IAM permissions)
- Propagate object metadata when performing multipart/composite object copy
- Deploy a per-stage GCF event relay for deployment sanity and because it seems a given GCF can only be subscribed to one bucket event source

Tested manually - tests for all of this are coming in the integration test suite.