### PR TITLE
Retry PUT requests on 504 errors

### DIFF
--- a/scripts/deploy_gcf.py
+++ b/scripts/deploy_gcf.py
@@ -10,6 +10,7 @@ import google.cloud.storage
 import google.cloud.exceptions
 from google.cloud.client import ClientWithProject
 from google.cloud._http import JSONConnection
+from urllib3.util.retry import Retry
 
 class GCPClient(ClientWithProject):
     SCOPE = ["https://www.googleapis.com/auth/cloud-platform",
@@ -35,6 +36,7 @@ gcp_region = os.environ["GCP_DEFAULT_REGION"]
 gcp_key_file = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
 gs = google.cloud.storage.Client.from_service_account_json(gcp_key_file)
 gcp_client = GCPClient()
+gcp_client._http.adapters["https://"].max_retries = Retry(status_forcelist={503, 504})
 grtc_conn = GoogleRuntimeConfigConnection(client=gcp_client)
 gcf_conn = GoogleCloudFunctionsConnection(client=gcp_client)
 gcf_ns = f"projects/{gcp_client.project}/locations/{gcp_region}/functions"


### PR DESCRIPTION
This should help with errors like this, which we see in the deploy stage occasionally:
```
make[1]: Entering directory '/home/travis/build/HumanCellAtlas/data-store/daemons'
/home/travis/build/HumanCellAtlas/data-store/scripts/deploy_gcf.py dss-gs-event-relay --entry-point "dss_gs_bucket_events_org_humancellatlas_dss_staging"
Waiting for deployment........................................GRTC config dss_gs_bucket_events_org_humancellatlas_dss_staging found
Writing GRTC variable AWS_ACCESS_KEY_ID
Writing GRTC variable AWS_SECRET_ACCESS_KEY
Writing GRTC variable AWS_REGION
Writing GRTC variable sns_topic_arn
Adding Readme.md
Adding index.js
Adding package.json
Uploaded <Blob: org-humancellatlas-dss-test-fixtures, dss-gs-event-relay-staging-deploy-2017-09-15-18-14-01-fa74cd74.zip>
{'name': 'operations/aHVtYW4tY2VsbC1hdGxhcy10cmF2aXMtdGVzdC91cy1jZW50cmFsMS9kc3MtZ3MtZXZlbnQtcmVsYXktc3RhZ2luZy9rU2cwVGFFcEtwRQ', 'metadata': {'@type': 'type.googleapis.com/google.cloud.functions.v1beta2.OperationMetadataV1Beta2', 'target': 'projects/human-cell-atlas-travis-test/locations/us-central1/functions/dss-gs-event-relay-staging', 'type': 'UPDATE_FUNCTION', 'versionId': '17'}}
Traceback (most recent call last):
  File "/home/travis/build/HumanCellAtlas/data-store/scripts/deploy_gcf.py", line 104, in <module>
    if gcf_conn.api_request("GET", f"/{gcf_ns}/{args.gcf_name}")["status"] != "DEPLOYING":
  File "/home/travis/virtualenv/python3.6.2/lib/python3.6/site-packages/google/cloud/_http.py", line 293, in api_request
    raise exceptions.from_http_response(response)
google.cloud.exceptions.GatewayTimeout: 504 GET https://cloudfunctions.googleapis.com/v1beta2/projects/human-cell-atlas-travis-test/locations/us-central1/functions/dss-gs-event-relay-staging: Deadline expired before operation could complete.
Makefile:29: recipe for target 'dss-gs-event-relay' failed
make[1]: *** [dss-gs-event-relay] Error 1
```
