### PR TITLE
Bogus is not the least likely hostname to exist

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -193,7 +193,7 @@ class TestSearchBase(DSSAssertMixin):
 
         es_logger.setLevel("ERROR")
         try:
-            os.environ['DSS_ES_ENDPOINT'] = "bogus"
+            os.environ['DSS_ES_ENDPOINT'] = "this-is-really-unlikely-to-exist"
             url = self.build_url()
             self.assertPostResponse(
                 path=url,


### PR DESCRIPTION
py-elasticsearch timeout is quick for DNS failures, but seems to be taking a lonnnng time for DNS success, no ES running.

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
