### PR TITLE
[easy] rename DeploymentStage to BucketConfig

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -19,11 +19,11 @@ from flask import json
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from dss import DeploymentStage, Config, create_app
+from dss import BucketConfig, Config, create_app
 from dss.util import paginate
 
 
-Config.set_config(DeploymentStage.NORMAL)
+Config.set_config(BucketConfig.NORMAL)
 
 
 EXECUTION_TERMINATION_THRESHOLD_SECONDS = 5.0

--- a/daemons/dss-chunked-task/app.py
+++ b/daemons/dss-chunked-task/app.py
@@ -13,7 +13,7 @@ from dss.events.chunkedtask import awsconstants
 
 app = domovoi.Domovoi()
 
-dss.Config.set_config(dss.DeploymentStage.NORMAL)
+dss.Config.set_config(dss.BucketConfig.NORMAL)
 
 expected_client_name = os.getenv("DSS_CHUNKED_TASK_CLIENT_NAME")
 worker_sns_topic = awsconstants.get_worker_sns_topic(expected_client_name)

--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -13,7 +13,7 @@ from dss.events.handlers.index import process_new_s3_indexable_object, process_n
 
 app = domovoi.Domovoi()
 
-dss.Config.set_config(dss.DeploymentStage.NORMAL)
+dss.Config.set_config(dss.BucketConfig.NORMAL)
 
 s3_bucket = dss.Config.get_s3_bucket()
 

--- a/daemons/dss-sync/app.py
+++ b/daemons/dss-sync/app.py
@@ -23,7 +23,7 @@ from dss.util.aws import ARN, send_sns_msg, clients, resources
 
 app = domovoi.Domovoi()
 
-dss.Config.set_config(dss.DeploymentStage.NORMAL)
+dss.Config.set_config(dss.BucketConfig.NORMAL)
 
 s3_bucket = dss.Config.get_s3_bucket()
 

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -24,7 +24,7 @@ from connexion.resolver import RestyResolver
 from connexion.exceptions import OAuthProblem, OAuthResponseProblem, OAuthScopeProblem
 from werkzeug.exceptions import Forbidden
 
-from .config import Config, DeploymentStage, ESIndexType, ESDocType, Replica
+from .config import Config, BucketConfig, ESIndexType, ESDocType, Replica
 from .error import DSSBindingException, DSSException, dss_handler
 
 def get_logger():

--- a/dss/config.py
+++ b/dss/config.py
@@ -12,24 +12,28 @@ from .hcablobstore.s3 import S3HCABlobStore
 from .hcablobstore.gs import GSHCABlobStore
 
 
-class DeploymentStage(Enum):
+class BucketConfig(Enum):
     ILLEGAL = auto()
     NORMAL = auto()
     TEST = auto()
     TEST_FIXTURE = auto()
 
+
 class ESIndexType(Enum):
     docs = auto()
     subscriptions = auto()
+
 
 class ESDocType(Enum):
     doc = auto()  # Metadata docs in the dss-docs index
     query = auto()  # Percolate queries (for event subscriptions) in the dss-docs index
     subscription = auto()  # Event subscriptions in the ds-subscriptions index
 
+
 class Replica(Enum):
     aws = auto()
     gcp = auto()
+
 
 class IndexSuffix:
     '''Creates a test specific index when in test config.'''
@@ -47,14 +51,15 @@ class IndexSuffix:
     def reset(cls):
         cls.name = ''
 
+
 class Config:
     _S3_BUCKET = None  # type: typing.Optional[str]
     _GS_BUCKET = None  # type: typing.Optional[str]
     _ALLOWED_EMAILS = None  # type: typing.Optional[str]
-    _CURRENT_CONFIG = DeploymentStage.ILLEGAL  # type: DeploymentStage
+    _CURRENT_CONFIG = BucketConfig.ILLEGAL  # type: BucketConfig
 
     @staticmethod
