### PR TITLE
add write access to staging bucket.

### DIFF
--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -15,7 +15,8 @@
       ],
       "Resource": [
         "arn:aws:s3:::$DSS_S3_BUCKET/*",
-        "arn:aws:s3:::$DSS_S3_BUCKET_TEST/*"
+        "arn:aws:s3:::$DSS_S3_BUCKET_TEST/*",
+        "arn:aws:s3:::$DSS_S3_BUCKET_STAGING/*"
       ]
     },
     {


### PR DESCRIPTION
This is needed for the deploy script in the cron script.

This depends on #477 because by itself, it would put us past the 2048 character limit.