### PR TITLE
Allow users of the URLBuilder API to set the query.

### DIFF
--- a/dss/util/__init__.py
+++ b/dss/util/__init__.py
@@ -1,4 +1,4 @@
-from urllib.parse import SplitResult, parse_qs, urlencode, urlparse, urlunsplit
+from urllib.parse import SplitResult, urlencode, urlunsplit
 
 import typing
 
@@ -26,7 +26,13 @@ class UrlBuilder:
         self.splitted = SplitResult("", "", "", "", "")
         self.query = list()
 
-    def set(self, scheme: str=None, netloc: str=None, path: str=None, fragment: str=None) -> "UrlBuilder":
+    def set(
+            self,
+            scheme: str=None,
+            netloc: str=None,
+            path: str=None,
+            query: typing.Sequence[typing.Tuple[str, str]]=None,
+            fragment: str=None) -> "UrlBuilder":
         kwargs = dict()
         if scheme is not None:
             kwargs['scheme'] = scheme
@@ -34,11 +40,20 @@ class UrlBuilder:
             kwargs['netloc'] = netloc
         if path is not None:
             kwargs['path'] = path
+        if query is not None:
+            self.query = query
         if fragment is not None:
             kwargs['fragment'] = fragment
         self.splitted = self.splitted._replace(**kwargs)
 
         return self
+
+    def has_query(self, needle_query_name: str) -> bool:
+        """Returns True iff the URL being constructed has a query field with name `needle_query_name`."""
+        for query_name, _ in self.query:
+            if query_name == needle_query_name:
+                return True
+        return False
 
     def add_query(self, query_name: str, query_value: str) -> "UrlBuilder":
         self.query.append((query_name, query_value))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,12 +7,14 @@ import unittest
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
+from dss.util import UrlBuilder
 from dss.util.aws import ARN, get_s3_chunk_size
-from tests import infra
+from tests.infra import logging
 
-infra.start_verbose_logging()
+logging.start_verbose_logging()
 
-class TestUtils(unittest.TestCase):
+
+class TestAwsUtils(unittest.TestCase):
     def test_aws_utils(self):
         arn = ARN(service="sns", resource="my_topic")
         arn.get_region()
@@ -26,6 +28,55 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(get_s3_chunk_size(10000 * 65 * 1024 * 1024 - 1), 65 * 1024 * 1024)
         self.assertEqual(get_s3_chunk_size(10000 * 65 * 1024 * 1024 + 0), 65 * 1024 * 1024)
         self.assertEqual(get_s3_chunk_size(10000 * 65 * 1024 * 1024 + 1), 66 * 1024 * 1024)
+
+
+class TestUrlBuilder(unittest.TestCase):
+    def test_simple(self):
+        builder = UrlBuilder().set(
+            scheme="https",
+            netloc="humancellatlas.org",
+            path="/abc",
+            query=[
+                ("ghi", "1"),
+                ("ghi", "2"),
+            ],
+            fragment="def")
+        self.assertEqual("https://humancellatlas.org/abc?ghi=1&ghi=2#def", str(builder))
+
+    def test_has_query(self):
+        builder = UrlBuilder().set(
+            scheme="https",
+            netloc="humancellatlas.org",
+            path="/abc",
+            query=[
+                ("ghi", "1"),
+                ("ghi", "2"),
+            ],
+            fragment="def")
+        self.assertTrue(builder.has_query("ghi"))
+        self.assertFalse(builder.has_query("abc"))
+
+    def test_add_query(self):
+        builder = UrlBuilder().set(
+            scheme="https",
+            netloc="humancellatlas.org",
+            path="/abc",
+            query=[
+                ("ghi", "1"),
+                ("ghi", "2"),
+            ],
+            fragment="def")
+        self.assertTrue(builder.has_query("ghi"))
+        self.assertFalse(builder.has_query("abc"))
+
+        self.assertEqual("https://humancellatlas.org/abc?ghi=1&ghi=2#def", str(builder))
+
+        builder.add_query("abc", "3")
+        self.assertTrue(builder.has_query("ghi"))
+        self.assertTrue(builder.has_query("abc"))
+
+        self.assertEqual("https://humancellatlas.org/abc?ghi=1&ghi=2&abc=3#def", str(builder))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also adds a `has_query()` method, which returns True if there's a query field with a given name.
