### PR TITLE
Make Elasticsearch indexes replica specific

### DIFF
--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -8,7 +9,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss.events.handlers.index import process_new_s3_indexable_object
+from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object
 
 app = domovoi.Domovoi()
 
@@ -29,4 +30,5 @@ def dispatch_gs_indexer_event(event, context):
     """
     This handler receives GS events via the Google Cloud Function deployed from daemons/dss-gs-event-relay.
     """
-    context.log(f"dss-index daemon got a GS event: {event}")
+    gs_event = json.loads(event['Records'][0]['Sns']['Message'])
+    process_new_gs_indexable_object(gs_event['data'], app.log)

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -38,6 +38,12 @@ paths:
                 type: object
             required:
               - es_query
+        - name: replica
+          in: query
+          description: Replica to search.
+          required: true
+          type: string
+          enum: [aws, gcp, azure]
       produces:
         - application/json
       responses:

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -20,23 +20,8 @@ from connexion.exceptions import OAuthProblem, OAuthResponseProblem, OAuthScopeP
 from flask_failsafe import failsafe
 from werkzeug.exceptions import Forbidden
 
-from .config import DeploymentStage, Config
+from .config import Config, DeploymentStage, ESIndexType, ESDocType, Replica
 from .error import DSSException, dss_handler
-
-# CONSTANTS COMMON TO THE INDEXER AND QUERY ROUTE.
-
-# ES index containing all docs
-DSS_ELASTICSEARCH_INDEX_NAME = "hca-" + os.environ["DSS_DEPLOYMENT_STAGE"]
-# ES type within DSS_ELASTICSEARCH_INDEX_NAME with docs
-DSS_ELASTICSEARCH_DOC_TYPE = "doc"
-# ES type within DSS_ELASTICSEARCH_INDEX_NAME with percolate queries
-DSS_ELASTICSEARCH_QUERY_TYPE = "query"
-
-# ES index with all registered percolate queries
-DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME = "subscriptions-" + os.environ["DSS_DEPLOYMENT_STAGE"]
-# ES type in DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME with subscriptions
-DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE = "subscription"
-
 
 def get_logger():
     try:

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -10,14 +10,12 @@ from dss import ESDocType
 from .. import Config, Replica, ESIndexType, dss_handler, get_logger, DSSException
 from ..util.es import ElasticsearchClient
 
-# TODO Adding replica as a search parameter and including tests for gcp
-# will be done in a different PR.
-replica = "aws"
-
 @dss_handler
-def post(json_request_body: dict):
+def post(json_request_body: dict, replica: str):
     es_query = json_request_body['es_query']
-    get_logger().debug("Received posted query: %s", json.dumps(es_query, indent=4))
+    get_logger().debug("Received posted query. Replica: %s Query: %s", replica, json.dumps(es_query, indent=4))
+    if replica is None:
+        replica = "aws"
     try:
         es_client = ElasticsearchClient.get(get_logger())
         search_obj = Search(using=es_client,

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -8,8 +8,11 @@ from flask import request, jsonify
 
 from .. import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE
 from .. import dss_handler, get_logger, DSSException
-from ..util.es import ElasticsearchClient
+from ..util.es import ElasticsearchClient, get_elasticsearch_index_name
 
+# TODO Adding replica as a search parameter and including tests for gcp
+# will be done in a different PR.
+replica = "aws"
 
 @dss_handler
 def post(json_request_body: dict):
@@ -18,7 +21,7 @@ def post(json_request_body: dict):
     try:
         es_client = ElasticsearchClient.get(get_logger())
         search_obj = Search(using=es_client,
-                            index=DSS_ELASTICSEARCH_INDEX_NAME,
+                            index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_INDEX_NAME, replica),
                             doc_type=DSS_ELASTICSEARCH_DOC_TYPE).update_from_dict(es_query)
 
         # TODO (mbaumann) extract version from the request path instead of hard-coding it here

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -6,6 +6,7 @@ from elasticsearch_dsl import Search
 from elasticsearch_dsl.exceptions import ElasticsearchDslException
 from flask import request, jsonify
 
+from dss import ESDocType
 from .. import Config, Replica, ESIndexType, dss_handler, get_logger, DSSException
 from ..util.es import ElasticsearchClient
 
@@ -20,8 +21,8 @@ def post(json_request_body: dict):
     try:
         es_client = ElasticsearchClient.get(get_logger())
         search_obj = Search(using=es_client,
-                            index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
-                            doc_type=DSS_ELASTICSEARCH_DOC_TYPE).update_from_dict(es_query)
+                     index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
+                             doc_type=ESDocType.doc.name).update_from_dict(es_query)
 
         # TODO (mbaumann) extract version from the request path instead of hard-coding it here
         bundles_url_base = request.host_url + 'v1/bundles/'

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -6,9 +6,8 @@ from elasticsearch_dsl import Search
 from elasticsearch_dsl.exceptions import ElasticsearchDslException
 from flask import request, jsonify
 
-from .. import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE
-from .. import dss_handler, get_logger, DSSException
-from ..util.es import ElasticsearchClient, get_elasticsearch_index_name
+from .. import Config, Replica, ESIndexType, dss_handler, get_logger, DSSException
+from ..util.es import ElasticsearchClient
 
 # TODO Adding replica as a search parameter and including tests for gcp
 # will be done in a different PR.
