### PR TITLE
Use the cloud-native content-type attached to the src data blob.

### DIFF
--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -130,6 +130,7 @@ def put(uuid: str, json_request_body: dict, version: str=None):
 
     metadata = handle.get_user_metadata(src_bucket, src_object_name)
     size = handle.get_size(src_bucket, src_object_name)
+    content_type = handle.get_content_type(src_bucket, src_object_name)
 
     # format all the checksums so they're lower-case.
     for metadata_spec in HCABlobStore.MANDATORY_METADATA.values():
@@ -161,7 +162,7 @@ def put(uuid: str, json_request_body: dict, version: str=None):
         FileMetadata.BUNDLE_UUID: json_request_body['bundle_uuid'],
         FileMetadata.CREATOR_UID: json_request_body['creator_uid'],
         FileMetadata.VERSION: version,
-        FileMetadata.CONTENT_TYPE: metadata['hca-dss-content-type'],
+        FileMetadata.CONTENT_TYPE: content_type,
         FileMetadata.SIZE: size,
         FileMetadata.CRC32C: metadata['hca-dss-crc32c'],
         FileMetadata.S3_ETAG: metadata['hca-dss-s3_etag'],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ chalice==1.0.3
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==0.0.4
+cloud-blobstore==0.0.5
 colorama==0.3.7
 connexion==1.1.15
 cookies==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ chained-aws-lambda==0.0.7
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==0.0.4
+cloud-blobstore==0.0.5
 connexion==1.1.15
 cryptography==2.0.3
 docutils==0.14

--- a/tests/fixtures/populate_lib.py
+++ b/tests/fixtures/populate_lib.py
@@ -13,22 +13,18 @@ def upload(uploader: Uploader):
     uploader.checksum_and_upload_file(
         "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
         "test_good_source_data/0",
-        {
-            "hca-dss-content-type": "text/plain",
-        }
+        "text/plain",
     )
     uploader.checksum_and_upload_file(
         "9cdc9050cecf59381fed55a2433140b69596fc861bee55abeafd1f9150f3e2da",
         "test_good_source_data/1",
-        {
-            "hca-dss-content-type": "text/plain",
-        }
+        "text/plain",
     )
     uploader.upload_file(
         "9cdc9050cecf59381fed55a2433140b69596fc861bee55abeafd1f9150f3e2da",
         "test_good_source_data/incorrect_case_checksum",
+        "text/plain",
         {
-            "hca-dss-content-type": "text/plain",
             "hca-dss-crc32c": "114DEE2C",
             "hca-dss-s3_etag": "7F54939B30AE7B6D45D473A4C82A41B0",
             "hca-dss-sha1": "15684690E8132044F378B4D4AF8A7331C8DA17B1",
@@ -38,12 +34,12 @@ def upload(uploader: Uploader):
 
     if isinstance(uploader, S3Uploader):
         # s3 has an extra test for merging tags and metadata...
-        uploader.upload_file(
+        typing.cast(S3Uploader, uploader).upload_file(
             "9cdc9050cecf59381fed55a2433140b69596fc861bee55abeafd1f9150f3e2da",
             "test_good_source_data/metadata_in_tags",
+            "text/plain",
             {},
             {
-                "hca-dss-content-type": "text/plain",
                 "hca-dss-crc32c": "114dee2c",
                 "hca-dss-s3_etag": "7f54939b30ae7b6d45d473a4c82a41b0",
                 "hca-dss-sha1": "15684690e8132044f378b4d4af8a7331c8da17b1",
@@ -55,8 +51,8 @@ def upload(uploader: Uploader):
     uploader.upload_file(
         "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
         "test_bad_source_data/incorrect_checksum",
+        "text/plain",
         {
-            "hca-dss-content-type": "text/plain",
             "hca-dss-crc32c": "07b9e16e",
             "hca-dss-s3_etag": "55fc854ddc3c6bd573b83ef96387f146",
             "hca-dss-sha1": "fb4ba0588b8b6c4918902b8b815229aa8a61e483",
@@ -109,9 +105,7 @@ def upload(uploader: Uploader):
         uploader.checksum_and_upload_file(
             f"test_api/{fname}",
             f"fixtures/test_api/bundle/{fname}",
-            {
-                "hca-dss-content-type": "application/javascript",
-            },
+            "application/json",
         )
 
     # Create a bundle based on data-bundle-examples/smartseq2/paired_ends.
@@ -126,9 +120,7 @@ def upload(uploader: Uploader):
             uploader.checksum_and_upload_file(
                 f"{source_path}/{fname}",
                 f"{target_path}/{fname}",
-                {
-                    "hca-dss-content-type": "application/json",
-                },
+                "application/json",
             )
 
     # Create a bundle based on data-bundle-examples/smartseq2/paired_ends.
@@ -139,9 +131,7 @@ def upload(uploader: Uploader):
         uploader.checksum_and_upload_file(
             f"indexing/{fname}",
             f"{target_path}/{fname}",
-            {
-                "hca-dss-content-type": "text/plain",
-            },
+            "text/plain",
         )
 
     # Create an index test bundle that includes a file of with content-type
@@ -156,9 +146,7 @@ def upload(uploader: Uploader):
     uploader.checksum_and_upload_file(
         f"indexing/{fname}",
         f"{target_path}/{fname}",
-        {
-            "hca-dss-content-type": "application/json",
-        },
+        "application/json",
     )
 
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -53,8 +53,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             fh.write(src_data)
             fh.flush()
 
-            uploader.checksum_and_upload_file(
-                fh.name, src_key, {"hca-dss-content-type": "text/plain", })
+            uploader.checksum_and_upload_file(fh.name, src_key, "text/plain")
 
         source_url = f"{scheme}://{test_bucket}/{src_key}"
 
@@ -85,8 +84,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             fh.write(src_data)
             fh.flush()
 
-            uploader.checksum_and_upload_file(
-                fh.name, src_key, {"hca-dss-content-type": "text/plain", })
+            uploader.checksum_and_upload_file(fh.name, src_key, "text/plain")
 
         # should be able to do this twice (i.e., same payload, different UUIDs).  first time should be asynchronous
         # since it's new data.  second time should be synchronous since the data is present.
@@ -295,8 +293,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             fh.write(src_data)
             fh.flush()
 
-            uploader.checksum_and_upload_file(
-                fh.name, src_key, {"hca-dss-content-type": "text/plain", })
+            uploader.checksum_and_upload_file(fh.name, src_key, "text/plain")
 
         source_url = f"{scheme}://{test_bucket}/{src_key}"
 


### PR DESCRIPTION
This removes the usage of the hca-dss-content-type field.

Connects to #605 

### Test plan
Tested by populating test fixtures buckets and running `DSS_GS_BUCKET_TEST_FIXTURES=org-humancellatlas-dss-test-fixtures-ttung DSS_S3_BUCKET_TEST_FIXTURES=org-humancellatlas-dss-test-fixtures-ttung make tests/test_file.py`.

The travis run is likely to fail, unfortunately, until I run this on the main test fixtures bucket.