### PR TITLE
[easy] Pass in the runtime into the task constructor.

### DIFF
--- a/dss/events/chunkedtask/_awstest.py
+++ b/dss/events/chunkedtask/_awstest.py
@@ -67,7 +67,7 @@ class AWSFastTestTask(Task[typing.MutableSequence, bool]):
     This is a chunked task that counts from a number to another.  Once the counting is complete, it prints something to
     console, which is detected by the unit test.
     """
-    def __init__(self, state: typing.MutableSequence) -> None:
+    def __init__(self, state: typing.MutableSequence, *args, **kwargs) -> None:
         self.state = state
 
     def get_state(self) -> typing.MutableSequence:

--- a/dss/events/chunkedtask/aws.py
+++ b/dss/events/chunkedtask/aws.py
@@ -171,7 +171,7 @@ def dispatch(context, payload, expected_client_name):
         else:
             runtime = AWSRuntime(context, client_name, task_id)
 
-        task = client_class(state)
+        task = client_class(state, runtime=runtime)
 
         runner = Runner(task, runtime)
         runner.run()

--- a/dss/events/chunkedtask/s3copyclient.py
+++ b/dss/events/chunkedtask/s3copyclient.py
@@ -32,7 +32,7 @@ class S3CopyTask(Task[dict, typing.Any]):
     """
     This is a chunked task that does a multipart copy from one blob to another.
     """
-    def __init__(self, state: dict, fetch_size: int=100) -> None:
+    def __init__(self, state: dict, fetch_size: int=100, *args, **kwargs) -> None:
         self.source_bucket = state[S3CopyTaskKeys.SOURCE_BUCKET]
         self.source_key = state[S3CopyTaskKeys.SOURCE_KEY]
         self.source_etag = state[S3CopyTaskKeys.SOURCE_ETAG]
@@ -192,7 +192,7 @@ class S3CopyWriteBundleTask(S3CopyTask):
     """
     This is a chunked task that does a multipart copy from one blob to another and writes a bundle manifest.
     """
-    def __init__(self, state: dict) -> None:
+    def __init__(self, state: dict, *args, **kwargs) -> None:
         super().__init__(state)
         self.metadata = state[S3CopyWriteBundleTaskKeys.METADATA]
         self.file_uuid = state[S3CopyWriteBundleTaskKeys.FILE_UUID]


### PR DESCRIPTION
This allows tasks to invoke things like task creation that's only available in the `Runtime` object.

Connects to #393