### PR TITLE
Fix issues with parallel copy.

### DIFF
--- a/daemons/Makefile
+++ b/daemons/Makefile
@@ -13,13 +13,31 @@ dss-sync dss-index:
 	    ../tests/daemons/sample_s3_bundle_created_event.json.template \
 	    ../tests/daemons/a47b90b2-0967-4fbf-87bc-c6c12db3fedf.2017-07-12T055120.037644Z; \
 
-chainedawslambdatargets := dss-s3-copy-write-metadata
+chainedawslambdatargets := chained-aws-lambda-s3-parallel-copy-worker
+dsschainedawslambdatargets := dss-s3-copy-write-metadata
+chained-aws-lambda: $(chainedawslambdatargets) $(dsschainedawslambdatargets)
 
-chained-aws-lambda: $(chainedawslambdatargets)
-$(chainedawslambdatargets): dss-%:
+$(chainedawslambdatargets): chained-aws-lambda-%:
 	rm -rf $@
 	cp -rf chained-aws-lambda $@
 	chained_aws_lambda.py '$$account_id' \
+	  --enable-s3-parallel-copy-worker --s3-parallel-copy-worker-lambda-name chained-aws-lambda-s3-parallel-copy-worker-dev \
+	  --s3-parallel-copy-worker-policy-path $@/policy.json.template \
+	  --s3-parallel-copy-worker-app-path $@/app.py
+
+	cat chained-aws-lambda/.chalice/config.json | jq '.app_name="$@"' > $@/.chalice/config.json
+	# blindly enable access to our test S3 bucket.  This is ok since most daemons require it anyway.
+	cat $@/policy.json.template | jq -f s3_enable.filter | sponge $@/policy.json.template
+	cp -R ../dss $@/domovoilib
+	cp "$(GOOGLE_APPLICATION_CREDENTIALS)" $@/domovoilib/gcp-credentials.json
+	iam_policy_template=$@/policy.json.template ./build_deploy_config.sh $@ $(DSS_DEPLOYMENT_STAGE)
+	cd $@; domovoi deploy --stage dev
+
+dss-s3-copy-write-metadata: dss-%:
+	rm -rf $@
+	cp -rf chained-aws-lambda $@
+	chained_aws_lambda.py '$$account_id' \
+	  --enable-s3-parallel-copy-worker --s3-parallel-copy-worker-lambda-name chained-aws-lambda-s3-parallel-copy-worker-dev \
 	  --policy-path $@/policy.json.template \
 	  --app-path $@/app.py \
 	  --lambda-name dss-$*-$(DSS_DEPLOYMENT_STAGE)
@@ -27,7 +45,10 @@ $(chainedawslambdatargets): dss-%:
 	cat chained-aws-lambda/.chalice/config.json | jq '.app_name="dss-$*"' > $@/.chalice/config.json
 	# grant access to $DSS_S3_BUCKET and $DSS_S3_BUCKET_TEST.  in build_deploy_config.sh, this gets replaced with the
 	# actual bucket names.
-	cat $@/policy.json.template | jq -f s3_enable.filter | sponge $@/policy.json.template
+	cat $@/policy.json.template | \
+	  jq -f s3_enable.filter | \
+	  jq -f dss-s3-copy-write-metadata.filter | \
+	  sponge $@/policy.json.template
 	shopt -s nullglob; for wheel in $@/vendor.in/*/*.whl; do unzip -q -o -d $@/vendor $$wheel; done
 	cp -R ../dss $@/domovoilib
 	cp "$(GOOGLE_APPLICATION_CREDENTIALS)" $@/domovoilib/gcp-credentials.json
@@ -37,4 +58,4 @@ $(chainedawslambdatargets): dss-%:
 dss-gs-event-relay:
 	$(DSS_HOME)/scripts/deploy_gcf.py $@ --entry-point "dss_gs_bucket_events_$(subst -,_,$(DSS_GS_BUCKET))"
 
-.PHONY: dss-sync dss-index $(chainedawslambdatargets) dss-gs-event-relay
+.PHONY: dss-sync dss-index $(chainedawslambdatargets) $(dsschainedawslambdatargets) dss-gs-event-relay

--- a/daemons/dss-s3-copy-write-metadata.filter
+++ b/daemons/dss-s3-copy-write-metadata.filter
@@ -1,0 +1,8 @@
+.Statement |=
+  (map((select(.Sid == "calsns") .Resource) += [
+    "arn:aws:sns:*:$account_id:chained-aws-lambda-s3-parallel-copy-worker-$stage"
+   ]) |
+  map((select(.Sid == "callog") .Resource) += [
+    "arn:aws:logs:*:*:log-group:chained-aws-lambda-s3-parallel-copy-worker-$stage",
+    "arn:aws:logs:*:*:log-group:chained-aws-lambda-s3-parallel-copy-worker-$stage:*"
+   ]))

--- a/dss/events/chunkedtask/s3copyclient.py
+++ b/dss/events/chunkedtask/s3copyclient.py
@@ -73,6 +73,7 @@ class S3CopyWriteBundleTask(Task[dict, dict]):
             S3CopyWriteBundleTaskKeys.FILE_VERSION: file_version,
             S3CopyWriteBundleTaskKeys.METADATA: metadata,
             S3CopyWriteBundleTaskKeys.STAGE: S3CopyWriteBundleTaskKeys.S3CopyWriteBundleTaskStages.COPYING,
+            S3CopyWriteBundleTaskKeys.USE_PARALLEL: use_parallel,
         }  # type: dict
         if use_parallel:
             state[S3CopyWriteBundleTaskKeys.COPY_STATE] = S3ParallelCopySupervisorTask.setup_copy_task(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ botocore==1.6.1
 cachetools==2.0.1
 certifi==2017.7.27.1
 cffi==1.10.0
-chained-aws-lambda==0.0.5
+chained-aws-lambda==0.0.7
 chalice==1.0.1
 chardet==3.0.4
 click==6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ botocore==1.6.1
 cachetools==2.0.1
 certifi==2017.7.27.1
 cffi==1.10.0
-chained-aws-lambda==0.0.5
+chained-aws-lambda==0.0.7
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2


### PR DESCRIPTION
1. We weren't invoking the parallel mode because we didn't write the parallel field.  Whoops.
2. We weren't deploying the child worker daemon.  This did not surface as a bug because of `(1)`.  Add Makefile & jq madness to fire up the child worker daemon.  The jq stuff is needed to enable the parent worker to call the child worker.
3. Upgrade chained-aws-lambda to pick up the statementid (sid) changes (https://github.com/chanzuckerberg/chained-aws-lambda/commit/6f10a132f82bb06c732e0f8bf0fcd0b3ff3e0682) to simplify the jq logic.

Connects to #393