### PR TITLE
Add the parallel copy supervisor to the list of chained-aws-lambda clients we enable.

### DIFF
--- a/daemons/Makefile
+++ b/daemons/Makefile
@@ -13,7 +13,7 @@ dss-sync dss-index:
 	    ../tests/daemons/sample_s3_bundle_created_event.json.template \
 	    ../tests/daemons/a47b90b2-0967-4fbf-87bc-c6c12db3fedf.2017-07-12T055120.037644Z; \
 
-chainedawslambdatargets := chained-aws-lambda-s3-parallel-copy-worker
+chainedawslambdatargets := chained-aws-lambda-s3-parallel-copy-supervisor chained-aws-lambda-s3-parallel-copy-worker
 dsschainedawslambdatargets := dss-s3-copy-write-metadata
 chained-aws-lambda: $(chainedawslambdatargets) $(dsschainedawslambdatargets)
 
@@ -21,9 +21,10 @@ $(chainedawslambdatargets): chained-aws-lambda-%:
 	rm -rf $@
 	cp -rf chained-aws-lambda $@
 	chained_aws_lambda.py '$$account_id' \
+	  --enable-s3-parallel-copy-supervisor --s3-parallel-copy-supervisor-lambda-name chained-aws-lambda-s3-parallel-copy-supervisor-$(DSS_DEPLOYMENT_STAGE) \
 	  --enable-s3-parallel-copy-worker --s3-parallel-copy-worker-lambda-name chained-aws-lambda-s3-parallel-copy-worker-$(DSS_DEPLOYMENT_STAGE) \
-	  --s3-parallel-copy-worker-policy-path $@/policy.json.template \
-	  --s3-parallel-copy-worker-app-path $@/app.py
+	  --$*-policy-path $@/policy.json.template \
+	  --$*-app-path $@/app.py
 
 	cat chained-aws-lambda/.chalice/config.json | jq '.app_name="$@"' > $@/.chalice/config.json
 	# blindly enable access to our test S3 bucket.  This is ok since most daemons require it anyway.

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -13,6 +13,7 @@ import traceback
 
 import chainedawslambda
 import chainedawslambda.aws
+import chainedawslambda.s3copyclient
 import flask
 import requests
 import connexion.apis.abstract
@@ -189,6 +190,8 @@ def chained_lambda_clients() -> typing.Iterable[typing.Tuple[str, typing.Type[ch
 
     deployment_stage = os.getenv("DSS_DEPLOYMENT_STAGE")
     return (
+        (s3copyclient.AWS_S3_COPY_CLIENT_PREFIX + deployment_stage,
+         chainedawslambda.s3copyclient.S3ParallelCopySupervisorTask),
         (s3copyclient.AWS_S3_COPY_AND_WRITE_METADATA_CLIENT_PREFIX + deployment_stage,
          s3copyclient.S3CopyWriteBundleTask),
     )

--- a/dss/events/chunkedtask/s3copyclient.py
+++ b/dss/events/chunkedtask/s3copyclient.py
@@ -8,6 +8,7 @@ from chainedawslambda.s3copyclient import S3CopyTask, S3ParallelCopySupervisorTa
 from ...api import files
 
 # this must match the lambda name in daemons/Makefile
+AWS_S3_COPY_CLIENT_PREFIX = "chained-aws-lambda-s3-parallel-copy-supervisor-"
 AWS_S3_COPY_AND_WRITE_METADATA_CLIENT_PREFIX = "dss-s3-copy-write-metadata-"
 
 


### PR DESCRIPTION
Roman needs this for the checkout service.
