### PR TITLE
Introduce TimedThread.

### DIFF
--- a/dss/stepfunctions/lambdaexecutor/__init__.py
+++ b/dss/stepfunctions/lambdaexecutor/__init__.py
@@ -1,0 +1,49 @@
+import copy
+import threading
+import typing
+
+
+StateType = typing.TypeVar('StateType')
+
+
+class TimedThread(typing.Generic[StateType]):
+    """
+    This is a "Thread" class that runs a job for a maximum period of time.  The class provides concurrency-safe methods
+    to retrieve and persist a chunk of state.
+    """
+    def __init__(self, timeout_seconds: float, state: StateType) -> None:
+        self.timeout_seconds = timeout_seconds
+        self.__state = copy.deepcopy(state)
+        self.lock = threading.Lock()
+
+    def run(self) -> StateType:
+        raise NotImplementedError()
+
+    def _run(self) -> None:
+        state = self.run()
+        self.save_state(state)
+
+    def _start_async(self) -> None:
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+
+    def _join(self) -> StateType:
+        self.thread.join(self.timeout_seconds)
+
+        with self.lock:
+            state = copy.deepcopy(self.__state)
+        return state
+
+    def start(self) -> StateType:
+        self._start_async()
+        return self._join()
+
+    def get_state_copy(self) -> StateType:
+        with self.lock:
+            state_copy = copy.deepcopy(self.__state)
+        return state_copy
+
+    def save_state(self, new_state: StateType) -> None:
+        new_state = copy.deepcopy(new_state)
+        with self.lock:
+            self.__state = new_state

--- a/tests/test_lambdaexecutor.py
+++ b/tests/test_lambdaexecutor.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+import dss.stepfunctions.lambdaexecutor as lambdaexecutor
+
+
+class TestLambdaExecutor(unittest.TestCase):
+    def test_state_freezing(self):
+        """Test that we freeze the state at the time when the timeout expires."""
+        class UUT(lambdaexecutor.TimedThread[dict]):
+            KEY = "key"
+
+            def __init__(self) -> None:
+                super().__init__(5, {UUT.KEY: 0})
+
+            def run(self) -> dict:
+                for ix in range(15):
+                    state = self.get_state_copy()
+                    state[UUT.KEY] += 1
+                    self.save_state(state)
+                    time.sleep(1)
+                return state
+
+        uut = UUT()
+        result = uut.start()
+        self.assertGreaterEqual(result[UUT.KEY], 4)
+        self.assertLessEqual(result[UUT.KEY], 6)
+
+    def test_exit(self):
+        """Test that we save the final state that `run()` returns."""
+        class UUT(lambdaexecutor.TimedThread[dict]):
+            KEY = "key"
+
+            def __init__(self) -> None:
+                super().__init__(5, {UUT.KEY: 0})
+
+            def run(self) -> dict:
+                state = self.get_state_copy()
+                for ix in range(15):
+                    state[UUT.KEY] += 1
+                return state
+
+        uut = UUT()
+        result = uut.start()
+        self.assertEqual(result[UUT.KEY], 15)
+
+    def test_immutable_constructor_state(self):
+        """Test that we make a copy of the state when we construct a TimedThread."""
+        class UUT(lambdaexecutor.TimedThread[dict]):
+            KEY = "key"
+
+            def __init__(self, state: dict, event: threading.Event) -> None:
+                super().__init__(5, state)
+                self.event = event
+
+            def run(uut_self) -> dict:
+                uut_self.event.wait()
+                state = uut_self.get_state_copy()
+                self.assertEqual(state[UUT.KEY], 0)
+                return state
+
+        state = {UUT.KEY: 0}
+        event = threading.Event()
+        uut = UUT(state, event)
+        uut._start_async()
+        state[UUT.KEY] = 1
+        event.set()
+        uut._join()
+
+    def test_immutable_get_state(self):
+        """Test that we make a copy of the state when we get it."""
+        class UUT(lambdaexecutor.TimedThread[dict]):
+            KEY = "key"
+
+            def __init__(self) -> None:
+                super().__init__(5, {UUT.KEY: 0})
+
+            def run(uut_self) -> dict:
+                state = uut_self.get_state_copy()
+                state[UUT.KEY] = 1
+                self.assertNotEqual(state, uut_self.get_state_copy())
+                return state
+
+        uut = UUT()
+        result = uut.start()
+        self.assertEqual(result[UUT.KEY], 1)
+
+    def test_immutable_set_state(self):
+        """Test that we make a copy of the state when we set it."""
+        class UUT(lambdaexecutor.TimedThread[dict]):
+            KEY = "key"
+
+            def __init__(self) -> None:
+                super().__init__(5, {UUT.KEY: 0})
+
+            def run(uut_self) -> dict:
+                state = {UUT.KEY: 15}
+                uut_self.save_state(state)
+                state[UUT.KEY] = 5
+                self.assertEqual(uut_self.get_state_copy()[UUT.KEY], 15)
+                return state
+
+        uut = UUT()
+        result = uut.start()
+        self.assertEqual(result[UUT.KEY], 5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Copy-paste from the docblock:

This is a "Thread" class that runs a job for a maximum period of time.  The class provides concurrency-safe methods to retrieve and persist a chunk of state.

You can use this primitive to wrap your lambda execution such that you send a consistent chunk of state out of the lambda back to AWS step functions.