### PR TITLE
Add support for signing webhook payloads with HMAC

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -332,7 +332,7 @@ paths:
                   - code
   /subscriptions:
     get:
-      summary: Retrieve an user's event subscriptions.
+      summary: Retrieve a user\'s event subscriptions.
       description: |
         Return a list of associated subscriptions, which contains the uuid,
         replica, query, creator_uid, and callback_url.
@@ -400,6 +400,14 @@ paths:
                 description: Url to send request to when a bundle comes in that matches this query.
                 type: string
                 format: url # Seems that this is possible now because of https://github.com/swagger-api/swagger-core/issues/1045
+                pattern: "http://.+"
+              secret:
+                description: |
+                  A key used to sign notifications sent to `callback_url`. The signature will be constructed according
+                  to https://tools.ietf.org/html/draft-cavage-http-signatures and transmitted in the Authorization
+                  header.
+                type: string
+                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - es_query
               - callback_url

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -400,14 +400,16 @@ paths:
                 description: Url to send request to when a bundle comes in that matches this query.
                 type: string
                 format: url # Seems that this is possible now because of https://github.com/swagger-api/swagger-core/issues/1045
-                pattern: "http://.+"
-              secret:
+              hmac_secret_key:
                 description: |
                   A key used to sign notifications sent to `callback_url`. The signature will be constructed according
                   to https://tools.ietf.org/html/draft-cavage-http-signatures and transmitted in the Authorization
                   header.
                 type: string
-                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+              hmac_key_id:
+                description: |
+                  A key ID to use for `hmac_secret_key`.
+                type: string
             required:
               - es_query
               - callback_url

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -223,6 +223,7 @@ def notify(subscription_id: str, subscription: dict, bundle_id: str, logger):
     }
     callback_url = subscription['callback_url']
 
+    # FIXME wrap all errors in this block with an exception handler
     assert urlparse(callback_url).scheme in {"http", "https"}
     if os.environ["DSS_DEPLOYMENT_STAGE"] not in {"dev", "staging"}:
         hostname = urlparse(callback_url).hostname

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -219,15 +219,12 @@ def notify(subscription_id: str, subscription: dict, bundle_id: str, logger):
             "bundle_version": bundle_version
         }
     }
-    #verify_signature(payload_body)
-    #signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['SECRET_TOKEN'], payload_body)
-    #return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
-
     callback_url = subscription['callback_url']
 
     auth = None
-    if "hmac_secret" in subscription:
-        auth = HTTPSignatureAuth(key=subscription["hmac_secret"], key_id="hca-dss:" + subscription_id)
+    if "hmac_secret_key" in subscription:
+        auth = HTTPSignatureAuth(key=subscription["hmac_secret_key"].encode(),
+                                 key_id=subscription.get("hmac_key_id", "hca-dss:" + subscription_id))
     response = requests.post(callback_url, json=payload, auth=auth)
 
     # TODO (mbaumann) Add webhook retry logic

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -7,6 +7,7 @@ import uuid
 from urllib.parse import unquote
 
 import requests
+from requests_http_signature import HTTPSignatureAuth
 from elasticsearch.helpers import scan
 
 from dss import Config, ESIndexType, ESDocType, Replica
@@ -223,7 +224,12 @@ def notify(subscription_id: str, subscription: dict, bundle_id: str, logger):
     #return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
 
     callback_url = subscription['callback_url']
-    response = requests.post(callback_url, json=payload)
+
+    auth = None
+    if "hmac_secret" in subscription:
+        auth = HTTPSignatureAuth(key=subscription["hmac_secret"], key_id="hca-dss:" + subscription_id)
+    response = requests.post(callback_url, json=payload, auth=auth)
+
     # TODO (mbaumann) Add webhook retry logic
     if 200 <= response.status_code < 300:
         logger.info(f"Successfully notified for subscription {subscription_id}"

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -218,7 +218,10 @@ def notify(subscription_id: str, subscription: dict, bundle_id: str, logger):
             "bundle_version": bundle_version
         }
     }
-    # TODO (mbaumann) Ensure webhooks are only delivered over verified HTTPS (unless maybe when running a test)
+    #verify_signature(payload_body)
+    #signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), ENV['SECRET_TOKEN'], payload_body)
+    #return halt 500, "Signatures didn't match!" unless Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
+
     callback_url = subscription['callback_url']
     response = requests.post(callback_url, json=payload)
     # TODO (mbaumann) Add webhook retry logic

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -225,7 +225,7 @@ def notify(subscription_id: str, subscription: dict, bundle_id: str, logger):
 
     # FIXME wrap all errors in this block with an exception handler
     assert urlparse(callback_url).scheme in {"http", "https"}
-    if os.environ["DSS_DEPLOYMENT_STAGE"] not in {"dev", "staging"}:
+    if os.environ["DSS_DEPLOYMENT_STAGE"] == "prod":
         hostname = urlparse(callback_url).hostname
         for family, socktype, proto, canonname, sockaddr in socket.getaddrinfo(hostname, port=None):
             assert ipaddress.ip_address(sockaddr[0]).is_global  # type: ignore

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -227,7 +227,7 @@ def notify(subscription_id: str, subscription: dict, bundle_id: str, logger):
     if os.environ["DSS_DEPLOYMENT_STAGE"] not in {"dev", "staging"}:
         hostname = urlparse(callback_url).hostname
         for family, socktype, proto, canonname, sockaddr in socket.getaddrinfo(hostname, port=None):
-            assert ipaddress.ip_address(sockaddr[0]).is_global
+            assert ipaddress.ip_address(sockaddr[0]).is_global  # type: ignore
         assert urlparse(callback_url).scheme == "https"
 
     auth = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,8 @@ pycparser==2.18
 python-dateutil==2.6.1
 PyYAML==3.12
 requests==2.18.4
-requests_aws4auth==0.9
+requests-aws4auth==0.9
+requests-http-signature==0.0.2
 rsa==3.4.2
 s3transfer==0.1.11
 six==1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ python-dateutil==2.6.1
 PyYAML==3.12
 requests==2.18.4
 requests-aws4auth==0.9
-requests-http-signature==0.0.2
+requests-http-signature==0.0.3
 rsa==3.4.2
 s3transfer==0.1.11
 six==1.11.0

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -9,3 +9,4 @@ google-cloud-storage
 iso8601
 requests_aws4auth
 urllib3
+requests-http-signature

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -230,13 +230,16 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         self.verify_notification(subscription_id, smartseq2_paired_ends_query, bundle_id)
 
     def test_subscription_notification_unsuccessful(self):
+        PostTestHandler.verify_payloads = True
         bundle_key = self.load_test_data_bundle_for_path("fixtures/smartseq2/paired_ends")
         sample_event = self.create_sample_bundle_created_event(bundle_key)
         self.process_new_indexable_object(sample_event, logger)
 
         ElasticsearchClient.get(logger).indices.create(self.subscription_index_name)
         subscription_id = self.subscribe_for_notification(smartseq2_paired_ends_query,
-                                                          f"http://{HTTPInfo.address}:{HTTPInfo.port}")
+                                                          f"http://{HTTPInfo.address}:{HTTPInfo.port}",
+                                                          hmac_secret_key=PostTestHandler.hmac_secret_key,
+                                                          hmac_key_id="test")
 
         bundle_key = self.load_test_data_bundle_for_path("fixtures/smartseq2/paired_ends")
         sample_event = self.create_sample_bundle_created_event(bundle_key)


### PR DESCRIPTION
Also:

- check against local resource access attacks in redirect URLs

- require https webhook URLs in production