### PR TITLE
size metadata written on file/bundle put

### DIFF
--- a/dss/api/bundles.py
+++ b/dss/api/bundles.py
@@ -125,6 +125,7 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str=None):
                 BundleFileMetadata.UUID: file['user_supplied_metadata']['uuid'],
                 BundleFileMetadata.VERSION: file['user_supplied_metadata']['version'],
                 BundleFileMetadata.CONTENT_TYPE: file['file_metadata'][FileMetadata.CONTENT_TYPE],
+                BundleFileMetadata.SIZE: file['file_metadata'][FileMetadata.SIZE],
                 BundleFileMetadata.INDEXED: file['user_supplied_metadata']['indexed'],
                 BundleFileMetadata.CRC32C: file['file_metadata'][FileMetadata.CRC32C],
                 BundleFileMetadata.S3_ETAG: file['file_metadata'][FileMetadata.S3_ETAG],

--- a/dss/hcablobstore/__init__.py
+++ b/dss/hcablobstore/__init__.py
@@ -43,13 +43,14 @@ class HCABlobStore:
 
 
 class FileMetadata:
-    FILE_FORMAT_VERSION = "0.0.2"
+    FILE_FORMAT_VERSION = "0.0.3"
 
     FORMAT = "format"
     BUNDLE_UUID = "bundle_uuid"
     CREATOR_UID = "creator_uid"
     VERSION = "version"
     CONTENT_TYPE = "content-type"
+    SIZE = "size"
     CRC32C = "crc32c"
     S3_ETAG = "s3-etag"
     SHA1 = "sha1"
@@ -70,6 +71,7 @@ class BundleFileMetadata:
     UUID = "uuid"
     VERSION = "version"
     CONTENT_TYPE = "content-type"
+    SIZE = "size"
     INDEXED = "indexed"
     CRC32C = "crc32c"
     S3_ETAG = "s3-etag"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ chalice==1.0.3
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==0.0.3
+cloud-blobstore==0.0.4
 colorama==0.3.7
 connexion==1.1.15
 cookies==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ chained-aws-lambda==0.0.7
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==0.0.3
+cloud-blobstore==0.0.4
 connexion==1.1.15
 cryptography==2.0.3
 docutils==0.14


### PR DESCRIPTION
Lookup size during file/bundle put.

Backward compatible size metadata on write path.
Read path to come later.
Expects get_size() from cloud_blobstore.

Connects to #471

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
Unit tests after read/write path finished.

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->