### PR TITLE
Send a content-length header to prevent a deadlock.

### DIFF
--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -452,6 +452,7 @@ class PostTestHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         self.send_response(self._response_code)
+        self.send_header("Content-length", "0")
         self.end_headers()
         length = int(self.headers['content-length'])
         if length:


### PR DESCRIPTION
If we don't send a content-length, the python requests library will sit there and continue to try to read until the network connection is severed.  This is happening because (after some of my other changes), there's a library that's polluting the http.server globals (I haven't tracked this down) and enabling HTTP/1.1, which supports resumes.
