### PR TITLE
added test specific index to indexer

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -42,6 +42,10 @@ class IndexSuffix:
     def name(self, value: str):
         self.__suf__ = value
 
+    @classmethod
+    def reset(cls):
+        cls.name = ''
+
 class Config:
     _S3_BUCKET = None  # type: typing.Optional[str]
     _GS_BUCKET = None  # type: typing.Optional[str]

--- a/dss/config.py
+++ b/dss/config.py
@@ -30,6 +30,18 @@ class Replica(Enum):
     aws = auto()
     gcp = auto()
 
+class IndexSuffix:
+    '''Creates a test specific index when in test config.'''
+    __suf__ = ''  # index suffix to use
+
+    @property
+    def name(self):
+        return self.__suf__
+
+    @name.setter
+    def name(self, value: str):
+        self.__suf__ = value
+
 class Config:
     _S3_BUCKET = None  # type: typing.Optional[str]
     _GS_BUCKET = None  # type: typing.Optional[str]
@@ -134,7 +146,7 @@ class Config:
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
         index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
         if Config._CURRENT_CONFIG == DeploymentStage.TEST:
-            index = f"{index}-{os.getenv('TEST_MODULE_NAME','')}"
+            index = f"{index}-{IndexSuffix.name}"
         return index
 
     @staticmethod

--- a/dss/config.py
+++ b/dss/config.py
@@ -132,7 +132,10 @@ class Config:
     @staticmethod
     def get_es_index_name(index_type: ESIndexType, replica: Replica) -> str:
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
-        return f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
+        index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
+        if Config._CURRENT_CONFIG == DeploymentStage.TEST:
+            index = f"{index}-{os.getenv('TEST_MODULE_NAME','')}"
+        return index
 
     @staticmethod
     def _clear_cached_bucket_config():

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -26,6 +26,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss import Config, DeploymentStage
+from dss.config import IndexSuffix
 from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object
 from dss.hcablobstore import BundleMetadata, BundleFileMetadata, FileMetadata
 from dss.util import create_blob_key, UrlBuilder
@@ -71,7 +72,7 @@ class ESInfo:
     server = None
 
 def setUpModule():
-    os.environ['TEST_MODULE_NAME'] = __name__.split('.')[-1]
+    IndexSuffix.name = __name__.split('.')[-1]
     HTTPInfo.port = findOpenPort()
     HTTPInfo.server = HTTPServer((HTTPInfo.address, HTTPInfo.port), PostTestHandler)
     HTTPInfo.thread = threading.Thread(target=HTTPInfo.server.serve_forever)
@@ -83,7 +84,7 @@ def setUpModule():
 def tearDownModule():
     ESInfo.server.shutdown()
     HTTPInfo.server.shutdown()
-    os.unsetenv("TEST_MODULE_NAME")
+    os.unsetenv('DSS_ES_PORT')
 
 
 class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
@@ -101,7 +102,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
 
     def setUp(self):
         self.app = dss.create_app().app.test_client()
-        elasticsearch_delete_index(f"*{os.environ['TEST_MODULE_NAME']}")
+        elasticsearch_delete_index(f"*{IndexSuffix.name}")
         PostTestHandler.reset()
 
     def tearDown(self):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -72,7 +72,7 @@ class ESInfo:
     server = None
 
 def setUpModule():
-    IndexSuffix.name = __name__.split('.')[-1]
+    IndexSuffix.name = __name__.rsplit('.', 1)[-1]
     HTTPInfo.port = findOpenPort()
     HTTPInfo.server = HTTPServer((HTTPInfo.address, HTTPInfo.port), PostTestHandler)
     HTTPInfo.thread = threading.Thread(target=HTTPInfo.server.serve_forever)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -84,6 +84,7 @@ def setUpModule():
 def tearDownModule():
     ESInfo.server.shutdown()
     HTTPInfo.server.shutdown()
+    IndexSuffix.reset()
     os.unsetenv('DSS_ES_PORT')
 
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -71,6 +71,7 @@ class ESInfo:
     server = None
 
 def setUpModule():
+    os.environ['TEST_MODULE_NAME'] = __name__.split('.')[-1]
     HTTPInfo.port = findOpenPort()
     HTTPInfo.server = HTTPServer((HTTPInfo.address, HTTPInfo.port), PostTestHandler)
     HTTPInfo.thread = threading.Thread(target=HTTPInfo.server.serve_forever)
