### PR TITLE
added total matching results to search response.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -84,6 +84,9 @@ paths:
               results:
                 description: Results matching the `es_query`.
                 type: array
+              count:
+                description: The total number of matching results found.
+                type: integer
           headers:
             Link:
               type: string

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -84,7 +84,7 @@ paths:
               results:
                 description: Results matching the `es_query`.
                 type: array
-              count:
+              total_hits:
                 description: The total number of matching results found.
                 type: integer
           headers:

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -80,9 +80,11 @@ def post(json_request_body: dict, replica: str, per_page: int, _scroll_id: typin
                                               .add_query("_scroll_id", _scroll_id))
             links = build_link_header({next_url: {"rel": "next"}})
 
-        # TODO: (tsmith12) check if all results found and return request.code.ok.
-        # TODO: (tsmith12) if all results not found return request.code.partial.
-        response = make_response(jsonify({'es_query': es_query, 'results': result_list}), requests.codes.ok)
+        # TODO: (tsmith12) if all results found, do not return a next link.
+        # TODO: (tsmith12) if all results not found return request.code.partial and return a next url
+        response = make_response(jsonify({'es_query': es_query,
+                                          'results': result_list,
+                                          'count': page['hits']['total']}), requests.codes.ok)
         response.headers['Link'] = links
 
         return response

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -84,7 +84,7 @@ def post(json_request_body: dict, replica: str, per_page: int, _scroll_id: typin
         # TODO: (tsmith12) if all results not found return request.code.partial and return a next url
         response = make_response(jsonify({'es_query': es_query,
                                           'results': result_list,
-                                          'count': page['hits']['total']}), requests.codes.ok)
+                                          'total_hits': page['hits']['total']}), requests.codes.ok)
         response.headers['Link'] = links
 
         return response

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -78,7 +78,7 @@ class TestSearchBase(DSSAssertMixin):
             expected_code=requests.codes.ok)
         next_url = self.get_next_url(search_obj.response.headers['Link'])
         self.assertEqual(next_url, '')
-        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, 1)
+        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, len(bundles), 1)
         self.verify_bundles(search_obj.json['results'], bundles)
 
     def test_search_returns_no_results_when_no_documents_indexed(self):
@@ -89,7 +89,7 @@ class TestSearchBase(DSSAssertMixin):
             expected_code=requests.codes.ok)
         next_url = self.get_next_url(search_obj.response.headers['Link'])
         self.assertEqual(next_url, '')
-        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, 0)
+        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, 0, 0)
 
     def test_search_returns_no_result_when_query_does_not_match_indexed_documents(self):
         query = \
@@ -177,7 +177,7 @@ class TestSearchBase(DSSAssertMixin):
                 self.check_count(smartseq2_paired_ends_query, indexed_docs)
                 search_obj, found_bundles = self.get_search_results(smartseq2_paired_ends_query,
                                                                     url_params=url_params)
-                self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, expected_results)
+                self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, docs, expected_results)
                 self.verify_bundles(found_bundles, bundles)
 
     def test_elasticsearch_exception(self):
@@ -211,13 +211,13 @@ class TestSearchBase(DSSAssertMixin):
         found_bundles = search_obj.json['results']
         next_url = self.get_next_url(search_obj.response.headers['Link'])
         self.verify_next_url(next_url)
-        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, 100)
+        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, len(bundles), 100)
         search_obj = self.assertPostResponse(
             path=next_url,
             json_request_body=dict(es_query=smartseq2_paired_ends_query),
             expected_code=requests.codes.ok)
         found_bundles.extend(search_obj.json['results'])
-        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, 50)
+        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, len(bundles), 50)
         self.verify_bundles(found_bundles, bundles)
 
     def test_page_has_N_results_when_per_page_is_N(self):
@@ -235,7 +235,7 @@ class TestSearchBase(DSSAssertMixin):
                     path=url,
                     json_request_body=dict(es_query=smartseq2_paired_ends_query),
                     expected_code=requests.codes.ok)
-                self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, expected)
+                self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, 500, expected)
                 next_url = self.get_next_url(search_obj.response.headers['Link'])
                 self.verify_next_url(next_url, per_page)
 
@@ -263,7 +263,7 @@ class TestSearchBase(DSSAssertMixin):
             path=url,
             json_request_body=dict(es_query=smartseq2_paired_ends_query),
             expected_code=requests.codes.ok)
-        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, 10)
+        self.verify_search_result(search_obj.json, smartseq2_paired_ends_query, 20, 10)
         next_url = self.get_next_url(search_obj.response.headers['Link'])
         scroll_id = self.verify_next_url(next_url, 10)
         es_client = ElasticsearchClient.get(logger)
@@ -298,9 +298,10 @@ class TestSearchBase(DSSAssertMixin):
                 url = url.add_query(param, url_params[param])
         return str(url)
 
-    def verify_search_result(self, search_json, es_query, expected_result_length=0):
+    def verify_search_result(self, search_json, es_query, count, expected_result_length=0):
         self.assertDictEqual(search_json['es_query'], es_query)
         self.assertEqual(len(search_json['results']), expected_result_length)
+        self.assertEqual(search_json['count'], count)
 
     def verify_bundles(self, found_bundles, expected_bundles):
         result_bundles = [(hit['bundle_id'], hit['bundle_url'])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -298,10 +298,10 @@ class TestSearchBase(DSSAssertMixin):
                 url = url.add_query(param, url_params[param])
         return str(url)
 
-    def verify_search_result(self, search_json, es_query, count, expected_result_length=0):
+    def verify_search_result(self, search_json, es_query, total_hits, expected_result_length=0):
         self.assertDictEqual(search_json['es_query'], es_query)
         self.assertEqual(len(search_json['results']), expected_result_length)
-        self.assertEqual(search_json['count'], count)
+        self.assertEqual(search_json['total_hits'], total_hits)
 
     def verify_bundles(self, found_bundles, expected_bundles):
         result_bundles = [(hit['bundle_id'], hit['bundle_url'])


### PR DESCRIPTION
Search will now return the `count` which is equal to the number of results matching the `es_query`. The search testcase have been updated to check the total count is equal to number of documents indexed.