### PR TITLE
New indexes are alias when created and access by alias name.

### DIFF
--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -107,7 +107,7 @@ def _es_search_page(es_query: dict,
     # }
     sort = {"sort": ["_doc"]}
     if _scroll_id is None:
-        page = es_client.search(index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
+        page = es_client.search(index=Config.get_es_alias_name(ESIndexType.docs, Replica[replica]),
                                 doc_type=ESDocType.doc.name,
                                 scroll=scroll,
                                 size=per_page,

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -18,7 +18,7 @@ from werkzeug.exceptions import BadRequest
 from .. import Config, Replica, ESIndexType, ESDocType, get_logger
 from ..error import DSSException, dss_handler
 from ..hcablobstore import FileMetadata, HCABlobStore
-from ..util.es import ElasticsearchClient, get_elasticsearch_index
+from ..util.es import ElasticsearchClient, get_elasticsearch_subscription_index
 
 logger = get_logger()
 
@@ -94,7 +94,7 @@ def put(json_request_body: dict, replica: str):
     # john@example.com would show up because elasticsearch matched example w/ example.
     # By including "index": "not_analyzed", Elasticsearch leaves all owner inputs alone.
     index_name = Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica])
-    get_elasticsearch_index(es_client, index_name, logger, index_mapping)
+    get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping)
 
     try:
         percolate_registration = _register_percolate(es_client, uuid, es_query, replica)

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -94,9 +94,9 @@ def put(json_request_body: dict, replica: str):
     # john@example.com would show up because elasticsearch matched example w/ example.
     # By including "index": "not_analyzed", Elasticsearch leaves all owner inputs alone.
     index_name = Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica])
-    #  TODO: get all indexes that use current alais
-    #  TODO: try to subscribe query to each of the indexes.
-    #  TODO: error if no queries are indexed.
+    #  TODO (tsmith): get all indexes that use current alais
+    #  TODO (tsmith): try to subscribe query to each of the indexes.
+    #  TODO (tsmith): error if no queries are indexed.
     get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping)
 
     try:

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -94,6 +94,9 @@ def put(json_request_body: dict, replica: str):
     # john@example.com would show up because elasticsearch matched example w/ example.
     # By including "index": "not_analyzed", Elasticsearch leaves all owner inputs alone.
     index_name = Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica])
+    #  TODO: get all indexes that use current alais
+    #  TODO: try to subscribe query to each of the indexes.
+    #  TODO: error if no queries are indexed.
     get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping)
 
     try:

--- a/dss/config.py
+++ b/dss/config.py
@@ -177,7 +177,16 @@ class Config:
 
     @staticmethod
     def get_es_index_name(index_type: ESIndexType, replica: Replica) -> str:
-        """Returns the index name or the alias for indexes"""
+        """Returns the index name"""
+        deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
+        index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
+        if Config._CURRENT_CONFIG == BucketConfig.TEST:
+            index = f"{index}.{IndexSuffix.name}"
+        return index
+
+    @staticmethod
+    def get_es_alias_name(index_type: ESIndexType, replica: Replica) -> str:
+        """Returns the alias for indexes"""
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
         index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:

--- a/dss/config.py
+++ b/dss/config.py
@@ -176,10 +176,14 @@ class Config:
         return Config._ALLOWED_EMAILS
 
     @staticmethod
-    def get_es_index_name(index_type: ESIndexType, replica: Replica) -> str:
+    def get_es_index_name(index_type: ESIndexType, replica: Replica,
+                          version: typing.Optional[str] = None
+                          ) -> str:
         """Returns the index name"""
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
         index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
+        if version:
+            index = f"{index}-{version}"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/dss/config.py
+++ b/dss/config.py
@@ -177,6 +177,7 @@ class Config:
 
     @staticmethod
     def get_es_index_name(index_type: ESIndexType, replica: Replica) -> str:
+        """Returns the index name or the alias for indexes"""
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
         index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:

--- a/dss/config.py
+++ b/dss/config.py
@@ -178,7 +178,7 @@ class Config:
     @staticmethod
     def get_es_index_name(index_type: ESIndexType, replica: Replica) -> str:
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
-        index = '-'.join(['dss', index_type.name, replica.name, deployment_stage])
+        index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/dss/config.py
+++ b/dss/config.py
@@ -178,9 +178,9 @@ class Config:
     @staticmethod
     def get_es_index_name(index_type: ESIndexType, replica: Replica) -> str:
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
-        index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}"
+        index = '-'.join(['dss', index_type.name, replica.name, deployment_stage])
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
-            index = f"{index}-{IndexSuffix.name}"
+            index = f"{index}.{IndexSuffix.name}"
         return index
 
     @staticmethod

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -132,7 +132,6 @@ def get_bundle_id_from_key(bundle_key: str) -> str:
 
 def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, alias_name: str, logger) -> None:
     #  TODO (tsmith): get the major version from index data.