@@ -21,7 +20,7 @@ def post(json_request_body: dict):
     try:
         es_client = ElasticsearchClient.get(get_logger())
         search_obj = Search(using=es_client,
-                            index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_INDEX_NAME, replica),
+                            index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
                             doc_type=DSS_ELASTICSEARCH_DOC_TYPE).update_from_dict(es_query)
 
         # TODO (mbaumann) extract version from the request path instead of hard-coding it here

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -19,8 +19,8 @@ def post(json_request_body: dict, replica: str):
     try:
         es_client = ElasticsearchClient.get(get_logger())
         search_obj = Search(using=es_client,
-                     index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
-                             doc_type=ESDocType.doc.name).update_from_dict(es_query)
+                            index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
+                            doc_type=ESDocType.doc.name).update_from_dict(es_query)
 
         # TODO (mbaumann) extract version from the request path instead of hard-coding it here
         bundles_url_base = request.host_url + 'v1/bundles/'

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -30,8 +30,7 @@ def get(uuid: str, replica: str):
     es_client = ElasticsearchClient.get(logger)
 
     try:
-        response = es_client.get(index=Config.get_es_index_name(ESIndexType.subscriptions,
-                                                                Replica[replica]),
+        response = es_client.get(index=Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica]),
                                  doc_type=ESDocType.subscription.name,
                                  id=uuid)
     except NotFoundError as ex:
@@ -133,8 +132,7 @@ def delete(uuid: str, replica: str):
     es_client = ElasticsearchClient.get(logger)
 
     try:
-        response = es_client.get(index=Config.get_es_index_name(ESIndexType.subscriptions,
-                                                                Replica[replica]),
+        response = es_client.get(index=Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica]),
                                  doc_type=ESDocType.subscription.name,
                                  id=uuid)
     except NotFoundError as ex:

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -14,15 +14,11 @@ from elasticsearch_dsl import Search
 from flask import jsonify, make_response, redirect, request
 from werkzeug.exceptions import BadRequest
 
-from .. import (
-    get_logger,
-    DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE, DSS_ELASTICSEARCH_QUERY_TYPE,
-    DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE)
+from .. import Config, Replica, ESIndexType, ESDocType, get_logger
 from ..blobstore import BlobNotFoundError
-from ..config import Config
 from ..error import DSSException, dss_handler
 from ..hcablobstore import FileMetadata, HCABlobStore
-from ..util.es import ElasticsearchClient, get_elasticsearch_index_name, get_elasticsearch_index
+from ..util.es import ElasticsearchClient, get_elasticsearch_index
 
 logger = get_logger()
 
@@ -34,8 +30,9 @@ def get(uuid: str, replica: str):
     es_client = ElasticsearchClient.get(logger)
 
     try:
-        response = es_client.get(index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, replica),
-                                 doc_type=DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE,
+        response = es_client.get(index=Config.get_es_index_name(ESIndexType.subscriptions,
+                                                                Replica[replica]),
+                                 doc_type=ESDocType.subscription.name,
                                  id=uuid)
     except NotFoundError as ex:
         raise DSSException(requests.codes.not_found, "not_found", "Cannot find subscription!")