-    def set_config(config: DeploymentStage):
+    def set_config(config: BucketConfig):
         Config._clear_cached_bucket_config()
         Config._clear_cached_email_config()
         Config._CURRENT_CONFIG = config
@@ -92,13 +97,13 @@ class Config:
     @staticmethod
     def get_s3_bucket() -> str:
         if Config._S3_BUCKET is None:
-            if Config._CURRENT_CONFIG == DeploymentStage.NORMAL:
+            if Config._CURRENT_CONFIG == BucketConfig.NORMAL:
                 envvar = "DSS_S3_BUCKET"
-            elif Config._CURRENT_CONFIG == DeploymentStage.TEST:
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST:
                 envvar = "DSS_S3_BUCKET_TEST"
-            elif Config._CURRENT_CONFIG == DeploymentStage.TEST_FIXTURE:
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST_FIXTURE:
                 envvar = "DSS_S3_BUCKET_TEST_FIXTURES"
-            elif Config._CURRENT_CONFIG == DeploymentStage.ILLEGAL:
+            elif Config._CURRENT_CONFIG == BucketConfig.ILLEGAL:
                 raise Exception("bucket config not set")
 
             if envvar not in os.environ:
@@ -111,13 +116,13 @@ class Config:
     @staticmethod
     def get_gs_bucket() -> str:
         if Config._GS_BUCKET is None:
-            if Config._CURRENT_CONFIG == DeploymentStage.NORMAL:
+            if Config._CURRENT_CONFIG == BucketConfig.NORMAL:
                 envvar = "DSS_GS_BUCKET"
-            elif Config._CURRENT_CONFIG == DeploymentStage.TEST:
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST:
                 envvar = "DSS_GS_BUCKET_TEST"
-            elif Config._CURRENT_CONFIG == DeploymentStage.TEST_FIXTURE:
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST_FIXTURE:
                 envvar = "DSS_GS_BUCKET_TEST_FIXTURES"
-            elif Config._CURRENT_CONFIG == DeploymentStage.ILLEGAL:
+            elif Config._CURRENT_CONFIG == BucketConfig.ILLEGAL:
                 raise Exception("bucket config not set")
 
             if envvar not in os.environ:
@@ -130,13 +135,13 @@ class Config:
     @staticmethod
     def get_allowed_email_domains() -> str:
         if Config._ALLOWED_EMAILS is None:
-            if Config._CURRENT_CONFIG == DeploymentStage.NORMAL:
+            if Config._CURRENT_CONFIG == BucketConfig.NORMAL:
                 envvar = "DSS_SUBSCRIPTION_AUTHORIZED_DOMAINS"
-            elif Config._CURRENT_CONFIG == DeploymentStage.TEST:
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST:
                 envvar = "DSS_SUBSCRIPTION_AUTHORIZED_DOMAINS_TEST"
-            elif Config._CURRENT_CONFIG == DeploymentStage.TEST_FIXTURE:
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST_FIXTURE:
                 envvar = "DSS_SUBSCRIPTION_AUTHORIZED_DOMAINS_TEST"
-            elif Config._CURRENT_CONFIG == DeploymentStage.ILLEGAL:
+            elif Config._CURRENT_CONFIG == BucketConfig.ILLEGAL:
                 raise Exception("authorized domains config not set")
 
             if envvar not in os.environ:
@@ -150,7 +155,7 @@ class Config:
     def get_es_index_name(index_type: ESIndexType, replica: Replica) -> str:
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
         index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
-        if Config._CURRENT_CONFIG == DeploymentStage.TEST:
+        if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}-{IndexSuffix.name}"
         return index
 
@@ -167,7 +172,7 @@ class Config:
 
 
 @contextmanager
-def override_bucket_config(temp_config: DeploymentStage):
+def override_bucket_config(temp_config: BucketConfig):
     original_config = Config._CURRENT_CONFIG
     Config._clear_cached_bucket_config()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,7 +27,7 @@ class TestApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin, DSSStorageMixin
 
     def setUp(self):
         self.replica = "aws"
