### PR TITLE
Fix timeouts for invocations on the command line.

### DIFF
--- a/chalice/.chalice/config.json
+++ b/chalice/.chalice/config.json
@@ -11,5 +11,6 @@
       "environment_variables": {
       }
     }
-  }
+  },
+  "lambda_timeout": 300
 }

--- a/dss-api
+++ b/dss-api
@@ -36,6 +36,8 @@ factory = CLIFactory(project_dir=args.project_dir, debug=args.debug)
 config = factory.create_config_obj(
     chalice_stage_name=os.environ["DSS_DEPLOYMENT_STAGE"]
 )
+# TODO: Remove this hack when https://github.com/aws/chalice/pull/579 is pulled into our repo.
+config._user_provided_params['lambda_timeout'] = 30000
 app_obj = factory.load_chalice_app()
 # When running `chalice local`, a stdout logger is configured
 # so you'll see the same stdout logging as you would when


### PR DESCRIPTION
When we use the chalice app in tests, we override the timeout.  When we use the chalice app on lambda, the timeout is valid.

However, in the current version of chalice we're using, calling `get_remaining_time_in_millis()` throws an exception when not run in a lambda. 

This diff:

1. Sets the timeout in config.
2. Overrides the timeout set in config due to a chalice bug (see https://github.com/aws/chalice/pull/579)