### PR TITLE
[easy] remove flask-failsafe.

### DIFF
--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -18,7 +18,6 @@ from connexion.lifecycle import ConnexionResponse
 from connexion.operation import Operation
 from connexion.resolver import RestyResolver
 from connexion.exceptions import OAuthProblem, OAuthResponseProblem, OAuthScopeProblem
-from flask_failsafe import failsafe
 from werkzeug.exceptions import Forbidden
 
 from .config import Config, DeploymentStage, ESIndexType, ESDocType, Replica
@@ -180,7 +179,7 @@ class DSSRequestBodyValidator(RequestBodyValidator):
 
         return wrapper
 
-@failsafe
+
 def create_app():
     app = DSSApp(
         __name__,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,6 @@ elasticsearch==5.4.0
 elasticsearch-dsl==5.3.0
 flake8==3.4.1
 Flask==0.12.2
-Flask-Failsafe==0.2
 google-auth==1.0.2
 google-cloud-core==0.26.0
 google-cloud-storage==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ docutils==0.14
 elasticsearch==5.4.0
 elasticsearch-dsl==5.3.0
 Flask==0.12.2
-Flask-Failsafe==0.2
 google-auth==1.0.2
 google-cloud-core==0.26.0
 google-cloud-storage==1.3.2

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -4,7 +4,6 @@ boto3
 connexion
 elasticsearch
 elasticsearch_dsl
-flask-failsafe
 google-cloud-storage
 iso8601
 urllib3


### PR DESCRIPTION
We use the chalice cli runner, which doesn't do auto-reload anyway.