### PR TITLE
generalize work scheduling

### DIFF
--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -192,7 +192,7 @@ def put(uuid: str, json_request_body: dict, version: str=None):
         state[s3copyclient.S3CopyWriteBundleTaskKeys.METADATA] = document
 
         # start a lambda to do the copy.
-        task_id = aws.schedule_task(s3copyclient.AWS_S3_COPY_AND_WRITE_METADATA_CLIENT_NAME, state)
+        task_id = aws.schedule_task(s3copyclient.S3CopyWriteBundleTask, state)
 
         return jsonify(dict(task_id=task_id, version=version)), requests.codes.accepted
     elif copy_mode == CopyMode.COPY_INLINE:

--- a/dss/events/chunkedtask/base.py
+++ b/dss/events/chunkedtask/base.py
@@ -39,9 +39,13 @@ class Runtime(typing.Generic[RuntimeStateType, RuntimeResultType]):
         """
         raise NotImplementedError()
 
-    def reschedule_work(self, state: RuntimeStateType):
+    def schedule_work(
+            self,
+            task_class: typing.Type[Task[typing.Any, typing.Any]],
+            state: typing.Any,
+            new_task: bool) -> str:
         """
-        In implementations of `Runtime` should, this should reschedule a task given its serialized state.
+        In implementations of `Runtime`, this should schedule a new task with a given serialized state.
         """
         raise NotImplementedError()
 

--- a/dss/events/chunkedtask/runner.py
+++ b/dss/events/chunkedtask/runner.py
@@ -45,4 +45,4 @@ class Runner(typing.Generic[RunnerStateType, RunnerResultType]):
 
         # schedule the next chunk of work.
         state = self.chunkedtask.get_state()
-        self.runtime.reschedule_work(state)
+        self.runtime.schedule_work(self.chunkedtask.__class__, state, False)

--- a/tests/chunked_worker.py
+++ b/tests/chunked_worker.py
@@ -17,14 +17,24 @@ class TestStingyRuntime(Runtime[dict, typing.Any]):
         if seq is None:
             seq = list()
         self.seq = itertools.chain(seq, itertools.repeat(0))
+        self.scheduled_work = list()  \
+            # type: typing.List[typing.Tuple[typing.Type[Task], dict, typing.Optional[str]]]
 
     def get_remaining_time_in_millis(self) -> int:
         return self.seq.__next__()
 
-    def reschedule_work(self, state: dict):
+    def schedule_work(
+            self,
+            task_class: typing.Type[Task[typing.Any, typing.Any]],
+            state: typing.Any,
+            new_task: bool,
+    ) -> str:
         # it's illegal for there to be no state.
         assert state is not None
-        self.rescheduled_state = state
+
+        task_id = str(uuid.uuid4()) if new_task else None
+        self.scheduled_work.append((task_class, state, task_id))
+        return task_id
 
     def work_complete_callback(self, result: typing.Any):
         self.result = result

--- a/tests/test_chunkedtask.py
+++ b/tests/test_chunkedtask.py
@@ -18,7 +18,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from dss.events import chunkedtask
 from dss.events.chunkedtask import aws, awsconstants
-from dss.events.chunkedtask._awstest import AWS_FAST_TEST_CLIENT_NAME
+from dss.events.chunkedtask._awstest import AWS_FAST_TEST_CLIENT_NAME, AWSFastTestTask
 from tests.chunked_worker import TestStingyRuntime, run_task_to_completion
 
 
@@ -60,7 +60,7 @@ class TestChunkedTaskRunner(unittest.TestCase):
             lambda results: TestStingyRuntime(results, itertools.repeat(sys.maxsize, 19)),
             lambda task_class, task_state, runtime: task_class(task_state, expected_max_one_unit_runtime_millis),
             lambda runtime: runtime.result,
-            lambda runtime: [(TestChunkedTask, runtime.rescheduled_state, None)],
+            lambda runtime: runtime.scheduled_work,
         )
 
         self.assertEqual(result, (196418, 121393))
@@ -69,10 +69,7 @@ class TestChunkedTaskRunner(unittest.TestCase):
 
 class TestAWSChunkedTask(unittest.TestCase):
     def test_fast(self):
-        task_id = aws.schedule_task(
-            AWS_FAST_TEST_CLIENT_NAME,
-            [0, 5],
-        )
+        task_id = aws.schedule_task(AWSFastTestTask, [0, 5])
 
         logs_client = boto3.client('logs')
         starttime = time.time()

--- a/tests/test_s3copyclient.py
+++ b/tests/test_s3copyclient.py
@@ -55,7 +55,7 @@ class TestAWSCopy(unittest.TestCase):
             lambda results: TestStingyRuntime(results),
             lambda task_class, task_state, runtime: task_class(task_state),
             lambda runtime: runtime.result,
-            lambda runtime: [(S3CopyTask, runtime.rescheduled_state, None)],
+            lambda runtime: runtime.scheduled_work,
         )
 
         self.assertGreater(freezes, 0)
@@ -76,7 +76,7 @@ class TestAWSCopy(unittest.TestCase):
             lambda results: TestStingyRuntime(results, seq=itertools.repeat(sys.maxsize, 7)),
             lambda task_class, task_state, runtime: task_class(task_state, fetch_size=4),
             lambda runtime: runtime.result,
-            lambda runtime: [(S3CopyTask, runtime.rescheduled_state, None)],
+            lambda runtime: runtime.scheduled_work,
         )
 
         self.assertGreater(freezes, 0)
@@ -110,7 +110,7 @@ class TestAWSCopyNonMultipart(unittest.TestCase):
             lambda results: TestStingyRuntime(results),
             lambda task_class, task_state, runtime: task_class(task_state),
             lambda runtime: runtime.result,
-            lambda runtime: [(S3CopyTask, runtime.rescheduled_state, None)],
+            lambda runtime: runtime.scheduled_work,
         )
 
         # verify that the destination has the same checksum.


### PR DESCRIPTION
1. Make it possible to schedule new tasks (as opposed to rescheduling the current tasks for resumption).
2. Manage all of work scheduling in `aws.py`:`schedule_task`

Connects to #393