### PR TITLE
Corrected CLI option in smoketest

### DIFF
--- a/tests/smoketest.py
+++ b/tests/smoketest.py
@@ -69,7 +69,7 @@ else:
 run("hca dss download --replica gcp $(jq -r .bundle_uuid upload.json)")
 
 for replica in "aws", "gcp":
-    run(f"hca dss post-search --es-query='{{}}' --output_format raw --replica {replica} > /dev/null")
+    run(f"hca dss post-search --es-query='{{}}' --output-format raw --replica {replica} > /dev/null")
 
 search_route = "https://${API_HOST}/v1/search"
 for replica in "aws", "gcp":


### PR DESCRIPTION
Corrected hca option use in smoketest.py that was causing this test to fail.
This failure may be seen in Travis build: https://travis-ci.org/HumanCellAtlas/data-store/builds/292794550

### Test plan
This failure was reproduced and the fix was verified using a deployment of the current master branch at UCSC.