@@ -57,8 +54,8 @@ def find(replica: str):
     es_client = ElasticsearchClient.get(logger)
 
     search_obj = Search(using=es_client,
-                        index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, replica),
-                        doc_type=DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE)
+                        index=Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica]),
+                        doc_type=ESDocType.subscription.name)
     search = search_obj.query({'match': {'owner': owner}})
 
     responses = [{
@@ -83,7 +80,7 @@ def put(json_request_body: dict, replica: str):
 
     index_mapping = {
         "mappings": {
-            DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE: {
+            ESDocType.subscription.name: {
                 "properties": {
                     "owner": {
                         "type": "string",
@@ -97,7 +94,7 @@ def put(json_request_body: dict, replica: str):
     # So for john@example.com, if I searched for people with the email address jill@example.com,
     # john@example.com would show up because elasticsearch matched example w/ example.
     # By including "index": "not_analyzed", Elasticsearch leaves all owner inputs alone.
-    index_name = get_elasticsearch_index_name(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, replica)
+    index_name = Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica])
     get_elasticsearch_index(es_client, index_name, logger, index_mapping)
 
     try:
@@ -119,7 +116,7 @@ def put(json_request_body: dict, replica: str):
 
         # Delete percolate query to make sure queries and subscriptions are in sync.
         es_client.delete(index=index_name,
-                         doc_type=DSS_ELASTICSEARCH_QUERY_TYPE,
+                         doc_type=ESDocType.query.name,
                          id=uuid,
                          refresh=True)
         raise DSSException(requests.codes.internal_server_error,
@@ -136,8 +133,9 @@ def delete(uuid: str, replica: str):
     es_client = ElasticsearchClient.get(logger)
 
     try:
-        response = es_client.get(index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, replica),
-                                 doc_type=DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE,
+        response = es_client.get(index=Config.get_es_index_name(ESIndexType.subscriptions,
+                                                                Replica[replica]),
+                                 doc_type=ESDocType.subscription.name,
                                  id=uuid)
     except NotFoundError as ex:
         raise DSSException(requests.codes.not_found, "not_found", "Cannot find subscription!")
@@ -148,13 +146,13 @@ def delete(uuid: str, replica: str):
         # common_error_handler defaults code to capitalized 'Forbidden' for Werkzeug exception. Keeping consistent.
         raise DSSException(requests.codes.forbidden, "Forbidden", "Your credentials can't access this subscription!")
 
-    es_client.delete(index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_INDEX_NAME, replica),
-                     doc_type=DSS_ELASTICSEARCH_QUERY_TYPE,
+    es_client.delete(index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
+                     doc_type=ESDocType.query.name,
                      id=uuid,
                      refresh=True)
 
-    es_client.delete(index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, replica),
-                     doc_type=DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE,
+    es_client.delete(index=Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica]),
+                     doc_type=ESDocType.subscription.name,
                      id=uuid)
 
     timestamp = datetime.datetime.utcnow()
@@ -164,18 +162,18 @@ def delete(uuid: str, replica: str):
 
 
 def _register_percolate(es_client: Elasticsearch, uuid: str, query: dict, replica: str):
-    index_name = get_elasticsearch_index_name(DSS_ELASTICSEARCH_INDEX_NAME, replica)
+    index_name = Config.get_es_index_name(ESIndexType.docs, Replica[replica])
     return es_client.index(index=index_name,
-                           doc_type=DSS_ELASTICSEARCH_QUERY_TYPE,
+                           doc_type=ESDocType.query.name,
                            id=uuid,
                            body=query,
                            refresh=True)
 
 
 def _register_subscription(es_client: Elasticsearch, uuid: str, json_request_body: dict, replica: str):
-    index_name = get_elasticsearch_index_name(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, replica)
+    index_name = Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica])
     return es_client.index(index=index_name,
-                           doc_type=DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE,
+                           doc_type=ESDocType.subscription.name,
                            id=uuid,
                            body=json_request_body,
                            refresh=True)

--- a/dss/config.py
+++ b/dss/config.py
@@ -17,6 +17,18 @@ class DeploymentStage(Enum):
     TEST = auto()
     TEST_FIXTURE = auto()
 
+class ESIndexType(Enum):
+    docs = auto()
+    subscriptions = auto()
+
+class ESDocType(Enum):
+    doc = auto()  # Metadata docs in the dss-docs index
+    query = auto()  # Percolate queries (for event subscriptions) in the dss-docs index
+    subscription = auto()  # Event subscriptions in the ds-subscriptions index
+
+class Replica(Enum):
+    aws = auto()
+    gcp = auto()
 
 class Config:
     _S3_BUCKET = None  # type: typing.Optional[str]
@@ -116,6 +128,11 @@ class Config:
             Config._ALLOWED_EMAILS = os.environ[envvar]
 
         return Config._ALLOWED_EMAILS
+
+    @staticmethod
+    def get_es_index_name(index_type: ESIndexType, replica: Replica) -> str:
+        deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
+        return f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
 
     @staticmethod
     def _clear_cached_bucket_config():

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -15,7 +15,7 @@ from ... import (DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE,
                  DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE)
 from ...util import create_blob_key
 from ...hcablobstore import BundleMetadata, BundleFileMetadata
-from ...util.es import ElasticsearchClient
+from ...util.es import ElasticsearchClient, get_elasticsearch_index_name, get_elasticsearch_index
 from ...blobstore import BlobStore, BlobNotFoundError
 
 DSS_BUNDLE_KEY_REGEX = r"^bundles/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\..+$"
@@ -50,9 +50,10 @@ def process_new_indexable_object(bucket_name: str, key: str, replica: str, logge
         manifest = read_bundle_manifest(blobstore, bucket_name, key, logger)
         bundle_id = get_bundle_id_from_key(key)
         index_data = create_index_data(blobstore, bucket_name, bundle_id, manifest, logger)
-        add_index_data_to_elasticsearch(bundle_id, index_data, logger)
-        subscriptions = find_matching_subscriptions(index_data, logger)
-        process_notifications(bundle_id, subscriptions, logger)
+        index_name = get_elasticsearch_index_name(DSS_ELASTICSEARCH_INDEX_NAME, replica)
+        add_index_data_to_elasticsearch(bundle_id, index_data, index_name, logger)
+        subscriptions = find_matching_subscriptions(index_data, index_name, logger)
+        process_notifications(bundle_id, subscriptions, replica, logger)
         logger.debug(f"Finished index processing of {replica} creation event for bundle: {key}")
     else:
         logger.debug(f"Not indexing {replica} creation event for key: {key}")
@@ -128,13 +129,13 @@ def get_bundle_id_from_key(bundle_key: str) -> str:
     raise Exception(f"This is not a key for a bundle: {bundle_key}")
 
 
-def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, logger) -> None:
-    create_elasticsearch_index(logger)
-    logger.debug("Adding index data to Elasticsearch: %s", json.dumps(index_data, indent=4))
-    add_data_to_elasticsearch(bundle_id, index_data, logger)
+def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, logger) -> None:
+    create_elasticsearch_index(index_name, logger)
+    logger.debug(f"Adding index data to Elasticsearch index '{index_name}': %s", json.dumps(index_data, indent=4))
+    add_data_to_elasticsearch(bundle_id, index_data, index_name, logger)
 
 
-def create_elasticsearch_index(logger):
+def create_elasticsearch_index(index_name, logger):
     index_mapping = {
         'mappings': {
             DSS_ELASTICSEARCH_QUERY_TYPE: {
@@ -146,32 +147,22 @@ def create_elasticsearch_index(logger):
             }
         }
     }
-    try:
-        es_client = ElasticsearchClient.get(logger)
-        response = es_client.indices.exists(DSS_ELASTICSEARCH_INDEX_NAME)
-        if not response:
-            logger.debug(f"Creating new Elasticsearch index: {DSS_ELASTICSEARCH_INDEX_NAME}")
-            response = es_client.indices.create(DSS_ELASTICSEARCH_INDEX_NAME, body=index_mapping)
-            logger.debug("Index creation response: %s", json.dumps(response, indent=4))
-        else:
-            logger.debug(f"Using existing Elasticsearch index: {DSS_ELASTICSEARCH_INDEX_NAME}", )
-    except Exception as ex:
-        logger.critical("Unable to create index %s  Exception: %s", DSS_ELASTICSEARCH_INDEX_NAME, ex)
-        raise
+    get_elasticsearch_index(ElasticsearchClient.get(logger), index_name, logger, index_mapping)
 
 
-def add_data_to_elasticsearch(bundle_id: str, index_data: dict, logger) -> None:
+def add_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, logger) -> None:
     try:
-        ElasticsearchClient.get(logger).index(index=DSS_ELASTICSEARCH_INDEX_NAME,
+        ElasticsearchClient.get(logger).index(index=index_name,
                                               doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
                                               id=bundle_id,
                                               body=json.dumps(index_data))  # Do not use refresh here - too expensive.
     except Exception as ex:
-        logger.error("Document not indexed. Exception: %s  Index data: %s", ex, json.dumps(index_data, indent=4))
+        logger.error(f"Document not indexed. Exception: {ex}, Index name: {index_name},  Index data: %s",
+                     json.dumps(index_data, indent=4))
         raise
 
 
-def find_matching_subscriptions(index_data: dict, logger) -> set:
+def find_matching_subscriptions(index_data: dict, index_name: str, logger) -> set:
     percolate_document = {
         'query': {
             'percolate': {
@@ -183,25 +174,25 @@ def find_matching_subscriptions(index_data: dict, logger) -> set:
     }
     subscription_ids = set()
     for hit in scan(ElasticsearchClient.get(logger),
-                    index=DSS_ELASTICSEARCH_INDEX_NAME,
+                    index=index_name,
                     query=percolate_document):
         subscription_ids.add(hit["_id"])
     logger.debug("Found matching subscription count: %i", len(subscription_ids))
     return subscription_ids
 
 
-def process_notifications(bundle_id: str, subscription_ids: set, logger) -> None:
+def process_notifications(bundle_id: str, subscription_ids: set, replica, logger) -> None:
     for subscription_id in subscription_ids:
         try:
             # TODO Batch this request
-            subscription = get_subscription(subscription_id, logger)
+            subscription = get_subscription(subscription_id, replica, logger)
             notify(subscription_id, subscription, bundle_id, logger)
         except Exception as ex:
             logger.error("Error occurred while processing subscription %s for bundle %s. %s",
                          subscription_id, bundle_id, ex)
 
 
-def get_subscription(subscription_id: str, logger):
+def get_subscription(subscription_id: str, replica: str, logger):
     subscription_query = {
         'query': {
             'ids': {
@@ -211,7 +202,7 @@ def get_subscription(subscription_id: str, logger):
         }
     }
     response = ElasticsearchClient.get(logger).search(
-        index=DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME,
+        index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, replica),
         body=subscription_query)
     if len(response['hits']['hits']) == 1:
         return response['hits']['hits'][0]['_source']

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -9,13 +9,10 @@ from urllib.parse import unquote
 import requests
 from elasticsearch.helpers import scan
 
-from dss import Config
-from ... import (DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE,
-                 DSS_ELASTICSEARCH_QUERY_TYPE, DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME,
-                 DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE)
+from dss import Config, ESIndexType, ESDocType, Replica
 from ...util import create_blob_key
 from ...hcablobstore import BundleMetadata, BundleFileMetadata
-from ...util.es import ElasticsearchClient, get_elasticsearch_index_name, get_elasticsearch_index
+from ...util.es import ElasticsearchClient, get_elasticsearch_index
 from ...blobstore import BlobStore, BlobNotFoundError
 
 DSS_BUNDLE_KEY_REGEX = r"^bundles/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\..+$"
@@ -50,7 +47,7 @@ def process_new_indexable_object(bucket_name: str, key: str, replica: str, logge
         manifest = read_bundle_manifest(blobstore, bucket_name, key, logger)
         bundle_id = get_bundle_id_from_key(key)
         index_data = create_index_data(blobstore, bucket_name, bundle_id, manifest, logger)
-        index_name = get_elasticsearch_index_name(DSS_ELASTICSEARCH_INDEX_NAME, replica)
+        index_name = Config.get_es_index_name(ESIndexType.docs, Replica[replica])
         add_index_data_to_elasticsearch(bundle_id, index_data, index_name, logger)
         subscriptions = find_matching_subscriptions(index_data, index_name, logger)
         process_notifications(bundle_id, subscriptions, replica, logger)
@@ -138,7 +135,7 @@ def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name
 def create_elasticsearch_index(index_name, logger):
     index_mapping = {
         'mappings': {
-            DSS_ELASTICSEARCH_QUERY_TYPE: {
+            ESDocType.query.name: {
                 'properties': {
                     'query': {
                         'type': "percolator"
@@ -153,7 +150,7 @@ def create_elasticsearch_index(index_name, logger):
 def add_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, logger) -> None:
     try:
         ElasticsearchClient.get(logger).index(index=index_name,
-                                              doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
+                                              doc_type=ESDocType.doc.name,
                                               id=bundle_id,
                                               body=json.dumps(index_data))  # Do not use refresh here - too expensive.
     except Exception as ex:
@@ -167,7 +164,7 @@ def find_matching_subscriptions(index_data: dict, index_name: str, logger) -> se
         'query': {
             'percolate': {
                 'field': "query",
-                'document_type': DSS_ELASTICSEARCH_DOC_TYPE,
+                'document_type': ESDocType.doc.name,
                 'document': index_data
             }
         }
@@ -196,13 +193,13 @@ def get_subscription(subscription_id: str, replica: str, logger):
     subscription_query = {
         'query': {
             'ids': {
-                'type': DSS_ELASTICSEARCH_SUBSCRIPTION_TYPE,
+                'type': ESDocType.subscription.name,
                 'values': [subscription_id]
             }
         }
     }
     response = ElasticsearchClient.get(logger).search(
-        index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME, replica),
+        index=Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica]),
         body=subscription_query)
     if len(response['hits']['hits']) == 1:
         return response['hits']['hits'][0]['_source']

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -135,16 +135,23 @@ class ElasticsearchClient:
         return client
 
 
-def get_elasticsearch_index(es_client, idx, logger, index_mapping=None):
+def get_elasticsearch_index_name(index_basename: str, replica: str):
+    """Make index name replica specific byusing the replica as an index name suffix. """
+    assert index_basename and replica
+
+    return f"{index_basename}-{replica}"
+
+
+def get_elasticsearch_index(es_client, index_name, logger, index_mapping=None):
     try:
-        response = es_client.indices.exists(idx)
+        response = es_client.indices.exists(index_name)
         if response:
-            logger.debug("Using existing Elasticsearch index: {}".format(idx))
+            logger.debug(f"Using existing Elasticsearch index: {index_name}")
         else:
-            logger.debug("Creating new Elasticsearch index: {}".format(idx))
-            response = es_client.indices.create(idx, body=index_mapping)
-            logger.debug("Index creation response: {}", (json.dumps(response, indent=4)))
+            logger.debug(f"Creating new Elasticsearch index: {index_name}")
+            response = es_client.indices.create(index_name, body=index_mapping)
+            logger.debug("Index creation response: %s", json.dumps(response, indent=4))
 
     except Exception as ex:
-        logger.error("Unable to create index {} Exception: {}".format(idx))
+        logger.error(f"Unable to create index: {index_name} Exception: {ex}")
         raise ex

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -135,13 +135,6 @@ class ElasticsearchClient:
         return client
 
 
-def get_elasticsearch_index_name(index_basename: str, replica: str):
-    """Make index name replica specific byusing the replica as an index name suffix. """
-    assert index_basename and replica
-
-    return f"{index_basename}-{replica}"
-
-
 def get_elasticsearch_index(es_client, index_name, logger, index_mapping=None):
     try:
         response = es_client.indices.exists(index_name)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -30,7 +30,7 @@ from dss.events.handlers.index import process_new_s3_indexable_object, process_n
 from dss.hcablobstore import BundleMetadata, BundleFileMetadata, FileMetadata
 from dss.util import create_blob_key, UrlBuilder
 from dss.util.es import ElasticsearchClient, ElasticsearchServer
-
+from tests import get_version
 from tests.es import elasticsearch_delete_index
 from tests.fixtures.populate import populate
 from tests.infra import DSSAsserts, DSSUploadMixin, StorageTestSupport, TestBundle, start_verbose_logging
@@ -193,7 +193,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
         sample_event = self.create_sample_bundle_created_event(bundle_key)
         self.process_new_indexable_object(sample_event, logger)
 
-        ElasticsearchClient.get(logger).indices.create(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME)
+        ElasticsearchClient.get(logger).indices.create(self.subscription_index_name)
         subscription_id = self.subscribe_for_notification(smartseq2_paired_ends_query,
                                                           f"http://{HTTPInfo.address}:{HTTPInfo.port}")
 
@@ -208,7 +208,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
         sample_event = self.create_sample_bundle_created_event(bundle_key)
         self.process_new_indexable_object(sample_event, logger)
 
-        ElasticsearchClient.get(logger).indices.create(DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME)
+        ElasticsearchClient.get(logger).indices.create(self.subscription_index_name)
         subscription_id = self.subscribe_for_notification(smartseq2_paired_ends_query,
                                                           f"http://{HTTPInfo.address}:{HTTPInfo.port}")
 
@@ -331,7 +331,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
         while True:
             response = ElasticsearchClient.get(logger).search(
                 index=cls.dss_index_name,
-                doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
+                doc_type=dss.ESDocType.doc.name,
                 body=json.dumps(query))
             if (len(response['hits']['hits']) >= expected_hit_count) \
                     or (time.time() >= timeout_time):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -142,8 +142,8 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
                 self.process_new_indexable_object(sample_event, logger)
             self.assertRegex(log_monitor.output[0], "DEBUG:.*Not indexing .* creation event for key: .*")
             with self.assertRaises(Exception) as ex:
-                ElasticsearchClient.get(logger).get(index=DSS_ELASTICSEARCH_INDEX_NAME,
-                                                    doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
+                ElasticsearchClient.get(logger).get(index=self.dss_index_name,
+                                                    doc_type=dss.ESIndexType.docs,
                                                     id=bundle_uuid)
             self.assertEqual('index_not_found_exception', ex.exception.error)
         finally:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -25,13 +25,11 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss import (DeploymentStage, Config,
-                 DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE,
-                 DSS_ELASTICSEARCH_SUBSCRIPTION_INDEX_NAME)
+from dss import Config, DeploymentStage
 from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object
 from dss.hcablobstore import BundleMetadata, BundleFileMetadata, FileMetadata
 from dss.util import create_blob_key, UrlBuilder
-from dss.util.es import ElasticsearchClient, ElasticsearchServer, get_elasticsearch_index_name
+from dss.util.es import ElasticsearchClient, ElasticsearchServer
 
 from tests.es import elasticsearch_delete_index
 from tests.fixtures.populate import populate

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -385,6 +385,48 @@ class TestGCPIndexer(TestIndexerBase, unittest.TestCase):
         return sample_event
 
 
+class TestGCPIndexer(unittest.TestCase, TestIndexerBase):
+
+    http_server_address = "127.0.0.1"
+    http_server_port = 8729
+
+    @classmethod
+    def setUpClass(cls):
+        cls.replica = "gcp"
+        Config.set_config(DeploymentStage.TEST_FIXTURE)
+        cls.blobstore, _, cls.test_fixture_bucket = Config.get_cloud_specific_handles(cls.replica)
+        Config.set_config(DeploymentStage.TEST)
+        _, _, cls.test_bucket = Config.get_cloud_specific_handles(cls.replica)
+        cls.es_server = ElasticsearchServer()
+        os.environ['DSS_ES_PORT'] = str(cls.es_server.port)
+        try:
+            cls.http_server = HTTPServer((cls.http_server_address, cls.http_server_port), PostTestHandler)
+            cls.http_server_thread = threading.Thread(target=cls.http_server.serve_forever)
+            cls.http_server_thread.start()
+        except OSError as ex:
+            logger.warning(f"Warning: occurred during test suite setup {ex}")
+
+    @staticmethod
+    def process_new_indexable_object(event, logger):
+        process_new_gs_indexable_object(event, logger)
+
+    def setUp(self):
+        self.app = dss.create_app().app.test_client()
+        elasticsearch_delete_index("_all")
+        PostTestHandler.reset()
+
+    def tearDown(self):
+        self.app = None
+        self.storageHelper = None
+
+    def create_sample_bundle_created_event(self, bundle_key: str) -> Dict:
+        with open(os.path.join(os.path.dirname(__file__), "sample_gs_bundle_created_event.json")) as fh:
+            sample_event = json.load(fh)
+        sample_event["bucket"] = self.test_bucket
+        sample_event["name"] = bundle_key
+        return sample_event
+
+
 class BundleBuilder:
     def __init__(self, replica, bundle_id=None, bundle_version=None):
         self.blobstore, _, _ = Config.get_cloud_specific_handles(replica)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -93,6 +93,9 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
         cls.blobstore, _, cls.test_fixture_bucket = Config.get_cloud_specific_handles(cls.replica)
         Config.set_config(DeploymentStage.TEST)
         _, _, cls.test_bucket = Config.get_cloud_specific_handles(cls.replica)
+        cls.dss_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[cls.replica])
+        cls.subscription_index_name = dss.Config.get_es_index_name(dss.ESIndexType.subscriptions,
+                                                                   dss.Replica[cls.replica])
 
     def setUp(self):
         self.app = dss.create_app().app.test_client()
@@ -179,7 +182,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
             self.process_new_indexable_object(sample_event, logger)
         self.assertRegex(log_monitor.output[0],
                          f"WARNING:.*:In bundle .* the file \"{inaccesssible_filename}\" is marked for indexing"
-                         " yet could not be accessed. This file will not be indexed. Exception:")
+                         " yet could not be accessed. This file will not be indexed. Exception: .*, File blob key:")
         search_results = self.get_search_results(smartseq2_paired_ends_query, 1)
         self.assertEqual(1, len(search_results))
         files = list(smartseq2_paried_ends_indexed_file_list)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,6 +13,7 @@ import uuid
 import requests
 
 from dss import ESDocType
+from dss.util import UrlBuilder
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -31,9 +32,11 @@ logger.setLevel(logging.INFO)
 
 start_verbose_logging()
 
+
 class TestSearch(unittest.TestCase, DSSAsserts):
     @classmethod
     def setUpClass(cls):
+        cls.replica = dss.Replica.aws.name
         cls.es_server = ElasticsearchServer()
         os.environ['DSS_ES_PORT'] = str(cls.es_server.port)
         cls.dss_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica.aws)
@@ -167,8 +170,11 @@ class TestSearch(unittest.TestCase, DSSAsserts):
         return bundles
 
     def post_search(self, query: dict, status_code: int):
+        url = str(UrlBuilder()
+                  .set(path="/v1/search")
+                  .add_query("replica", self.replica))
         return self.assertPostResponse(
-            "/v1/search",
+            path=url,
             json_request_body=dict(es_query=query),
             expected_code=status_code)
 
@@ -185,7 +191,6 @@ class TestSearch(unittest.TestCase, DSSAsserts):
                 time.sleep(0.5)
         else:
             self.fail("elasticsearch failed to return all results.")
-
         self.assertDictEqual(search_response['es_query'], query)
         self.assertEqual(len(search_response['results']), expected_result_length)
         result_bundles = [(hit['bundle_id'], hit['bundle_url'])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -12,6 +12,8 @@ import uuid
 
 import requests
 
+from dss import ESDocType
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -47,7 +49,7 @@ class TestSearch(unittest.TestCase, DSSAsserts):
     def setUp(self):
         dss.Config.set_config(dss.DeploymentStage.TEST)
         self.app = dss.create_app().app.test_client()
-        create_elasticsearch_index(self.dss_index_name)
+        elasticsearch_delete_index(self.dss_index_name)
         create_elasticsearch_index(self.dss_index_name, logger)
 
     def test_search_post(self):
@@ -58,8 +60,8 @@ class TestSearch(unittest.TestCase, DSSAsserts):
         bundle_url = f"http://localhost/v1/bundles/{bundle_uuid}?version={version}"
 
         es_client = ElasticsearchClient.get(logger)
-        es_client.index(index=DSS_ELASTICSEARCH_INDEX_NAME,
-                        doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
+        es_client.index(index=self.dss_index_name,
+                        doc_type=ESDocType.doc.name,
                         id=bundle_id,
                         body=self.index_document,
                         refresh=True)
@@ -157,8 +159,8 @@ class TestSearch(unittest.TestCase, DSSAsserts):
             bundle_id = f"{bundle_uuid}.{version}"
             bundle_url = f"http://localhost/v1/bundles/{bundle_uuid}?version={version}"
 
-            es_client.index(index=DSS_ELASTICSEARCH_INDEX_NAME,
-                            doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
+            es_client.index(index=self.dss_index_name,
+                            doc_type=ESDocType.doc.name,
                             id=bundle_id,
                             body=index_document)
             bundles.append((bundle_id, bundle_url))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -18,7 +18,7 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE
 from dss.events.handlers.index import create_elasticsearch_index
-from dss.util.es import ElasticsearchServer, ElasticsearchClient
+from dss.util.es import ElasticsearchServer, ElasticsearchClient, get_elasticsearch_index_name
 from tests.infra import DSSAsserts, start_verbose_logging
 from tests.es import elasticsearch_delete_index
 from tests import get_version
@@ -36,6 +36,7 @@ class TestSearch(unittest.TestCase, DSSAsserts):
     def setUpClass(cls):
         cls.es_server = ElasticsearchServer()
         os.environ['DSS_ES_PORT'] = str(cls.es_server.port)
+        cls.dss_index_name = get_elasticsearch_index_name(dss.DSS_ELASTICSEARCH_INDEX_NAME, "aws")
         dss.Config.set_config(dss.DeploymentStage.TEST)
         cls.app = dss.create_app().app.test_client()
         with open(os.path.join(os.path.dirname(__file__), "sample_index_doc.json"), "r") as fh:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -16,9 +16,8 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE
 from dss.events.handlers.index import create_elasticsearch_index
-from dss.util.es import ElasticsearchServer, ElasticsearchClient, get_elasticsearch_index_name
+from dss.util.es import ElasticsearchServer, ElasticsearchClient
 from tests.infra import DSSAsserts, start_verbose_logging
 from tests.es import elasticsearch_delete_index
 from tests import get_version
@@ -30,13 +29,12 @@ logger.setLevel(logging.INFO)
 
 start_verbose_logging()
 
-
 class TestSearch(unittest.TestCase, DSSAsserts):
     @classmethod
     def setUpClass(cls):
         cls.es_server = ElasticsearchServer()
         os.environ['DSS_ES_PORT'] = str(cls.es_server.port)
-        cls.dss_index_name = get_elasticsearch_index_name(dss.DSS_ELASTICSEARCH_INDEX_NAME, "aws")
+        cls.dss_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica.aws)
         dss.Config.set_config(dss.DeploymentStage.TEST)
         cls.app = dss.create_app().app.test_client()
         with open(os.path.join(os.path.dirname(__file__), "sample_index_doc.json"), "r") as fh:
@@ -47,8 +45,10 @@ class TestSearch(unittest.TestCase, DSSAsserts):
         cls.es_server.shutdown()
 
     def setUp(self):
-        elasticsearch_delete_index(DSS_ELASTICSEARCH_INDEX_NAME)
-        create_elasticsearch_index(logger)
+        dss.Config.set_config(dss.DeploymentStage.TEST)
+        self.app = dss.create_app().app.test_client()
+        create_elasticsearch_index(self.dss_index_name)
+        create_elasticsearch_index(self.dss_index_name, logger)
 
     def test_search_post(self):
         bundle_uuid = str(uuid.uuid4())
@@ -190,3 +190,6 @@ class TestSearch(unittest.TestCase, DSSAsserts):
                           for hit in search_response['results']]
         for bundle in bundles:
             self.assertIn(bundle, result_bundles)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -21,7 +21,7 @@ sys.path.insert(0, pkg_root) # noqa
 import dss
 from dss import DSS_ELASTICSEARCH_INDEX_NAME, DSS_ELASTICSEARCH_DOC_TYPE, DSS_ELASTICSEARCH_QUERY_TYPE
 from dss.util import UrlBuilder
-from dss.util.es import ElasticsearchClient, ElasticsearchServer, get_elasticsearch_index
+from dss.util.es import ElasticsearchClient, ElasticsearchServer, get_elasticsearch_index_name, get_elasticsearch_index
 from tests.infra import DSSAsserts
 
 logging.basicConfig(level=logging.INFO)
@@ -59,7 +59,8 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
                 }
             }
         }
-        get_elasticsearch_index(es_client, DSS_ELASTICSEARCH_INDEX_NAME, logger, index_mapping)
+        index_name = get_elasticsearch_index_name(DSS_ELASTICSEARCH_INDEX_NAME, "aws")
+        get_elasticsearch_index(es_client, index_name, logger, index_mapping)
 
         with open(os.path.join(os.path.dirname(__file__), "sample_index_doc.json"), "r") as fh:
             index_document = json.load(fh)
@@ -68,7 +69,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
         with open(os.path.join(os.path.dirname(__file__), "sample_query.json"), "r") as fh:
             self.sample_percolate_query = json.load(fh)
 
-        es_client.index(index=DSS_ELASTICSEARCH_INDEX_NAME,
+        es_client.index(index=index_name,
                         doc_type=DSS_ELASTICSEARCH_DOC_TYPE,
                         id=str(uuid.uuid4()),
                         body=index_document,
@@ -95,7 +96,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
         uuid_ = self._put_subscription()
 
         es_client = ElasticsearchClient.get(logger)
-        response = es_client.get(index=DSS_ELASTICSEARCH_INDEX_NAME,
+        response = es_client.get(index=get_elasticsearch_index_name(DSS_ELASTICSEARCH_INDEX_NAME, "aws"),
                                  doc_type=DSS_ELASTICSEARCH_QUERY_TYPE,
                                  id=uuid_)
         registered_query = response['_source']

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -28,15 +28,21 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class TestSubscriptions(unittest.TestCase, DSSAsserts):
-    @classmethod
-    def setUpClass(cls):
-        cls.es_server = ElasticsearchServer()
-        os.environ['DSS_ES_PORT'] = str(cls.es_server.port)
+class ESInfo:
+    server = None
 
+def setUpModule():
+    ESInfo.server = ElasticsearchServer()
+    os.environ['DSS_ES_PORT'] = str(ESInfo.server.port)
+
+def tearDownModule():
+    ESInfo.server.shutdown()
+    os.unsetenv('DSS_ES_PORT')
+
+class TestSubscriptionsBase(DSSAsserts):
     @classmethod
-    def tearDownClass(cls):
-        cls.es_server.shutdown()
+    def subsciption_setup(cls, replica):
+        cls.replica = replica
 
     def setUp(self):
         os.environ['DSS_ES_ENDPOINT'] = os.getenv('DSS_ES_ENDPOINT', "localhost")
@@ -58,7 +64,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
                 }
             }
         }
-        index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica.aws)
+        index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, self.replica)
         get_elasticsearch_index(es_client, index_name, logger, index_mapping)
 
         with open(os.path.join(os.path.dirname(__file__), "sample_index_doc.json"), "r") as fh:
@@ -77,7 +83,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
     def test_auth_errors(self):
         url = str(UrlBuilder()
                   .set(path="/v1/subscriptions/" + str(uuid.uuid4()))
-                  .add_query("replica", "aws"))
+                  .add_query("replica", self.replica.name))
 
         # Unauthorized email
         with self.throw_403():