@@ -82,6 +83,7 @@ def setUpModule():
 def tearDownModule():
     ESInfo.server.shutdown()
     HTTPInfo.server.shutdown()
+    os.unsetenv("TEST_MODULE_NAME")
 
 
 class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
@@ -99,7 +101,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
 
     def setUp(self):
         self.app = dss.create_app().app.test_client()
-        elasticsearch_delete_index("_all")
+        elasticsearch_delete_index(f"*{os.environ['TEST_MODULE_NAME']}")
         PostTestHandler.reset()
 
     def tearDown(self):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -62,8 +62,6 @@ class TestSearchBase(DSSAsserts):
         dss.Config.set_config(dss.DeploymentStage.TEST)
         self.app = dss.create_app().app.test_client()
         elasticsearch_delete_index(f"*{os.environ['TEST_MODULE_NAME']}")
-        elasticsearch_delete_index(self.dss_index_name)
-        create_elasticsearch_index(self.dss_index_name, logger)
 
     def test_search_post(self):
         bundle_uuid = str(uuid.uuid4())
@@ -87,6 +85,7 @@ class TestSearchBase(DSSAsserts):
         self.assertEqual(search_response['results'][0]['bundle_url'], bundle_url)
 
     def test_search_returns_no_results_when_no_documents_indexed(self):
+        create_elasticsearch_index(self.dss_index_name, logger)
         self.verify_search_results(smartseq2_paired_ends_query)
 
     def test_search_returns_no_result_when_query_does_not_match_indexed_documents(self):
@@ -98,7 +97,6 @@ class TestSearchBase(DSSAsserts):
                     }
                 }
             }
-
         self.populate_search_index(self.index_document, 1)
         self.verify_search_results(query)
 
@@ -135,9 +133,10 @@ class TestSearchBase(DSSAsserts):
         """Create N identical documents. A search query is executed to match the document. All documents created must be
         present in the query results. N is varied across a variety of values.
         """
-        test_matches = [0, 1, 9, 10, 11, 1000, 5000]
+        test_matches = [0, 1, 9, 10, 11, 1000, 10001]
         bundle_ids = []
         indexed = 0
+        create_elasticsearch_index(self.dss_index_name, logger)
         for x in test_matches:
             create = x - indexed
             indexed = x

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -19,6 +19,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
+from dss.config import IndexSuffix
 from dss.events.handlers.index import create_elasticsearch_index
 from dss.util.es import ElasticsearchServer, ElasticsearchClient
 from tests.infra import DSSAsserts, start_verbose_logging
@@ -38,15 +39,14 @@ class ESInfo:
 
 
 def setUpModule():
-    os.environ['TEST_MODULE_NAME'] = __name__.split('.')[-1]
+    IndexSuffix.name = __name__.split('.')[-1]
     ESInfo.server = ElasticsearchServer()
     os.environ['DSS_ES_PORT'] = str(ESInfo.server.port)
 
 
 def tearDownModule():
     ESInfo.server.shutdown()
-    os.unsetenv("TEST_MODULE_NAME")
-
+    os.unsetenv('DSS_ES_PORT')
 
 class TestSearchBase(DSSAsserts):
     @classmethod
@@ -61,7 +61,7 @@ class TestSearchBase(DSSAsserts):
     def setUp(self):
         dss.Config.set_config(dss.DeploymentStage.TEST)
         self.app = dss.create_app().app.test_client()
-        elasticsearch_delete_index(f"*{os.environ['TEST_MODULE_NAME']}")
+        elasticsearch_delete_index(f"*{IndexSuffix.name}")
 
     def test_search_post(self):
         bundle_uuid = str(uuid.uuid4())

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -46,6 +46,7 @@ def setUpModule():
 
 def tearDownModule():
     ESInfo.server.shutdown()
+    IndexSuffix.reset()
     os.unsetenv('DSS_ES_PORT')
 
 class TestSearchBase(DSSAsserts):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -39,7 +39,7 @@ class ESInfo:
 
 
 def setUpModule():
-    IndexSuffix.name = __name__.split('.')[-1]
+    IndexSuffix.name = __name__.rsplit('.', 1)[-1]
     ESInfo.server = ElasticsearchServer()
     os.environ['DSS_ES_PORT'] = str(ESInfo.server.port)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -63,6 +63,7 @@ class TestSearchBase(DSSAsserts):
         dss.Config.set_config(dss.DeploymentStage.TEST)
         self.app = dss.create_app().app.test_client()
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
+        create_elasticsearch_index(self.dss_index_name, logger)
 
     def test_search_post(self):
         bundle_uuid = str(uuid.uuid4())