-    #  version = index_data['manifest']['format'].split('.')[0]
     version = '1'
     #  create the elasticsearch index name from alias
     name, doc_type, replica, deployment = alias_name.split('-')

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -131,7 +131,7 @@ def get_bundle_id_from_key(bundle_key: str) -> str:
 
 
 def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, index_alias: str, logger) -> None:
-    #  TODO: get the major version from index data.
+    #  TODO (tsmith): get the major version from index data.
     #  version = index_data['manifest']['format'].split('.')[0]
     version = 1
     #  create the elasticsearch index name from alias

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -16,7 +16,7 @@ from requests_http_signature import HTTPSignatureAuth
 from dss import Config, DeploymentStage, ESIndexType, ESDocType, Replica
 from ...util import create_blob_key
 from ...hcablobstore import BundleMetadata, BundleFileMetadata
-from ...util.es import ElasticsearchClient, get_elasticsearch_bundle_index
+from ...util.es import ElasticsearchClient, get_elasticsearch_doc_index
 
 DSS_BUNDLE_KEY_REGEX = r"^bundles/[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\..+$"
 
@@ -148,7 +148,7 @@ def create_elasticsearch_index(index_name, alias_name, logger):
             index_mapping = json.load(fh)
         index_mapping["mappings"][ESDocType.doc.name] = index_mapping["mappings"].pop("doc")
         index_mapping["mappings"][ESDocType.query.name] = index_mapping["mappings"].pop("query")
-        get_elasticsearch_bundle_index(ElasticsearchClient.get(logger), index_name, alias_name, logger, index_mapping)
+        get_elasticsearch_doc_index(ElasticsearchClient.get(logger), index_name, alias_name, logger, index_mapping)
     else:
         logger.debug(f"Using existing Elasticsearch index: {index_name}")
 

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -131,9 +131,9 @@ def get_bundle_id_from_key(bundle_key: str) -> str:
 
 
 def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, index_alias: str, logger) -> None:
-    #  TODO: get the major version from the index.
-    #  TODO: create the elasticsearch index name.
+    #  get the major version from index data.
     version = index_data['manifest']['format'].split('.')[0]
+    #  create the elasticsearch index name from alias
     name, doc_type, replica, deployment = index_alias.split('-')
     index_name = '-'.join([name, doc_type, replica, version, deployment])
     create_elasticsearch_index(index_name, index_alias, logger)

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -131,8 +131,9 @@ def get_bundle_id_from_key(bundle_key: str) -> str:
 
 
 def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, index_alias: str, logger) -> None:
-    #  get the major version from index data.
-    version = index_data['manifest']['format'].split('.')[0]
+    #  TODO: get the major version from index data.
+    #  version = index_data['manifest']['format'].split('.')[0]
+    version = 1
     #  create the elasticsearch index name from alias
     name, doc_type, replica, deployment = index_alias.split('-')
     index_name = '-'.join([name, doc_type, replica, version, deployment])

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -133,7 +133,7 @@ class ElasticsearchClient:
         return client
 
 
-def get_elasticsearch_doc_index(es_client, index_name, alias_name, logger, index_mapping=None):
+def create_elasticsearch_doc_index(es_client, index_name, alias_name, logger, index_mapping=None):
     try:
             logger.debug(f"Creating new Elasticsearch index: {index_name}")
             response = es_client.indices.create(index_name, body=index_mapping)

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -17,7 +17,6 @@ from requests_aws4auth import AWS4Auth
 
 from . import networking
 
