### PR TITLE
Deployment stage + magic methods to invoke.

### DIFF
--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -24,7 +24,7 @@ from connexion.resolver import RestyResolver
 from connexion.exceptions import OAuthProblem, OAuthResponseProblem, OAuthScopeProblem
 from werkzeug.exceptions import Forbidden
 
-from .config import Config, BucketConfig, ESIndexType, ESDocType, Replica
+from .config import BucketConfig, Config, DeploymentStage, ESIndexType, ESDocType, Replica
 from .error import DSSBindingException, DSSException, dss_handler
 
 def get_logger():

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -13,7 +13,7 @@ from cloud_blobstore import BlobStore, BlobStoreError
 from elasticsearch.helpers import scan
 from requests_http_signature import HTTPSignatureAuth
 
-from dss import Config, ESIndexType, ESDocType, Replica
+from dss import Config, DeploymentStage, ESIndexType, ESDocType, Replica
 from ...util import create_blob_key
 from ...hcablobstore import BundleMetadata, BundleFileMetadata
 from ...util.es import ElasticsearchClient, get_elasticsearch_index
@@ -224,14 +224,14 @@ def notify(subscription_id: str, subscription: dict, bundle_id: str, logger):
     callback_url = subscription['callback_url']
 
     # FIXME wrap all errors in this block with an exception handler
-    if os.environ["DSS_DEPLOYMENT_STAGE"] == "prod":
+    if DeploymentStage.IS_PROD():
         allowed_schemes = {'https'}
     else:
         allowed_schemes = {'https', 'http'}
 
     assert urlparse(callback_url).scheme in allowed_schemes, "Unexpected scheme for callback URL"
 
-    if os.environ["DSS_DEPLOYMENT_STAGE"] == "prod":
+    if DeploymentStage.IS_PROD():
         hostname = urlparse(callback_url).hostname
         for family, socktype, proto, canonname, sockaddr in socket.getaddrinfo(hostname, port=None):
             msg = "Callback hostname resolves to forbidden network"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+Tests for dss.Config
+"""
+
+import os
+import sys
+import unittest
+from contextlib import contextmanager
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from dss.config import DeploymentStage
+
+
+class TestConfig(unittest.TestCase):
+    def test_predicates(self):
+        @contextmanager
+        def override_deployment_stage(stage: DeploymentStage):
+            original_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
+            os.environ["DSS_DEPLOYMENT_STAGE"] = stage.value
+
+            try:
+                yield
+            finally:
+                os.environ["DSS_DEPLOYMENT_STAGE"] = original_stage
+
+        with override_deployment_stage(DeploymentStage.DEV):
+            self.assertTrue(DeploymentStage.IS_DEV())
+            self.assertFalse(DeploymentStage.IS_STAGING())
+            self.assertFalse(DeploymentStage.IS_PROD())
+
+        with override_deployment_stage(DeploymentStage.STAGING):
+            self.assertFalse(DeploymentStage.IS_DEV())
+            self.assertTrue(DeploymentStage.IS_STAGING())
+            self.assertFalse(DeploymentStage.IS_PROD())
+
+        with override_deployment_stage(DeploymentStage.PROD):
+            self.assertFalse(DeploymentStage.IS_DEV())
+            self.assertFalse(DeploymentStage.IS_STAGING())
+            self.assertTrue(DeploymentStage.IS_PROD())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -23,7 +23,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss import Config, BucketConfig
+from dss import Config, BucketConfig, DeploymentStage
 from dss.config import IndexSuffix
 from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object, notify
 from dss.hcablobstore import BundleMetadata, BundleFileMetadata, FileMetadata
@@ -207,7 +207,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
             _notify(subscription=dict(id="", es_query={}, callback_url="wss://localhost"))
         try:
             environ_backup = os.environ
-            os.environ = dict(DSS_DEPLOYMENT_STAGE="prod")
+            os.environ = dict(DSS_DEPLOYMENT_STAGE=DeploymentStage.PROD.value)
             with self.assertRaisesRegex(AssertionError, "Unexpected scheme for callback URL"):
                 _notify(subscription=dict(id="", es_query={}, callback_url="http://example.com"))
             with self.assertRaisesRegex(AssertionError, "Callback hostname resolves to forbidden network"):


### PR DESCRIPTION
If we don't nip this in the bud, we'll have the codebase littered with `os.environ["DSS_DEPLOYMENT_STAGE"] == "ababab"` and that would be awful.

Depends on #561 