### PR TITLE
Connect GCP events to indexer

### DIFF
--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -8,7 +9,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss.events.handlers.index import process_new_s3_indexable_object
+from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object
 
 app = domovoi.Domovoi()
 
@@ -29,4 +30,5 @@ def dispatch_gs_indexer_event(event, context):
     """
     This handler receives GS events via the Google Cloud Function deployed from daemons/dss-gs-event-relay.
     """
-    context.log(f"dss-index daemon got a GS event: {event}")
+    gs_event = json.loads(event['Records'][0]['Sns']['Message'])
+    process_new_gs_indexable_object(gs_event['data'], app.log)

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -78,7 +78,7 @@ def create_index_data(handle: BlobStore, bucket_name: str, bundle_id: str, manif
     files_info = manifest[BundleMetadata.FILES]
     index_files = {}
     for file_info in files_info:
-        if file_info[BundleFileMetadata.INDEXED]:
+        if file_info[BundleFileMetadata.INDEXED] is True:
             if file_info[BundleFileMetadata.CONTENT_TYPE] != 'application/json':
                 logger.warning(f"In bundle {bundle_id} the file \"{file_info[BundleFileMetadata.NAME]}\""
                                " is marked for indexing yet has content type"

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -13,7 +13,7 @@ from dss import Config, ESIndexType, ESDocType, Replica
 from ...util import create_blob_key
 from ...hcablobstore import BundleMetadata, BundleFileMetadata
 from ...util.es import ElasticsearchClient, get_elasticsearch_index
-from ...blobstore import BlobStore, BlobNotFoundError
+from ...blobstore import BlobStore, BlobStoreError
 
 DSS_BUNDLE_KEY_REGEX = r"^bundles/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\..+$"
 
@@ -78,7 +78,7 @@ def create_index_data(handle: BlobStore, bucket_name: str, bundle_id: str, manif
     files_info = manifest[BundleMetadata.FILES]
     index_files = {}
     for file_info in files_info:
-        if file_info[BundleFileMetadata.INDEXED] is True:
+        if file_info[BundleFileMetadata.INDEXED]:
             if file_info[BundleFileMetadata.CONTENT_TYPE] != 'application/json':
                 logger.warning(f"In bundle {bundle_id} the file \"{file_info[BundleFileMetadata.NAME]}\""
                                " is marked for indexing yet has content type"
@@ -87,8 +87,8 @@ def create_index_data(handle: BlobStore, bucket_name: str, bundle_id: str, manif
                                " This file will not be indexed.")
                 continue
             try:
-                file_key = create_blob_key(file_info)
-                file_string = handle.get(bucket_name, file_key).decode("utf-8")
+                file_blob_key = create_blob_key(file_info)
+                file_string = handle.get(bucket_name, file_blob_key).decode("utf-8")
                 file_json = json.loads(file_string)
             # TODO (mbaumann) Are there other JSON-related exceptions that should be checked below?
             except json.decoder.JSONDecodeError as ex:
@@ -96,10 +96,11 @@ def create_index_data(handle: BlobStore, bucket_name: str, bundle_id: str, manif
                                " is marked for indexing yet could not be parsed."
                                " This file will not be indexed. Exception: %s", ex)
                 continue
-            except BlobNotFoundError as ex:
+            except BlobStoreError as ex:
                 logger.warning(f"In bundle {bundle_id} the file \"{file_info[BundleFileMetadata.NAME]}\""
                                " is marked for indexing yet could not be accessed."
-                               " This file will not be indexed. Exception: %s", ex)
+                               " This file will not be indexed. Exception: %s, File blob key: %s",
+                               type(ex).__name__, file_blob_key)
                 continue
             logger.debug(f"Indexing file: {file_info[BundleFileMetadata.NAME]}")
             # There are two reasons in favor of not using dot in the name of the individual

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -182,7 +182,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
             self.process_new_indexable_object(sample_event, logger)
         self.assertRegex(log_monitor.output[0],
                          f"WARNING:.*:In bundle .* the file \"{inaccesssible_filename}\" is marked for indexing"
-                         " yet could not be accessed. This file will not be indexed. Exception: .* File blob key:")
+                         " yet could not be accessed. This file will not be indexed. Exception: .*, File blob key:")
         search_results = self.get_search_results(smartseq2_paired_ends_query, 1)
         self.assertEqual(1, len(search_results))
         files = list(smartseq2_paried_ends_indexed_file_list)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -182,7 +182,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
             self.process_new_indexable_object(sample_event, logger)
         self.assertRegex(log_monitor.output[0],
                          f"WARNING:.*:In bundle .* the file \"{inaccesssible_filename}\" is marked for indexing"
-                         " yet could not be accessed. This file will not be indexed. Exception:")
+                         " yet could not be accessed. This file will not be indexed. Exception: .* File blob key:")
         search_results = self.get_search_results(smartseq2_paired_ends_query, 1)
         self.assertEqual(1, len(search_results))
         files = list(smartseq2_paried_ends_indexed_file_list)


### PR DESCRIPTION
Pass GCP events received via GCF/SNS to the indexer.
Log additional details in the case of a file access error during indexing.

smoketest.py output of test deployment:

```
$ scripts/smoketest.py 2>&1 | tee smoketest0.0.txt
'import warnings' failed; traceback:
Traceback (most recent call last):
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 505, in <module>
    _processoptions(sys.warnoptions)
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 186, in _processoptions
    _setoption(arg)
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 192, in _setoption
    import re
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/re.py", line 122, in <module>
    import enum
ModuleNotFoundError: No module named 'enum'
Requirement already satisfied: boto3==1.4.4 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 1))
Requirement already satisfied: crcmod==1.7 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 2))
Requirement already satisfied: google-auth>=1.0.2 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 3))
Requirement already satisfied: google-auth-oauthlib>=0.1.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 4))
Requirement already satisfied: Jinja2==2.9.6 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 5))
Requirement already satisfied: jsonpointer==1.10 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 6))
Requirement already satisfied: jsonschema==2.6.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 7))
Requirement already satisfied: requests==2.17.3 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 8))
Requirement already satisfied: six==1.10.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 9))
Requirement already satisfied: tweak==0.5.1 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from -r data-store-cli/requirements.txt (line 10))
Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from boto3==1.4.4->-r data-store-cli/requirements.txt (line 1))
Requirement already satisfied: s3transfer<0.2.0,>=0.1.10 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from boto3==1.4.4->-r data-store-cli/requirements.txt (line 1))
Requirement already satisfied: botocore<1.6.0,>=1.5.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from boto3==1.4.4->-r data-store-cli/requirements.txt (line 1))
Requirement already satisfied: pyasn1-modules>=0.0.5 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth>=1.0.2->-r data-store-cli/requirements.txt (line 3))
Requirement already satisfied: rsa>=3.1.4 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth>=1.0.2->-r data-store-cli/requirements.txt (line 3))
Requirement already satisfied: cachetools>=2.0.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth>=1.0.2->-r data-store-cli/requirements.txt (line 3))
Requirement already satisfied: pyasn1>=0.1.7 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth>=1.0.2->-r data-store-cli/requirements.txt (line 3))
Requirement already satisfied: requests-oauthlib>=0.7.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth-oauthlib>=0.1.0->-r data-store-cli/requirements.txt (line 4))
Requirement already satisfied: MarkupSafe>=0.23 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from Jinja2==2.9.6->-r data-store-cli/requirements.txt (line 5))
Requirement already satisfied: certifi>=2017.4.17 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests==2.17.3->-r data-store-cli/requirements.txt (line 8))
Requirement already satisfied: idna<2.6,>=2.5 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests==2.17.3->-r data-store-cli/requirements.txt (line 8))
Requirement already satisfied: urllib3<1.22,>=1.21.1 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests==2.17.3->-r data-store-cli/requirements.txt (line 8))
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests==2.17.3->-r data-store-cli/requirements.txt (line 8))
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from botocore<1.6.0,>=1.5.0->boto3==1.4.4->-r data-store-cli/requirements.txt (line 1))
Requirement already satisfied: docutils>=0.10 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from botocore<1.6.0,>=1.5.0->boto3==1.4.4->-r data-store-cli/requirements.txt (line 1))
Requirement already satisfied: oauthlib>=0.6.2 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib>=0.1.0->-r data-store-cli/requirements.txt (line 4))
Processing /Users/mbaumann/Projects/HCA/data-store-smoketest/data-store-cli
Requirement already up-to-date: boto3==1.4.4 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: crcmod==1.7 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: google-auth>=1.0.2 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: google-auth-oauthlib>=0.1.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: Jinja2==2.9.6 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: jsonpointer==1.10 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: jsonschema==2.6.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: requests==2.17.3 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: six==1.10.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: tweak==0.5.1 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from hca==0.10.0)
Requirement already up-to-date: botocore<1.6.0,>=1.5.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from boto3==1.4.4->hca==0.10.0)
Requirement already up-to-date: s3transfer<0.2.0,>=0.1.10 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from boto3==1.4.4->hca==0.10.0)
Requirement already up-to-date: jmespath<1.0.0,>=0.7.1 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from boto3==1.4.4->hca==0.10.0)
Requirement already up-to-date: pyasn1>=0.1.7 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth>=1.0.2->hca==0.10.0)
Requirement already up-to-date: rsa>=3.1.4 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth>=1.0.2->hca==0.10.0)
Requirement already up-to-date: pyasn1-modules>=0.0.5 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth>=1.0.2->hca==0.10.0)
Requirement already up-to-date: cachetools>=2.0.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth>=1.0.2->hca==0.10.0)
Requirement already up-to-date: requests-oauthlib>=0.7.0 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from google-auth-oauthlib>=0.1.0->hca==0.10.0)
Requirement already up-to-date: MarkupSafe>=0.23 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from Jinja2==2.9.6->hca==0.10.0)
Requirement already up-to-date: certifi>=2017.4.17 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests==2.17.3->hca==0.10.0)
Requirement already up-to-date: idna<2.6,>=2.5 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests==2.17.3->hca==0.10.0)
Requirement already up-to-date: chardet<3.1.0,>=3.0.2 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests==2.17.3->hca==0.10.0)
Requirement already up-to-date: urllib3<1.22,>=1.21.1 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests==2.17.3->hca==0.10.0)
Requirement already up-to-date: python-dateutil<3.0.0,>=2.1 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from botocore<1.6.0,>=1.5.0->boto3==1.4.4->hca==0.10.0)
Requirement already up-to-date: docutils>=0.10 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from botocore<1.6.0,>=1.5.0->boto3==1.4.4->hca==0.10.0)
Requirement already up-to-date: oauthlib>=0.6.2 in /Users/mbaumann/.virtualenvs/data-store-smoketest/lib/python3.6/site-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib>=0.1.0->hca==0.10.0)
Building wheels for collected packages: hca
  Running setup.py bdist_wheel for hca: started
  Running setup.py bdist_wheel for hca: finished with status 'done'
  Stored in directory: /Users/mbaumann/Library/Caches/pip/wheels/a2/d5/25/799862250888de3bea3027e87978fae0813f7afbfd3b9f2d76
Successfully built hca
Installing collected packages: hca
  Found existing installation: hca 0.10.0
    Uninstalling hca-0.10.0:
      Successfully uninstalled hca-0.10.0
Successfully installed hca-0.10.0

Uploading the following keys to aws:
assay.json
manifest.json
project.json
sample.json
The following keys were uploaded successfully:
assay.json    c2e6dece-8184-4cf9-b161-868d65c307ce/assay.json
manifest.json  f9edb3c7-46d7-4cfd-92b4-49b5d1f856b1/manifest.json
project.json  8ad5ed2b-4efd-40ff-a5bf-b8aad4933015/project.json
sample.json   40f9c60d-12e1-43f1-95c8-33a55595a752/sample.json
File assay.json: registering...
s3://mbaumann-dss-test/c2e6dece-8184-4cf9-b161-868d65c307ce/assay.json
File assay.json: assigned uuid c2e6dece-8184-4cf9-b161-868d65c307ce
File assay.json: registered with uuid c2e6dece-8184-4cf9-b161-868d65c307ce
Request response
{
  "version": "2017-09-11T191528.511553Z"
}

File manifest.json: registering...
s3://mbaumann-dss-test/f9edb3c7-46d7-4cfd-92b4-49b5d1f856b1/manifest.json
File manifest.json: assigned uuid f9edb3c7-46d7-4cfd-92b4-49b5d1f856b1
File manifest.json: registered with uuid f9edb3c7-46d7-4cfd-92b4-49b5d1f856b1
Request response
{
  "version": "2017-09-11T191530.042413Z"
}

File project.json: registering...
s3://mbaumann-dss-test/8ad5ed2b-4efd-40ff-a5bf-b8aad4933015/project.json
File project.json: assigned uuid 8ad5ed2b-4efd-40ff-a5bf-b8aad4933015
File project.json: registered with uuid 8ad5ed2b-4efd-40ff-a5bf-b8aad4933015
Request response
{
  "version": "2017-09-11T191531.091550Z"
}

File sample.json: registering...
s3://mbaumann-dss-test/40f9c60d-12e1-43f1-95c8-33a55595a752/sample.json
File sample.json: assigned uuid 40f9c60d-12e1-43f1-95c8-33a55595a752
File sample.json: registered with uuid 40f9c60d-12e1-43f1-95c8-33a55595a752
Request response
{
  "version": "2017-09-11T191532.120235Z"
}

Bundle dcdb261e-c138-47d4-825d-6cc53771e2f9: registering...
Bundle dcdb261e-c138-47d4-825d-6cc53771e2f9: registered successfully
Request response:
{
  "version": "2017-09-11T191533.379304Z"
}

Bundle dcdb261e-c138-47d4-825d-6cc53771e2f9: Retrieving...
Bundle dcdb261e-c138-47d4-825d-6cc53771e2f9: GET SUCCEEDED. 4 files to download
Request response:
{
  "bundle": {
    "creator_uid": 1,
    "files": [
      {
        "content-type": "application/json",
        "crc32c": "0abce81f",
        "name": "assay.json",
        "s3_etag": "8e2d7cef63b26942a07da3832476bf40",
        "sha1": "03822b7d0f13e5975870454dfe6cd7eec5220ee7",
        "sha256": "1d032f0bd8aa56ba6b7f13e89b6dd93dfce6d47a6784ce6caed3983016a4173e",
        "uuid": "c2e6dece-8184-4cf9-b161-868d65c307ce",
        "version": "2017-09-11T191528.511553Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "9021d883",
        "name": "manifest.json",
        "s3_etag": "17d8580e24cbbafe062663469536b123",
        "sha1": "4a85da1d17658bf58577dd6102d06d182f5c2ccf",
        "sha256": "c5e4ed8cca8214a0149522efeda5fae6f54daf76f4fd4bf6fbafcb2d734bf1c0",
        "uuid": "f9edb3c7-46d7-4cfd-92b4-49b5d1f856b1",
        "version": "2017-09-11T191530.042413Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "a9c218ca",
        "name": "project.json",
        "s3_etag": "26d1c9dc989b812813503d038dc4b9d1",
        "sha1": "f79723cf2e7473dfb7dc17d8943f9408e5512098",
        "sha256": "dcafb87b68f851d9c7d34f66421ab9b97e3e7348f11abf04ab4f09653787414d",
        "uuid": "8ad5ed2b-4efd-40ff-a5bf-b8aad4933015",
        "version": "2017-09-11T191531.091550Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "320b052a",
        "name": "sample.json",
        "s3_etag": "521979228ab0ee4ee11f74e0cf904480",
        "sha1": "400492922724bf98b5612d803aa04c501a570aa2",
        "sha256": "8baff9e5ff8b2182d1fd2212f78e25dfd9f25c4bf0984f28701b04882b9c35b5",
        "uuid": "40f9c60d-12e1-43f1-95c8-33a55595a752",
        "version": "2017-09-11T191532.120235Z"
      }
    ],
    "uuid": "dcdb261e-c138-47d4-825d-6cc53771e2f9",
    "version": "2017-09-11T191533.379304Z"
  }
}


File assay.json: Retrieving...
File assay.json: GET SUCCEEDED. Writing to disk.
File assay.json: GET SUCCEEDED. Stored at dcdb261e-c138-47d4-825d-6cc53771e2f9/assay.json.
File manifest.json: Retrieving...
File manifest.json: GET SUCCEEDED. Writing to disk.
File manifest.json: GET SUCCEEDED. Stored at dcdb261e-c138-47d4-825d-6cc53771e2f9/manifest.json.
File project.json: Retrieving...
File project.json: GET SUCCEEDED. Writing to disk.
File project.json: GET SUCCEEDED. Stored at dcdb261e-c138-47d4-825d-6cc53771e2f9/project.json.
File sample.json: Retrieving...
File sample.json: GET SUCCEEDED. Writing to disk.
File sample.json: GET SUCCEEDED. Stored at dcdb261e-c138-47d4-825d-6cc53771e2f9/sample.json.{"completed": true}
'import warnings' failed; traceback:
Traceback (most recent call last):
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 505, in <module>
    _processoptions(sys.warnoptions)
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 186, in _processoptions
    _setoption(arg)
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 192, in _setoption
    import re
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/re.py", line 122, in <module>
    import enum
ModuleNotFoundError: No module named 'enum'
GET /v1/bundles/dcdb261e-c138-47d4-825d-6cc53771e2f9?replica=gcp HTTP/1.1
User-Agent: HTTPie/0.9.9
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
Host: hca-dss-4.ucsc-cgp-dev.org



HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 1866
Connection: keep-alive
Date: Mon, 11 Sep 2017 19:15:45 GMT
x-amzn-RequestId: 9b9de66f-9725-11e7-83b0-eb220d01df4b
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Authorization,Content-Type,X-Amz-Date,X-Amz-Security-Token,X-Api-Key
X-Amzn-Trace-Id: sampled=0;root=1-59b6e0df-b3a353c36a8daed4aa99ab94
X-Cache: Miss from cloudfront
Via: 1.1 fb9b30d0bac34e91aef1c344524376e1.cloudfront.net (CloudFront)
X-Amz-Cf-Id: MeUXlYYoDz7OyUnLu4S8Fu-xSi3T7LM81j90VFGxIV3VjXoLyVC6CQ==

{
  "bundle": {
    "creator_uid": 1,
    "files": [
      {
        "content-type": "application/json",
        "crc32c": "0abce81f",
        "name": "assay.json",
        "s3_etag": "8e2d7cef63b26942a07da3832476bf40",
        "sha1": "03822b7d0f13e5975870454dfe6cd7eec5220ee7",
        "sha256": "1d032f0bd8aa56ba6b7f13e89b6dd93dfce6d47a6784ce6caed3983016a4173e",
        "uuid": "c2e6dece-8184-4cf9-b161-868d65c307ce",
        "version": "2017-09-11T191528.511553Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "9021d883",
        "name": "manifest.json",
        "s3_etag": "17d8580e24cbbafe062663469536b123",
        "sha1": "4a85da1d17658bf58577dd6102d06d182f5c2ccf",
        "sha256": "c5e4ed8cca8214a0149522efeda5fae6f54daf76f4fd4bf6fbafcb2d734bf1c0",
        "uuid": "f9edb3c7-46d7-4cfd-92b4-49b5d1f856b1",
        "version": "2017-09-11T191530.042413Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "a9c218ca",
        "name": "project.json",
        "s3_etag": "26d1c9dc989b812813503d038dc4b9d1",
        "sha1": "f79723cf2e7473dfb7dc17d8943f9408e5512098",
        "sha256": "dcafb87b68f851d9c7d34f66421ab9b97e3e7348f11abf04ab4f09653787414d",
        "uuid": "8ad5ed2b-4efd-40ff-a5bf-b8aad4933015",
        "version": "2017-09-11T191531.091550Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "320b052a",
        "name": "sample.json",
        "s3_etag": "521979228ab0ee4ee11f74e0cf904480",
        "sha1": "400492922724bf98b5612d803aa04c501a570aa2",
        "sha256": "8baff9e5ff8b2182d1fd2212f78e25dfd9f25c4bf0984f28701b04882b9c35b5",
        "uuid": "40f9c60d-12e1-43f1-95c8-33a55595a752",
        "version": "2017-09-11T191532.120235Z"
      }
    ],
    "uuid": "dcdb261e-c138-47d4-825d-6cc53771e2f9",
    "version": "2017-09-11T191533.379304Z"
  }
}

Bundle dcdb261e-c138-47d4-825d-6cc53771e2f9: Retrieving...
Request response:
{
  "bundle": {
    "creator_uid": 1,
    "files": [
      {
        "content-type": "application/json",
        "crc32c": "0abce81f",
        "name": "assay.json",
        "s3_etag": "8e2d7cef63b26942a07da3832476bf40",
        "sha1": "03822b7d0f13e5975870454dfe6cd7eec5220ee7",
        "sha256": "1d032f0bd8aa56ba6b7f13e89b6dd93dfce6d47a6784ce6caed3983016a4173e",
        "uuid": "c2e6dece-8184-4cf9-b161-868d65c307ce",
        "version": "2017-09-11T191528.511553Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "9021d883",
        "name": "manifest.json",
        "s3_etag": "17d8580e24cbbafe062663469536b123",
        "sha1": "4a85da1d17658bf58577dd6102d06d182f5c2ccf",
        "sha256": "c5e4ed8cca8214a0149522efeda5fae6f54daf76f4fd4bf6fbafcb2d734bf1c0",
        "uuid": "f9edb3c7-46d7-4cfd-92b4-49b5d1f856b1",
        "version": "2017-09-11T191530.042413Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "a9c218ca",
        "name": "project.json",
        "s3_etag": "26d1c9dc989b812813503d038dc4b9d1",
        "sha1": "f79723cf2e7473dfb7dc17d8943f9408e5512098",
        "sha256": "dcafb87b68f851d9c7d34f66421ab9b97e3e7348f11abf04ab4f09653787414d",
        "uuid": "8ad5ed2b-4efd-40ff-a5bf-b8aad4933015",
        "version": "2017-09-11T191531.091550Z"
      },
      {
        "content-type": "application/json",
        "crc32c": "320b052a",
        "name": "sample.json",
        "s3_etag": "521979228ab0ee4ee11f74e0cf904480",
        "sha1": "400492922724bf98b5612d803aa04c501a570aa2",
        "sha256": "8baff9e5ff8b2182d1fd2212f78e25dfd9f25c4bf0984f28701b04882b9c35b5",
        "uuid": "40f9c60d-12e1-43f1-95c8-33a55595a752",
        "version": "2017-09-11T191532.120235Z"
      }
    ],
    "uuid": "dcdb261e-c138-47d4-825d-6cc53771e2f9",
    "version": "2017-09-11T191533.379304Z"
  }
}


File assay.json: Retrieving...
File assay.json: GET SUCCEEDED. Writing to disk.
File assay.json: GET SUCCEEDED. Stored at dcdb261e-c138-47d4-825d-6cc53771e2f9/assay.json.
File manifest.json: Retrieving...
File manifest.json: GET SUCCEEDED. Writing to disk.
File manifest.json: GET SUCCEEDED. Stored at dcdb261e-c138-47d4-825d-6cc53771e2f9/manifest.json.
File project.json: Retrieving...
File project.json: GET SUCCEEDED. Writing to disk.
File project.json: GET SUCCEEDED. Stored at dcdb261e-c138-47d4-825d-6cc53771e2f9/project.json.
File sample.json: Retrieving...
File sample.json: GET SUCCEEDED. Writing to disk.
File sample.json: GET SUCCEEDED. Stored at dcdb261e-c138-47d4-825d-6cc53771e2f9/sample.json.{"completed": true}
usage: hca post-search [-h] --es-query ES_QUERY [--replica REPLICA]

'import warnings' failed; traceback:
Traceback (most recent call last):
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 505, in <module>
    _processoptions(sys.warnoptions)
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 186, in _processoptions
    _setoption(arg)
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/warnings.py", line 192, in _setoption
    import re
  File "/usr/local/Cellar/httpie/0.9.9/libexec/bin/../lib/python3.6/re.py", line 122, in <module>
    import enum
ModuleNotFoundError: No module named 'enum'
http --check-status https://${API_HOST}/v1/swagger.json > data-store-cli/swagger.json
pip install -r data-store-cli/requirements.txt
python -c 'import sys, hca.regenerate_api as r; r.generate_python_bindings(sys.argv[1])' swagger.json
find data-store-cli/hca -name '*.pyc' -delete
pip install --upgrade .
cat data-bundle-examples/10X_v2/pbmc8k/sample.json | jq .uuid=env.sid | sponge data-bundle-examples/10X_v2/pbmc8k/sample.json
hca upload --replica aws --staging-bucket $DSS_S3_BUCKET_TEST --file-or-dir data-bundle-examples/10X_v2/pbmc8k > upload.json
hca download --replica aws $(jq -r .bundle_uuid upload.json)
http -v --check-status https://${API_HOST}/v1/bundles/$(jq -r .bundle_uuid upload.json)?replica=gcp
hca download --replica gcp $(jq -r .bundle_uuid upload.json)
hca post-search
jq -n '.es_query.query.match[env.k]=env.v' | http --check-status https://${API_HOST}/v1/search > res.json
{
    "es_query": {
        "query": {
            "match": {
                "files.sample_json.uuid": "057ebdfd-0ae5-4c79-8b6b-c0956be2de80"
            }
        }
    },
    "results": [
        {
            "bundle_id": "dcdb261e-c138-47d4-825d-6cc53771e2f9.2017-09-11T191533.379304Z",
            "bundle_url": "https://hca-dss-4.ucsc-cgp-dev.org/v1/bundles/dcdb261e-c138-47d4-825d-6cc53771e2f9?version=2017-09-11T191533.379304Z",
            "search_score": null
        }
    ]
}
```

Connects to #348 