-
 class AWSV4Sign(requests.auth.AuthBase):
     """
     AWS V4 Request Signer for Requests.
@@ -135,17 +134,28 @@ class ElasticsearchClient:
 
 def create_elasticsearch_doc_index(es_client, index_name, alias_name, logger, index_mapping=None):
     try:
-            logger.debug(f"Creating new Elasticsearch index: {index_name}")
-            response = es_client.indices.create(index_name, body=index_mapping)
-            logger.debug("Index creation response: %s", json.dumps(response, indent=4))
-            response = es_client.indices.update_aliases({
-                "actions": [
-                    {"add": {"index": index_name, "alias": alias_name}}
-                ]
-            })
-            logger.debug("Index put alias response: %s", json.dumps(response, indent=4))
+        logger.debug(f"Creating new Elasticsearch index: {index_name}")
+        response = es_client.indices.create(index_name, body=index_mapping)
+        logger.debug("Index creation response: %s", json.dumps(response, indent=4))
     except Exception as ex:
         logger.error(f"Unable to create index: {index_name} Exception: {ex}")
+        raise ex
+    try:
+        logger.debug(f"Aliasing {index_name} as {alias_name}")
+        response = es_client.indices.update_aliases({
+            "actions": [
+                {"add": {"index": index_name, "alias": alias_name}}
+            ]
+        })
+        logger.debug("Index add alias response: %s", json.dumps(response, indent=4))
+    except Exception as ex:
+        logger.error(f"Unable to alias index: {index_name} as {alias_name} Exception: {ex}")
+        response = es_client.indices.update_aliases({
+            "actions": [
+                {"remove": {"index": index_name, "alias": alias_name}}
+            ]
+        })
+        es_client.indices.delete(index_name)
         raise ex
 
 

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -133,14 +133,14 @@ class ElasticsearchClient:
         return client
 
 
-def get_elasticsearch_bundle_index(es_client, index_name, index_alias, logger, index_mapping=None):
+def get_elasticsearch_bundle_index(es_client, index_name, alias_name, logger, index_mapping=None):
     try:
             logger.debug(f"Creating new Elasticsearch index: {index_name}")
             response = es_client.indices.create(index_name, body=index_mapping)
             logger.debug("Index creation response: %s", json.dumps(response, indent=4))
             response = es_client.indices.update_aliases({
                 "actions": [
-                    {"add": {"index": index_name, "alias": index_alias}}
+                    {"add": {"index": index_name, "alias": alias_name}}
                 ]
             })
             logger.debug("Index put alias response: %s", json.dumps(response, indent=4))
@@ -149,16 +149,16 @@ def get_elasticsearch_bundle_index(es_client, index_name, index_alias, logger, i
         raise ex
 
 
-def get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping=None):
+def get_elasticsearch_subscription_index(es_client, alias_name, logger, index_mapping=None):
     try:
-        response = es_client.indices.exists(index_name)
+        response = es_client.indices.exists(alias_name)
         if response:
-            logger.debug(f"Using existing Elasticsearch index: {index_name}")
+            logger.debug(f"Using existing Elasticsearch index: {alias_name}")
         else:
-            logger.debug(f"Creating new Elasticsearch index: {index_name}")
-            response = es_client.indices.create(index_name, body=index_mapping)
+            logger.debug(f"Creating new Elasticsearch index: {alias_name}")
+            response = es_client.indices.create(alias_name, body=index_mapping)
             logger.debug("Index creation response: %s", json.dumps(response, indent=4))
 
     except Exception as ex:
-        logger.error(f"Unable to create index: {index_name} Exception: {ex}")
+        logger.error(f"Unable to create index: {alias_name} Exception: {ex}")
         raise ex

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -140,7 +140,7 @@ def get_elasticsearch_bundle_index(es_client, index_name, index_alias, logger, i
             logger.debug("Index creation response: %s", json.dumps(response, indent=4))
             response = es_client.indices.update_aliases({
                 "actions": [
-                    {"add":    {"index": index_name, "alias": index_alias}}
+                    {"add": {"index": index_name, "alias": index_alias}}
                 ]
             })
             logger.debug("Index put alias response: %s", json.dumps(response, indent=4))

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -149,16 +149,16 @@ def get_elasticsearch_doc_index(es_client, index_name, alias_name, logger, index
         raise ex
 
 
-def get_elasticsearch_subscription_index(es_client, alias_name, logger, index_mapping=None):
+def get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping=None):
     try:
-        response = es_client.indices.exists(alias_name)
+        response = es_client.indices.exists(index_name)
         if response:
-            logger.debug(f"Using existing Elasticsearch index: {alias_name}")
+            logger.debug(f"Using existing Elasticsearch index: {index_name}")
         else:
-            logger.debug(f"Creating new Elasticsearch index: {alias_name}")
-            response = es_client.indices.create(alias_name, body=index_mapping)
+            logger.debug(f"Creating new Elasticsearch index: {index_name}")
+            response = es_client.indices.create(index_name, body=index_mapping)
             logger.debug("Index creation response: %s", json.dumps(response, indent=4))
 
     except Exception as ex:
-        logger.error(f"Unable to create index: {alias_name} Exception: {ex}")
+        logger.error(f"Unable to create index: {index_name} Exception: {ex}")
         raise ex

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -133,7 +133,7 @@ class ElasticsearchClient:
         return client
 
 
-def get_elasticsearch_bundle_index(es_client, index_name, alias_name, logger, index_mapping=None):
+def get_elasticsearch_doc_index(es_client, index_name, alias_name, logger, index_mapping=None):
     try:
             logger.debug(f"Creating new Elasticsearch index: {index_name}")
             response = es_client.indices.create(index_name, body=index_mapping)

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -133,7 +133,23 @@ class ElasticsearchClient:
         return client
 
 
-def get_elasticsearch_index(es_client, index_name, logger, index_mapping=None):
+def get_elasticsearch_bundle_index(es_client, index_name, index_alias, logger, index_mapping=None):
+    try:
+            logger.debug(f"Creating new Elasticsearch index: {index_name}")
+            response = es_client.indices.create(index_name, body=index_mapping)
+            logger.debug("Index creation response: %s", json.dumps(response, indent=4))
+            response = es_client.indices.update_aliases({
+                "actions": [
+                    {"add":    {"index": index_name, "alias": index_alias}}
+                ]
+            })
+            logger.debug("Index put alias response: %s", json.dumps(response, indent=4))
+    except Exception as ex:
+        logger.error(f"Unable to create index: {index_name} Exception: {ex}")
+        raise ex
+
+
+def get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping=None):
     try:
         response = es_client.indices.exists(index_name)
         if response:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -98,7 +98,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         cls.blobstore, _, cls.test_fixture_bucket = Config.get_cloud_specific_handles(cls.replica)
         Config.set_config(BucketConfig.TEST)
         _, _, cls.test_bucket = Config.get_cloud_specific_handles(cls.replica)
-        cls.dss_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[cls.replica])
+        cls.dss_alias_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[cls.replica])
         cls.subscription_index_name = dss.Config.get_es_index_name(dss.ESIndexType.subscriptions,
                                                                    dss.Replica[cls.replica])
 
@@ -156,7 +156,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
                 self.process_new_indexable_object(sample_event, logger)
             self.assertRegex(log_monitor.output[0], "DEBUG:.*Not indexing .* creation event for key: .*")
             with self.assertRaises(Exception) as ex:
-                ElasticsearchClient.get(logger).get(index=self.dss_index_name,
+                ElasticsearchClient.get(logger).get(index=self.dss_alias_name,
                                                     doc_type=dss.ESIndexType.docs,
                                                     id=bundle_uuid)
             self.assertEqual('index_not_found_exception', ex.exception.error)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -272,8 +272,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         sample_event = self.create_sample_bundle_created_event(self.bundle_key)
         self.process_new_indexable_object(sample_event, logger)
         es_client = ElasticsearchClient.get(logger)
-        index_names = [i['i'] for i in es_client.cat.aliases(name=self.dss_alias_name, h=['a', 'i'], format='json')]
-        self.assertNotEqual(len(index_names), 0)
+        self.assertTrue(es_client.indices.exists_alias(name=[self.dss_alias_name]))
 
     @unittest.skip("WIP")
     def test_index_when_multiple_indexes_using_alias(self):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -268,6 +268,10 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
                          f"WARNING:.*:Failed notification for subscription {subscription_id}"
                          f" for bundle {bundle_id} with transaction id .+ Code: {error_response_code}")
 
+    @unittest.skip("WIP")
+    def test_index_when_multiple_indexes_using_alias(self):
+        pass
+
     def verify_notification(self, subscription_id, es_query, bundle_id):
         posted_payload_string = self.get_notification_payload()
         self.assertIsNotNone(posted_payload_string)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -98,8 +98,8 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         cls.blobstore, _, cls.test_fixture_bucket = Config.get_cloud_specific_handles(cls.replica)
         Config.set_config(BucketConfig.TEST)
         _, _, cls.test_bucket = Config.get_cloud_specific_handles(cls.replica)
-        cls.dss_alias_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[cls.replica])
-        cls.subscription_index_name = dss.Config.get_es_index_name(dss.ESIndexType.subscriptions,
+        cls.dss_alias_name = dss.Config.get_es_alias_name(dss.ESIndexType.docs, dss.Replica[cls.replica])
+        cls.subscription_index_name = dss.Config.get_es_alias_name(dss.ESIndexType.subscriptions,
                                                                    dss.Replica[cls.replica])
 
     @classmethod

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -72,7 +72,7 @@ class TestSearchBase(DSSAssertMixin):
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
-        create_elasticsearch_index(self.dss_index_name, logger)
+        create_elasticsearch_index("search-unitTest", self.dss_index_name, logger)
 
     def test_es_search_page(self):
         """Confirm that elasaticsearch is returning _source info only when necessary."""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -72,7 +72,7 @@ class TestSearchBase(DSSAssertMixin):
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
-        create_elasticsearch_index("search-unitTest", self.dss_index_name, logger)
+        create_elasticsearch_index("search-unittest", self.dss_index_name, logger)
 
     def test_es_search_page(self):
         """Confirm that elasaticsearch is returning _source info only when necessary."""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -61,7 +61,7 @@ class TestSearchBase(DSSAssertMixin):
         cls.app.start()
         cls.replica_name = replica.name
         dss.Config.set_config(dss.BucketConfig.TEST)
-        cls.dss_alias_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, replica)
+        cls.dss_alias_name = dss.Config.get_es_alias_name(dss.ESIndexType.docs, replica)
         cls.dss_index_name = "search-unittest"
         with open(os.path.join(os.path.dirname(__file__), "sample_v3_index_doc.json"), "r") as fh:
             cls.index_document = json.load(fh)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -23,7 +23,7 @@ import dss
 from dss.api.search import _es_search_page
 from copy import deepcopy
 from dss.config import IndexSuffix
-from dss.events.handlers.index import create_elasticsearch_index
+from dss.events.handlers.index import get_elasticsearch_index
 from dss.util.es import ElasticsearchServer, ElasticsearchClient
 from tests import get_version
 from tests.es import elasticsearch_delete_index
@@ -73,7 +73,7 @@ class TestSearchBase(DSSAssertMixin):
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
-        create_elasticsearch_index(self.dss_index_name, self.dss_alias_name, logger)
+        get_elasticsearch_index(self.dss_index_name, self.dss_alias_name, logger)
 
     def test_es_search_page(self):
         """Confirm that elasaticsearch is returning _source info only when necessary."""

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -21,7 +21,7 @@ sys.path.insert(0, pkg_root) # noqa
 import dss
 from dss.config import IndexSuffix
 from dss.util import UrlBuilder
-from dss.util.es import ElasticsearchClient, ElasticsearchServer, get_elasticsearch_index
+from dss.util.es import ElasticsearchClient, ElasticsearchServer, get_elasticsearch_subscription_index
 from tests.es import elasticsearch_delete_index
 from tests.infra import DSSAssertMixin, ExpectedErrorFields
 from tests.infra.server import ThreadedLocalServer
@@ -76,7 +76,7 @@ class TestSubscriptionsBase(DSSAssertMixin):
             }
         }
         index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, self.replica)
-        get_elasticsearch_index(es_client, index_name, logger, index_mapping)
+        get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping)
 
         with open(os.path.join(os.path.dirname(__file__), "sample_v3_index_doc.json"), "r") as fh:
             index_document = json.load(fh)

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -197,6 +197,10 @@ class TestSubscriptionsBase(DSSAssertMixin):
         self.assertEqual(self.callback_url, json_response['subscriptions'][0]['callback_url'])
         self.assertEqual(NUM_ADDITIONS, len(json_response['subscriptions']))
 
+    @unittest.skip("WIP")
+    def test_subscribe_when_multiple_indexes_using_alias(self):
+        pass
+
     def test_delete(self):
         find_uuid = self._put_subscription()
         url = str(UrlBuilder()

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -15,7 +15,7 @@ import google.auth
 import google.auth.transport.requests
 import requests
 
-from dss.events.handlers.index import create_elasticsearch_index
+from dss.events.handlers.index import get_elasticsearch_index
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
 sys.path.insert(0, pkg_root) # noqa
@@ -67,7 +67,7 @@ class TestSubscriptionsBase(DSSAssertMixin):
         es_client = ElasticsearchClient.get(logger)
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
         alias_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, self.replica)
-        create_elasticsearch_index("subscription_test", alias_name, logger)
+        get_elasticsearch_index("subscription_test", alias_name, logger)
 
         with open(os.path.join(os.path.dirname(__file__), "sample_v3_index_doc.json"), "r") as fh:
             index_document = json.load(fh)


### PR DESCRIPTION
Rather than accessing indexes directly they are now accessed through an alias name. This helps with reindexing and indexing by major version. For now the alias will only point to a single index. 

Connected to #594

### Test plan
Updated units test to reflect change. Will need further refactoring once indexing by major version is implemented.

### Deployment Notes
Do not merge until reindex is supported.

### Release notes
split get_elasticsearch_index into get_elasticsearch_subscription_index, and get_elasticsearch_doc_index
using document version to create the actual index
adding new indexes to alias on creation.

