### PR TITLE
make PUT /files idempotent.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -240,6 +240,17 @@ paths:
               - bundle_uuid
               - creator_uid
       responses:
+        200:
+          description: Returned when the file is already present and is identical to the file being uploaded.
+          schema:
+            type: object
+            properties:
+              version:
+                description: Timestamp of file creation in RFC3339.
+                type: string
+                format: date-time
+            required:
+              - version
         201:
           description: Returned when the file is successfully copied.
           schema:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -81,10 +81,18 @@ class TestFileApi(unittest.TestCase, DSSAsserts, DSSUploadMixin):
                 self.assertIn('version', resp_obj.json)
 
         file_uuid = str(uuid.uuid4())
+        bundle_uuid = str(uuid.uuid4())
+        version = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H%M%S.%fZ")
 
         # should be able to do this twice (i.e., same payload, different UUIDs)
-        upload_file(file_uuid)
+        upload_file(file_uuid, bundle_uuid=bundle_uuid, version=version)
         upload_file(str(uuid.uuid4()))
+
+        # should be able to do this twice (i.e., same payload, same UUIDs)
+        upload_file(file_uuid, bundle_uuid=bundle_uuid, version=version, expected_code=requests.codes.ok)
+
+        # should *NOT* be able to do this twice (i.e., different payload, same UUIDs)
+        upload_file(file_uuid, version=version, expected_code=requests.codes.conflict)
 
     def test_file_put_large(self):
         tempdir = tempfile.gettempdir()


### PR DESCRIPTION
This makes it easier to manage API clients that have to do retries.  Idempotence means that they can just blindly try until they succeed.

It is idempotent as long as the parameters are identical.

This depends on #491.

Connects to #399 