### PR TITLE
spin-loop for PUT /bundles on missing file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ chalice==1.0.3
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==0.0.5
+cloud-blobstore==0.0.6
 colorama==0.3.7
 connexion==1.1.15
 cookies==2.2.1
@@ -48,6 +48,7 @@ mccabe==0.6.1
 mock==2.0.0
 moto==1.1.21
 mypy==0.530
+nestedcontext==0.0.4
 pbr==3.1.1
 protobuf==3.4.0
 pyaml==17.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ chained-aws-lambda==0.0.7
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==0.0.5
+cloud-blobstore==0.0.6
 connexion==1.1.15
 cryptography==2.0.3
 docutils==0.14
@@ -32,6 +32,7 @@ Jinja2==2.9.6
 jmespath==0.9.3
 jsonschema==2.6.0
 MarkupSafe==1.0
+nestedcontext==0.0.4
 protobuf==3.4.0
 pyasn1==0.3.7
 pyasn1-modules==0.1.4

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -8,6 +8,7 @@ elasticsearch
 elasticsearch_dsl
 google-cloud-storage
 iso8601
+nestedcontext
 requests_aws4auth
 urllib3
 requests-http-signature

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -3,13 +3,17 @@
 
 import datetime
 import hashlib
+import io
 import os
 import sys
+import time
+import threading
 import typing
 import unittest
 import urllib.parse
 import uuid
 
+import nestedcontext
 import requests
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
@@ -193,15 +197,50 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         )
 
         # should *NOT* be able to upload a bundle with a missing file, but we should get requests.codes.conflict.
-        resp_obj = upload_bundle(
-            bundle_uuid,
-            [
-                (file_uuid, file_version, "LICENSE0"),
-                (missing_file_uuid, file_version, "LICENSE1"),
-            ],
-            expected_code=requests.codes.conflict,
+        with nestedcontext.bind(time_left=lambda: 0):
+            resp_obj = upload_bundle(
+                bundle_uuid,
+                [
+                    (file_uuid, file_version, "LICENSE0"),
+                    (missing_file_uuid, file_version, "LICENSE1"),
+                ],
+                expected_code=requests.codes.conflict,
+            )
+            self.assertEqual(resp_obj.json['code'], "file_missing")
+
+        # uploads a file, but delete the file metadata.  put it back after a delay.
+        self.upload_file_wait(
+            f"{schema}://{fixtures_bucket}/test_good_source_data/0",
+            replica,
+            missing_file_uuid,
+            file_version,
+            bundle_uuid=bundle_uuid
         )
-        self.assertEqual(resp_obj.json['code'], "file_missing")
+        handle, _, bucket = Config.get_cloud_specific_handles(replica)
+        file_metadata = handle.get(bucket, f"files/{missing_file_uuid}.{file_version}")
+        handle.delete(bucket, f"files/{missing_file_uuid}.{file_version}")
+
+        class UploadThread(threading.Thread):
+            def run(innerself):
+                time.sleep(5)
+                data_fh = io.BytesIO(file_metadata)
+                handle.upload_file_handle(bucket, f"files/{missing_file_uuid}.{file_version}", data_fh)
+        # start the upload (on a delay...)
+        upload_thread = UploadThread()
+        upload_thread.start()
+
+        # this should at first fail to find one of the files, but the UploadThread will eventually upload the file
+        # metadata.  since we give the upload bundle process ample time to spin, it should eventually find the file
+        # metadata and succeed.
+        with nestedcontext.bind(time_left=lambda: sys.maxsize):
+            upload_bundle(
+                bundle_uuid,
+                [
+                    (file_uuid, file_version, "LICENSE0"),
+                    (missing_file_uuid, file_version, "LICENSE1"),
+                ],
+                expected_code=requests.codes.created,
+            )
 
     def test_no_replica(self):
         """


### PR DESCRIPTION
We've observed that there are race conditions on S3 where a `PUT /files` has completed but the metadata files are not available on the subsequent `PUT /bundles` request.  We added logic to make it easier for the client to identify this situation (and retry) in #566, but it is desirable to attempt the retry on the server as well.

Connects to #464

### Test plan
Verified that the existing paths still work.

Added test that sets up a missing file, starts a `PUT /bundles` request, and then uploads the missing file.