### PR TITLE
parallel make test should not intermix output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - export PATH=$(pwd)/make4/usr/bin:$PATH
 script:
 - set -eo pipefail
-- make -j4 test
+- make -j4 -O test
 - if [[ $TRAVIS_BRANCH == staging ]]; then source environment.staging; fi
 - if [[ $TRAVIS_EVENT_TYPE == cron ]]; then make smoketest; fi
 after_success:


### PR DESCRIPTION
Use the -O mode, which buffers output and groups it by process.
