### PR TITLE
[easy] increase test timeout for test search and index

### DIFF
--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -246,7 +246,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
 
     @staticmethod
     def get_notification_payload():
-        timeout = 2
+        timeout = 5
         timeout_time = time.time() + timeout
         while True:
             posted_payload_string = PostTestHandler.get_payload()
@@ -333,7 +333,7 @@ class TestIndexerBase(DSSAsserts, StorageTestSupport, DSSUploadMixin):
         # By default, the refresh interval is one second.
         # https://www.elastic.co/guide/en/elasticsearch/reference/5.5/_modifying_your_data.html
         # Yet, sometimes one second is not quite enough given the churn in the local Elasticsearch instance.
-        timeout = 2
+        timeout = 5
         timeout_time = time.time() + timeout
         while True:
             response = ElasticsearchClient.get(logger).search(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -188,7 +188,7 @@ class TestSearchBase(DSSAsserts):
             json_request_body=dict(es_query=es_query),
             expected_code=status_code)
 
-    def verify_search_results(self, es_query, expected_result_length=0, bundles=[], timeout=5):
+    def verify_search_results(self, es_query, expected_result_length=0, bundles=[], timeout=8):
         timeout_time = timeout + time.time()
         while time.time() <= timeout_time:
             response = self.post_search(es_query, requests.codes.ok)


### PR DESCRIPTION
This will fix some search and index test cases from failing occasionally due to timeout.

Fixes #502 