### PR TITLE
Updated test_indexer to reset test notification handler between uses

### DIFF
--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -243,6 +243,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
             prefix, _, bundle_id = bundle_key.partition("/")
             self.verify_notification(subscription_id, smartseq2_paired_ends_query, bundle_id)
             self.delete_subscription(subscription_id)
+            PostTestHandler.reset()
 
     def test_subscription_notification_unsuccessful(self):
         PostTestHandler.verify_payloads = True


### PR DESCRIPTION
Updated test_indexer.test_subscription_notification_successful to
reset the notification test handler between notifications within the same test.
See issue #580 for details.
Fixes #580.