### PR TITLE
Corrected quoting of jq command in smoketest.py

### DIFF
--- a/tests/smoketest.py
+++ b/tests/smoketest.py
@@ -54,7 +54,7 @@ bundle_dir = "data-bundle-examples/10X_v2/pbmc8k"
 with open(os.path.join(bundle_dir, "async_copied_file"), "wb") as fh:
     fh.write(os.urandom(ASYNC_COPY_THRESHOLD + 1))
 
-run(f"cat {bundle_dir}/sample.json | jq .uuid=\"{sample_id}\" | sponge {bundle_dir}/sample.json")
+run(f"cat {bundle_dir}/sample.json | jq .uuid=\\\"{sample_id}\\\" | sponge {bundle_dir}/sample.json")
 run(f"hca dss upload --replica aws --staging-bucket $DSS_S3_BUCKET_TEST --file-or-dir {bundle_dir} > upload.json")
 run("hca dss download --replica aws $(jq -r .bundle_uuid upload.json)")
 for i in range(10):


### PR DESCRIPTION
Corrected quoting to resolve the following error occurring during smoketest.py execution, which was indirectly causing smoketest to fail:

jq: error: syntax error, unexpected IDENT, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
.uuid=4ec21a01-46cb-4130-9a1d-2da3c1c85809

### Test plan
This problem was seen in the following Travis cron/smoketest builds:
https://travis-ci.org/HumanCellAtlas/data-store/jobs/286195792
https://travis-ci.org/HumanCellAtlas/data-store/builds/287704452

The fix was verified in a local (UCSC) deployment of the current master branch.