@@ -86,7 +87,6 @@ class TestSearchBase(DSSAsserts):
         self.assertEqual(search_response['results'][0]['bundle_url'], bundle_url)
 
     def test_search_returns_no_results_when_no_documents_indexed(self):
-        create_elasticsearch_index(self.dss_index_name, logger)
         self.verify_search_results(smartseq2_paired_ends_query)
 
     def test_search_returns_no_result_when_query_does_not_match_indexed_documents(self):

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -22,6 +22,7 @@ import dss
 from dss.util import UrlBuilder
 from dss.util.es import ElasticsearchClient, ElasticsearchServer, get_elasticsearch_index
 from tests.infra import DSSAsserts, ExpectedErrorFields
+from tests.es import elasticsearch_delete_index
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ class ESInfo:
     server = None
 
 def setUpModule():
+    os.environ['TEST_MODULE_NAME'] = __name__.split('.')[-1]
     ESInfo.server = ElasticsearchServer()
     os.environ['DSS_ES_PORT'] = str(ESInfo.server.port)
 
@@ -52,6 +54,7 @@ class TestSubscriptionsBase(DSSAsserts):
 
         logger.debug("Setting up Elasticsearch")
         es_client = ElasticsearchClient.get(logger)
+        elasticsearch_delete_index(f"*{os.environ['TEST_MODULE_NAME']}")
         es_client.indices.delete(index="_all", ignore=[404])  # Disregard if no indices - don't error.
         index_mapping = {  # Need to make a mapping for the percolator type before we add any.
             "mappings": {

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -40,6 +40,7 @@ def setUpModule():
 
 def tearDownModule():
     ESInfo.server.shutdown()
+    IndexSuffix.reset()
     os.unsetenv('DSS_ES_PORT')
 
 class TestSubscriptionsBase(DSSAsserts):

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -19,6 +19,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
 sys.path.insert(0, pkg_root) # noqa
 
 import dss
+from dss.config import IndexSuffix
 from dss.util import UrlBuilder
 from dss.util.es import ElasticsearchClient, ElasticsearchServer, get_elasticsearch_index
 from tests.infra import DSSAsserts, ExpectedErrorFields
@@ -33,7 +34,7 @@ class ESInfo:
     server = None
 
 def setUpModule():
-    os.environ['TEST_MODULE_NAME'] = __name__.split('.')[-1]
+    IndexSuffix.name = __name__.split('.')[-1]
     ESInfo.server = ElasticsearchServer()
     os.environ['DSS_ES_PORT'] = str(ESInfo.server.port)
 
@@ -54,7 +55,7 @@ class TestSubscriptionsBase(DSSAsserts):
 
         logger.debug("Setting up Elasticsearch")
         es_client = ElasticsearchClient.get(logger)
-        elasticsearch_delete_index(f"*{os.environ['TEST_MODULE_NAME']}")
+        elasticsearch_delete_index(f"*{IndexSuffix.name}")
         index_mapping = {  # Need to make a mapping for the percolator type before we add any.
             "mappings": {
                 dss.ESDocType.query.name: {

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -55,7 +55,6 @@ class TestSubscriptionsBase(DSSAsserts):
         logger.debug("Setting up Elasticsearch")
         es_client = ElasticsearchClient.get(logger)
         elasticsearch_delete_index(f"*{os.environ['TEST_MODULE_NAME']}")
-        es_client.indices.delete(index="_all", ignore=[404])  # Disregard if no indices - don't error.
         index_mapping = {  # Need to make a mapping for the percolator type before we add any.
             "mappings": {
                 dss.ESDocType.query.name: {

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -34,7 +34,7 @@ class ESInfo:
     server = None
 
 def setUpModule():
-    IndexSuffix.name = __name__.split('.')[-1]
+    IndexSuffix.name = __name__.rsplit('.', 1)[-1]
     ESInfo.server = ElasticsearchServer()
     os.environ['DSS_ES_PORT'] = str(ESInfo.server.port)
 


### PR DESCRIPTION
- Added the environment variable `TEST_MODULE_NAME` to test cases that use an elasticsearch index. 

- Modified `get_es_index_name()` to append the `index`  with `TEST_MODULE_NAME` if `DSS_DEPLOYMENT_STAGE == Test`. 

We can now run the test cases in parallel to speed up execution time.

Connects to #355