@@ -95,7 +101,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
         uuid_ = self._put_subscription()
 
         es_client = ElasticsearchClient.get(logger)
-        response = es_client.get(index=dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica.aws),
+        response = es_client.get(index=dss.Config.get_es_index_name(dss.ESIndexType.docs, self.replica),
                                  doc_type=dss.ESDocType.query.name,
                                  id=uuid_)
         registered_query = response['_source']
@@ -107,7 +113,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
         # Normal request
         url = str(UrlBuilder()
                   .set(path="/v1/subscriptions/" + str(find_uuid))
-                  .add_query("replica", "aws"))
+                  .add_query("replica", self.replica.name))
         resp_obj = self.assertGetResponse(
             url,
             requests.codes.okay,
@@ -126,7 +132,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
         # File not found request
         url = str(UrlBuilder()
                   .set(path="/v1/subscriptions/" + str(uuid.uuid4()))
-                  .add_query("replica", "aws"))
+                  .add_query("replica", self.replica.name))
         self.assertGetResponse(
             url,
             requests.codes.not_found,
@@ -138,7 +144,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
             self._put_subscription()
         url = str(UrlBuilder()
                   .set(path="/v1/subscriptions")
-                  .add_query("replica", "aws"))
+                  .add_query("replica", self.replica.name))
         resp_obj = self.assertGetResponse(
             url,
             requests.codes.okay,
@@ -152,7 +158,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
         find_uuid = self._put_subscription()
         url = str(UrlBuilder()
                   .set(path="/v1/subscriptions/" + find_uuid)
-                  .add_query("replica", "aws"))
+                  .add_query("replica", self.replica.name))
 
         # Forbidden delete request
         with self.throw_403():
@@ -168,7 +174,7 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
     def _put_subscription(self):
         url = str(UrlBuilder()
                   .set(path="/v1/subscriptions")
-                  .add_query("replica", "aws"))
+                  .add_query("replica", self.replica.name))
         resp_obj = self.assertPutResponse(
             url,
             requests.codes.created,
@@ -199,6 +205,18 @@ class TestSubscriptions(unittest.TestCase, DSSAsserts):
             yield
         finally:
             connexion.apis.abstract.Operation.testing_403 = orig_testing_403
+
+
+class TestGCPSubscription(TestSubscriptionsBase, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().subsciption_setup(dss.Replica.gcp)
+
+
+class TestAWSSubscription(TestSubscriptionsBase, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().subsciption_setup(dss.Replica.aws)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Change Elasticsearch index names to be replica specific to enable replica
independent indexing, search, subscription/notification.
This commit is focused on replica specific indexing, with changes
to search and subscription for all tests to pass with replica specific indexes.
Additional changes are required to make the search route replica aware,
and additional GCP-specific testing is required for subscriptions,
which will be done as additional PRs.