### PR TITLE
Be more patient with test requests.

### DIFF
--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -55,6 +55,7 @@ class ThreadedLocalServer(threading.Thread):
         return method(
             f"http://localhost:{self._port}{path}",
             allow_redirects=False,
+            timeout=(1.0, 30.0),
             **kwargs)
 
     def __getattr__(self, name):


### PR DESCRIPTION
Since our execution can theoretically take up to 30s, let's be patient about responding.

### Test plan
Test no longer spews out errors about requests timing out.  It fails for other reasons now!