### PR TITLE
Specific error condition/code for missing files.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -660,6 +660,27 @@ paths:
                 format: date-time
             required:
               - version
+        409:
+          description: Unexpected error
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: |
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+
+                      The code `bundle_already_exists` indicates that the bundle+version already exists, and has
+                      different contents than this request would generate.
+
+                      The code `file_missing` indicates that one of the files does not exist on the cloud provider.
+                      Because the storage backend only guarantees eventual consistency, it may be desirable to retry
+                      requests that return this error code.
+                    enum: [bundle_already_exists, file_missing]
+                required:
+                  - code
         default:
           description: Unexpected error
           schema:

--- a/dss/api/bundles.py
+++ b/dss/api/bundles.py
@@ -111,7 +111,15 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str=None):
     for file in files:
         user_supplied_metadata = file['user_supplied_metadata']
         metadata_path = 'files/{}.{}'.format(user_supplied_metadata['uuid'], user_supplied_metadata['version'])
-        file['file_metadata'] = json.loads(handle.get(bucket, metadata_path))
+        try:
+            file_metadata = handle.get(bucket, metadata_path)
+        except BlobNotFoundError:
+            raise DSSException(
+                requests.codes.conflict,
+                "file_missing",
+                f"Could not find file {user_supplied_metadata['uuid']}/{user_supplied_metadata['version']}."
+            )
+        file['file_metadata'] = json.loads(file_metadata)
 
     # TODO: (ttung) should validate the files' bundle UUID points back at us.
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -158,6 +158,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
         bundle_uuid = str(uuid.uuid4())
         file_uuid = str(uuid.uuid4())
+        missing_file_uuid = str(uuid.uuid4())
         resp_obj = self.upload_file_wait(
             f"{schema}://{fixtures_bucket}/test_good_source_data/0",
             replica,
@@ -189,6 +190,17 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             bundle_version,
             requests.codes.conflict,
         )
+
+        # should *NOT* be able to upload a bundle with a missing file, but we should get requests.codes.conflict.
+        resp_obj = upload_bundle(
+            bundle_uuid,
+            [
+                (file_uuid, file_version, "LICENSE0"),
+                (missing_file_uuid, file_version, "LICENSE1"),
+            ],
+            expected_code=requests.codes.conflict,
+        )
+        self.assertEqual(resp_obj.json['code'], "file_missing")
 
     def test_no_replica(self):
         """


### PR DESCRIPTION
There's no way we can know if the missing file is due to race conditions or not, but we code a specific error so clients can retry in this scenario.

Also improve the existing documentation for 409 CONFLICT (previously nonexistent, of course).

Connects to #464