-        dss.Config.set_config(dss.DeploymentStage.TEST)
+        dss.Config.set_config(dss.BucketConfig.TEST)
         self.blobstore, _, self.bucket = dss.Config.get_cloud_specific_handles(self.replica)
 
     BUNDLE_FIXTURE = 'fixtures/test_api/bundle'

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -16,7 +16,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss.config import DeploymentStage, Config, override_bucket_config
+from dss.config import BucketConfig, Config, override_bucket_config
 from dss.util import UrlBuilder
 from tests.infra import DSSAssertMixin, DSSUploadMixin, ExpectedErrorFields, get_env
 from tests.infra.server import ThreadedLocalServer
@@ -33,7 +33,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         cls.app.shutdown()
 
     def setUp(self):
-        dss.Config.set_config(dss.DeploymentStage.TEST)
+        dss.Config.set_config(dss.BucketConfig.TEST)
         self.s3_test_fixtures_bucket = get_env("DSS_S3_BUCKET_TEST_FIXTURES")
         self.gs_test_fixtures_bucket = get_env("DSS_GS_BUCKET_TEST_FIXTURES")
 
@@ -50,7 +50,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .add_query("replica", replica)
                   .add_query("version", version))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             resp_obj = self.assertGetResponse(
                 url,
                 requests.codes.ok)
@@ -87,7 +87,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .add_query("version", version)
                   .add_query("directurls", "true"))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             resp_obj = self.assertGetResponse(
                 url,
                 requests.codes.ok)
