### PR TITLE
close the test connection.

### DIFF
--- a/tests/test_standalone_script.py
+++ b/tests/test_standalone_script.py
@@ -5,6 +5,7 @@
 Test that the standalone can start up and answer a request.
 """
 
+import contextlib
 import os
 import socket
 import subprocess
@@ -41,7 +42,8 @@ class TestStandaloneScript(unittest.TestCase):
         delay = 0.05
         while time.time() < end_time:
             try:
-                socket.create_connection(("127.0.0.1", cls.port))
+                with contextlib.closing(socket.create_connection(("127.0.0.1", cls.port))):
+                    pass
                 break
             except ConnectionError:
                 delay = max(1.0, delay * 2)


### PR DESCRIPTION
For reasons unclear to me, the standalone test is now failing without this.  It appears that it is waiting for the test connection to make its request, and that never happens, and it does not answer subsequent requests.
