### PR TITLE
Adds an AWS-based test in which a task forks other tasks and waits for their completion.

### DIFF
--- a/dss/events/chunkedtask/_awstest.py
+++ b/dss/events/chunkedtask/_awstest.py
@@ -122,3 +122,23 @@ class SupervisorTask(Task[dict, bool]):
 
     def check_success_marker(self):
         raise NotImplementedError()
+
+
+AWS_SUPERVISOR_TEST_CLIENT_NAME = "supervisortest"
+
+
+class AWSSupervisorTask(SupervisorTask):
+    def __init__(self, state: dict, runtime: AWSRuntime) -> None:
+        super().__init__(state, runtime)
+
+    def check_success_marker(self):
+        # don't pound the filter logs API to a pulp.
+        if (self.last_checked is not None and
+                time.time() < self.last_checked + 1):
+            time.sleep(1)
+
+        if is_task_complete(AWS_FAST_TEST_CLIENT_NAME, self.state[SupervisorTask.SPAWNED_TASK_KEY]):
+            return True
+
+        self.last_checked = time.time()
+        return None

--- a/dss/events/chunkedtask/aws.py
+++ b/dss/events/chunkedtask/aws.py
@@ -16,6 +16,7 @@ from .runner import Runner
 def get_clients():
     return {
         _awstest.AWS_FAST_TEST_CLIENT_NAME: _awstest.AWSFastTestTask,
+        _awstest.AWS_SUPERVISOR_TEST_CLIENT_NAME: _awstest.AWSSupervisorTask,
         s3copyclient.AWS_S3_COPY_CLIENT_NAME: s3copyclient.S3CopyTask,
         s3copyclient.AWS_S3_COPY_AND_WRITE_METADATA_CLIENT_NAME: s3copyclient.S3CopyWriteBundleTask,
     }

--- a/tests/test_chunkedtask.py
+++ b/tests/test_chunkedtask.py
@@ -104,6 +104,25 @@ class TestForkedTask(unittest.TestCase):
         self.assertGreater(freeze_count, 0)
         self.assertTrue(result is True)
 
+    def test_forked_task_AWS(self, timeout_seconds: int=90):
+        """
+        This is an elaborate test that involves an initial task that spawns another task to complete some work.  Once
+        that work is complete, the initial task will complete.
+
+        In this case, the initial task spawns second task that counts from 0 to a number on AWS.  The initial task then
+        spins until it sees the completion marker written in AWS Cloudwatch by the spawned task.
+        """
+        task_id = aws.schedule_task(_awstest.AWSSupervisorTask, dict())
+
+        starttime = time.time()
+        while time.time() < starttime + timeout_seconds:
+            if _awstest.is_task_complete(_awstest.AWS_SUPERVISOR_TEST_CLIENT_NAME, task_id):
+                return
+
+            time.sleep(1)
+
+        self.fail("Did not find success marker in logs")
+
 
 class TestAWSChunkedTask(unittest.TestCase):
     def test_fast(self):


### PR DESCRIPTION
This is like #417 except it's on the AWS Runtime.

Connects to #393