@@ -199,7 +199,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         url = str(UrlBuilder()
                   .set(path="/v1/bundles/" + bundle_uuid))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertPutResponse(
                 url,
                 requests.codes.bad_request,
@@ -223,7 +223,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .set(path="/v1/bundles/" + bundle_uuid)
                   .add_query("replica", "aws"))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertPutResponse(
                 url,
                 requests.codes.bad_request,
@@ -250,7 +250,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .set(path="/v1/bundles/" + bundle_uuid)
                   .add_query("replica", replica))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertGetResponse(
                 url,
                 requests.codes.not_found,
@@ -265,7 +265,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .add_query("replica", replica)
                   .add_query("version", version))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertGetResponse(
                 url,
                 requests.codes.not_found,

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -15,7 +15,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss.config import DeploymentStage, override_bucket_config
+from dss.config import BucketConfig, override_bucket_config
 from dss.util import UrlBuilder
 from dss.util.aws import AWS_MIN_CHUNK_SIZE
 from tests.fixtures.cloud_uploader import GSUploader, S3Uploader, Uploader
@@ -34,7 +34,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         cls.app.shutdown()
 
     def setUp(self):
-        dss.Config.set_config(dss.DeploymentStage.TEST)
+        dss.Config.set_config(dss.BucketConfig.TEST)
         self.s3_test_fixtures_bucket = get_env("DSS_S3_BUCKET_TEST_FIXTURES")
         self.gs_test_fixtures_bucket = get_env("DSS_GS_BUCKET_TEST_FIXTURES")
         self.s3_test_bucket = get_env("DSS_S3_BUCKET_TEST")
@@ -174,7 +174,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .add_query("replica", replica)
                   .add_query("version", version))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertHeadResponse(
                 url,
                 requests.codes.ok
@@ -198,7 +198,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .add_query("replica", replica)
                   .add_query("version", version))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             resp_obj = self.assertGetResponse(
                 url,
                 requests.codes.found
@@ -230,7 +230,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .set(path="/v1/files/" + file_uuid)
                   .add_query("replica", replica))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             resp_obj = self.assertGetResponse(
                 url,
                 requests.codes.found
@@ -262,7 +262,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .set(path="/v1/files/" + file_uuid)
                   .add_query("replica", replica))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertGetResponse(
                 url,
                 requests.codes.not_found,
@@ -278,7 +278,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .add_query("replica", replica)
                   .add_query("version", version))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertGetResponse(
                 url,
                 requests.codes.not_found,
@@ -297,7 +297,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         url = str(UrlBuilder()
                   .set(path="/v1/files/" + file_uuid))
 
-        with override_bucket_config(DeploymentStage.TEST_FIXTURE):
+        with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertGetResponse(
                 url,
                 requests.codes.bad_request,

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -6,19 +6,16 @@ import io
 import json
 import logging
 import os
-import socket
 import sys
 import threading
 import time
 import unittest
 import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from random import randint
 from typing import Dict
 
 import google.auth
 import google.auth.transport.requests
-import moto
 import requests
 from requests_http_signature import HTTPSignatureAuth
 
@@ -26,7 +23,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss import Config, DeploymentStage
+from dss import Config, BucketConfig
 from dss.config import IndexSuffix
 from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object, notify
 from dss.hcablobstore import BundleMetadata, BundleFileMetadata, FileMetadata
@@ -95,9 +92,9 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         cls.app = ThreadedLocalServer()
         cls.app.start()
         cls.replica = replica
-        Config.set_config(DeploymentStage.TEST_FIXTURE)
+        Config.set_config(BucketConfig.TEST_FIXTURE)
         cls.blobstore, _, cls.test_fixture_bucket = Config.get_cloud_specific_handles(cls.replica)
-        Config.set_config(DeploymentStage.TEST)
+        Config.set_config(BucketConfig.TEST)
         _, _, cls.test_bucket = Config.get_cloud_specific_handles(cls.replica)
         cls.dss_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[cls.replica])
         cls.subscription_index_name = dss.Config.get_es_index_name(dss.ESIndexType.subscriptions,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -59,7 +59,7 @@ class TestSearchBase(DSSAssertMixin):
         cls.app = ThreadedLocalServer()
         cls.app.start()
         cls.replica_name = replica.name
-        dss.Config.set_config(dss.DeploymentStage.TEST)
+        dss.Config.set_config(dss.BucketConfig.TEST)
         cls.dss_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, replica)
         with open(os.path.join(os.path.dirname(__file__), "sample_index_doc.json"), "r") as fh:
             cls.index_document = json.load(fh)
@@ -69,7 +69,7 @@ class TestSearchBase(DSSAssertMixin):
         cls.app.shutdown()
 
     def setUp(self):
-        dss.Config.set_config(dss.DeploymentStage.TEST)
+        dss.Config.set_config(dss.BucketConfig.TEST)
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
         create_elasticsearch_index(self.dss_index_name, logger)
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -58,7 +58,7 @@ class TestSubscriptionsBase(DSSAssertMixin):
     def setUp(self):
         os.environ['DSS_ES_ENDPOINT'] = os.getenv('DSS_ES_ENDPOINT', "localhost")
 
-        dss.Config.set_config(dss.DeploymentStage.TEST)
+        dss.Config.set_config(dss.BucketConfig.TEST)
 
         logger.debug("Setting up Elasticsearch")
         es_client = ElasticsearchClient.get(logger)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -31,7 +31,7 @@ infra.start_verbose_logging()
 
 class TestSyncUtils(unittest.TestCase):
     def setUp(self):
-        dss.Config.set_config(dss.DeploymentStage.TEST)
+        dss.Config.set_config(dss.BucketConfig.TEST)
         self.gs_bucket_name, self.s3_bucket_name = dss.Config.get_gs_bucket(), dss.Config.get_s3_bucket()
         self.logger = logging.getLogger(__name__)
         gcp_key_file = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]


### PR DESCRIPTION
It's actually really BucketConfig, and not DeploymentStage.

I know we once renamed this from BucketConfig to DeploymentStage, but this really has no relationship with the deployment stage, which is controlled by `DSS_DEPLOYMENT_STAGE`.