### PR TITLE
Finish changes for schema version specific subscription/notification

### DIFF
--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -88,7 +88,7 @@ def put(json_request_body: dict, replica: str):
     get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping)
 
     #  get all indexes that use current alias
-    alias_name = Config.get_es_index_name(ESIndexType.docs, Replica[replica])
+    alias_name = Config.get_es_alias_name(ESIndexType.docs, Replica[replica])
     doc_indexes = [i['i'] for i in es_client.cat.aliases(name=alias_name, h=['a', 'i'], format='json')]
     #  try to subscribe query to each of the indexes.
     subscribed_indexes = []

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -172,12 +172,13 @@ def delete(uuid: str, replica: str):
 
 
 def _unregister_percolate(es_client: Elasticsearch, subscribed_indexes: List[str], uuid: str):
-    # TODO Check return value and log errors
-    es_client.delete_by_query(index=subscribed_indexes,
-                              doc_type=ESDocType.query.name,
-                              body={"query": {"ids": {"type": ESDocType.query.name, "values": [uuid]}}},
-                              conflicts="proceed",
-                              refresh=True)
+    response = es_client.delete_by_query(index=subscribed_indexes,
+                                         doc_type=ESDocType.query.name,
+                                         body={"query": {"ids": {"type": ESDocType.query.name, "values": [uuid]}}},
+                                         conflicts="proceed",
+                                         refresh=True)
+    if response['failures']:
+        logger.error("Failed to unregister percolate query for subscription %s: %s", uuid, response)
 
 
 def _register_percolate(es_client: Elasticsearch, index_name: str, uuid: str, es_query: dict, replica: str):

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -1,23 +1,14 @@
 import datetime
-import io
-import json
-import re
-import typing
 from uuid import uuid4
 
-import iso8601
 import requests
-
-from cloud_blobstore import BlobNotFoundError
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ElasticsearchException, NotFoundError
 from elasticsearch_dsl import Search
-from flask import jsonify, make_response, redirect, request
-from werkzeug.exceptions import BadRequest
+from flask import jsonify, request
 
 from .. import Config, Replica, ESIndexType, ESDocType, get_logger
 from ..error import DSSException, dss_handler
-from ..hcablobstore import FileMetadata, HCABlobStore
 from ..util.es import ElasticsearchClient, get_elasticsearch_subscription_index
 
 logger = get_logger()
@@ -94,22 +85,32 @@ def put(json_request_body: dict, replica: str):
     # john@example.com would show up because elasticsearch matched example w/ example.
     # By including "index": "not_analyzed", Elasticsearch leaves all owner inputs alone.
     index_name = Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica])
-    #  TODO (tsmith): get all indexes that use current alais
-    #  TODO (tsmith): try to subscribe query to each of the indexes.
-    #  TODO (tsmith): error if no queries are indexed.
     get_elasticsearch_subscription_index(es_client, index_name, logger, index_mapping)
 
-    try:
-        percolate_registration = _register_percolate(es_client, uuid, es_query, replica)
-        logger.debug(f"Percolate query registration succeeded:\n{percolate_registration}")
-    except ElasticsearchException as ex:
+    #  get all indexes that use current alias
+    alias_name = Config.get_es_index_name(ESIndexType.docs, Replica[replica])
+    doc_indexes = [i['i'] for i in es_client.cat.aliases(name=alias_name, h=['a', 'i'], format='json')]
+    #  try to subscribe query to each of the indexes.
+    subscribed_indexes = []
+    for doc_index in doc_indexes:
+        try:
+
+            percolate_registration = _register_percolate(es_client, doc_index, uuid, es_query, replica)
+            logger.debug(f"Percolate query registration succeeded:\n{percolate_registration}")
+            subscribed_indexes.append(doc_index)
+        except ElasticsearchException as ex:
+            last_ex = ex
+
+    # error if no queries are successfully indexed.
+    if len(subscribed_indexes) == 0:
         logger.critical("%s", f"Percolate query registration failed: owner: {owner}, uuid: {uuid}, "
-                              f"replica: {replica}, es_query: {es_query}, Exception: {ex}")
+                              f"replica: {replica}, es_query: {es_query}, Exception: {Exception(last_ex)}")
         raise DSSException(requests.codes.internal_server_error,
                            "elasticsearch_error",
-                           "Unable to register elasticsearch percolate query!")
+                           "Unable to register elasticsearch percolate query!") from Exception(last_ex)
 
     json_request_body['owner'] = owner
+    json_request_body['subscribed_indexes'] = subscribed_indexes
 
     try:
         subscription_registration = _register_subscription(es_client, uuid, json_request_body, replica)
@@ -119,10 +120,8 @@ def put(json_request_body: dict, replica: str):
                               f"replica: {replica}, Exception: {ex}")
 
         # Delete percolate query to make sure queries and subscriptions are in sync.
-        es_client.delete(index=index_name,
-                         doc_type=ESDocType.query.name,
-                         id=uuid,
-                         refresh=True)
+        _unregister_percolate(es_client, subscribed_indexes, uuid)
+
         raise DSSException(requests.codes.internal_server_error,
                            "elasticsearch_error",
                            "Unable to register subscription! Rolling back percolate query.")
@@ -149,10 +148,7 @@ def delete(uuid: str, replica: str):
         # common_error_handler defaults code to capitalized 'Forbidden' for Werkzeug exception. Keeping consistent.
         raise DSSException(requests.codes.forbidden, "Forbidden", "Your credentials can't access this subscription!")
 
-    es_client.delete(index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
-                     doc_type=ESDocType.query.name,
-                     id=uuid,
-                     refresh=True)
+    _unregister_percolate(es_client, stored_metadata["subscribed_indexes"], uuid)
 
     es_client.delete(index=Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica]),
                      doc_type=ESDocType.subscription.name,
@@ -164,8 +160,15 @@ def delete(uuid: str, replica: str):
     return jsonify({'timeDeleted': time_deleted}), requests.codes.okay
 
 
-def _register_percolate(es_client: Elasticsearch, uuid: str, es_query: dict, replica: str):
-    index_name = Config.get_es_index_name(ESIndexType.docs, Replica[replica])
+def _unregister_percolate(es_client: Elasticsearch, subscribed_indexes: list, uuid: str):
+    for index in subscribed_indexes:
+        es_client.delete(index=index,
+                         doc_type=ESDocType.query.name,
+                         id=uuid,
+                         refresh=True)
+
+
+def _register_percolate(es_client: Elasticsearch, index_name: str, uuid: str, es_query: dict, replica: str):
     return es_client.index(index=index_name,
                            doc_type=ESDocType.query.name,
                            id=uuid,

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import List
 from uuid import uuid4
 
 import requests
@@ -163,12 +164,11 @@ def delete(uuid: str, replica: str):
     return jsonify({'timeDeleted': time_deleted}), requests.codes.okay
 
 
-def _unregister_percolate(es_client: Elasticsearch, subscribed_indexes: list, uuid: str):
-    for index in subscribed_indexes:
-        es_client.delete(index=index,
-                         doc_type=ESDocType.query.name,
-                         id=uuid,
-                         refresh=True)
+def _unregister_percolate(es_client: Elasticsearch, subscribed_indexes: List[str], uuid: str):
+    es_client.delete(index=subscribed_indexes,
+                     doc_type=ESDocType.query.name,
+                     id=uuid,
+                     refresh=True)
 
 
 def _register_percolate(es_client: Elasticsearch, index_name: str, uuid: str, es_query: dict, replica: str):

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -76,6 +76,10 @@ def put(json_request_body: dict, replica: str):
                     "owner": {
                         "type": "string",
                         "index": "not_analyzed"
+                    },
+                    "es_query": {
+                        "type": "object",
+                        "enabled": "false"
                     }
                 }
             }
@@ -90,7 +94,7 @@ def put(json_request_body: dict, replica: str):
 
     #  get all indexes that use current alias
     alias_name = Config.get_es_alias_name(ESIndexType.docs, Replica[replica])
-    doc_indexes = [indexes['i'] for indexes in es_client.cat.aliases(name=alias_name, h=['i'], format='json')]
+    doc_indexes = _get_indexes_by_alias(es_client, alias_name)
 
     #  try to subscribe query to each of the indexes.
     subscribed_indexes = []
@@ -106,7 +110,7 @@ def put(json_request_body: dict, replica: str):
 
     # Queries are unlikely to fit in all of the indexes, therefore errors will almost always occur. Only return an error
     # if no queries are successfully indexed.
-    if not subscribed_indexes:
+    if len(doc_indexes) > 0 and not subscribed_indexes:
         logger.critical("%s", f"Percolate query registration failed: owner: {owner}, uuid: {uuid}, "
                               f"replica: {replica}, es_query: {es_query}, Exception: {last_ex}")
         raise DSSException(requests.codes.internal_server_error,
@@ -114,7 +118,6 @@ def put(json_request_body: dict, replica: str):
                            "Unable to register elasticsearch percolate query!") from last_ex
 
     json_request_body['owner'] = owner
-    json_request_body['subscribed_indexes'] = subscribed_indexes
 
     try:
         subscription_registration = _register_subscription(es_client, uuid, json_request_body, replica)
@@ -152,7 +155,10 @@ def delete(uuid: str, replica: str):
         # common_error_handler defaults code to capitalized 'Forbidden' for Werkzeug exception. Keeping consistent.
         raise DSSException(requests.codes.forbidden, "Forbidden", "Your credentials can't access this subscription!")
 
-    _unregister_percolate(es_client, stored_metadata["subscribed_indexes"], uuid)
+    #  get all indexes that use current alias
+    alias_name = Config.get_es_alias_name(ESIndexType.docs, Replica[replica])
+    doc_indexes = _get_indexes_by_alias(es_client, alias_name)
+    _unregister_percolate(es_client, doc_indexes, uuid)
 
     es_client.delete(index=Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica]),
                      doc_type=ESDocType.subscription.name,
@@ -164,7 +170,7 @@ def delete(uuid: str, replica: str):
     return jsonify({'timeDeleted': time_deleted}), requests.codes.okay
 
 
-def _unregister_percolate(es_client: Elasticsearch, subscribed_indexes: List[str], uuid: str):
+def _unregister_percolate(es_client: Elasticsearch, subscribed_indexes: list, uuid: str):
     es_client.delete(index=subscribed_indexes,
                      doc_type=ESDocType.query.name,
                      id=uuid,
@@ -186,3 +192,6 @@ def _register_subscription(es_client: Elasticsearch, uuid: str, json_request_bod
                            id=uuid,
                            body=json_request_body,
                            refresh=True)
+
+def _get_indexes_by_alias(es_client: Elasticsearch, alias_name: str):
+    return [indexes['i'] for indexes in es_client.cat.aliases(name=alias_name, h=['i'], format='json')]

--- a/dss/config.py
+++ b/dss/config.py
@@ -216,7 +216,7 @@ class Config:
     def get_es_alias_name(index_type: ESIndexType, replica: Replica) -> str:
         """Returns the alias for indexes"""
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
-        index = f"dss-{index_type.name}-{deployment_stage}-{replica.name}"
+        index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}-alias"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/dss/config.py
+++ b/dss/config.py
@@ -203,7 +203,7 @@ class Config:
                           ) -> str:
         """Returns the index name"""
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
-        index = f"dss-{index_type.name}-{deployment_stage}-{replica.name}"
+        index = f"dss-{deployment_stage}-{replica.name}-{index_type.name}"
         if version:
             index = f"{index}-{version}"
         if version:
@@ -216,7 +216,7 @@ class Config:
     def get_es_alias_name(index_type: ESIndexType, replica: Replica) -> str:
         """Returns the alias for indexes"""
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
-        index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}-alias"
+        index = f"dss-{deployment_stage}-{replica.name}-{index_type.name}-alias"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/dss/config.py
+++ b/dss/config.py
@@ -206,8 +206,6 @@ class Config:
         index = f"dss-{deployment_stage}-{replica.name}-{index_type.name}"
         if version:
             index = f"{index}-{version}"
-        if version:
-            index = f"{index}-{version}"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse, unquote
 import requests
 from cloud_blobstore import BlobStore, BlobStoreError
 from collections import defaultdict
-from elasticsearch.helpers import scan, bulk, streaming_bulk, BulkIndexError
+from elasticsearch.helpers import scan, bulk, BulkIndexError
 from requests_http_signature import HTTPSignatureAuth
 
 from dss import Config, DeploymentStage, ESIndexType, ESDocType, Replica

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse, unquote
 import requests
 from cloud_blobstore import BlobStore, BlobStoreError
 from collections import defaultdict
-from elasticsearch.helpers import scan
+from elasticsearch.helpers import scan, bulk, streaming_bulk, BulkIndexError
 from requests_http_signature import HTTPSignatureAuth
 
 from dss import Config, DeploymentStage, ESIndexType, ESDocType, Replica
@@ -56,8 +56,8 @@ def process_new_indexable_object(bucket_name: str, key: str, replica: str, logge
         index_shape_identifier = get_index_shape_identifier(index_data, logger)
         index_name = Config.get_es_index_name(ESIndexType.docs, Replica[replica], index_shape_identifier)
         get_elasticsearch_index(index_name, alias_name, logger)
-        add_data_to_elasticsearch(bundle_id, index_data, index_name, logger)
-        subscriptions = find_matching_subscriptions(index_data, alias_name, logger)
+        add_data_to_elasticsearch(bundle_id, index_data, index_name, replica, logger)
+        subscriptions = find_matching_subscriptions(index_data, index_name, logger)
         process_notifications(bundle_id, subscriptions, replica, logger)
         logger.debug(f"Finished index processing of {replica} creation event for bundle: {key}")
     else:
@@ -177,12 +177,6 @@ def get_bundle_id_from_key(bundle_key: str) -> str:
     raise Exception(f"This is not a key for a bundle: {bundle_key}")
 
 
-def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, alias_name: str, logger) -> None:
-    get_elasticsearch_index(index_name, alias_name, logger)
-    logger.debug("Adding index data to Elasticsearch index '%s': %s", index_name, json.dumps(index_data, indent=4))
-    add_data_to_elasticsearch(bundle_id, index_data, index_name, logger)
-
-
 def get_elasticsearch_index(index_name: str, alias_name: str, logger):
     if not ElasticsearchClient.get(logger).indices.exists(index_name):
         with open(os.path.join(os.path.dirname(__file__), "mapping.json"), "r") as fh:
@@ -194,8 +188,10 @@ def get_elasticsearch_index(index_name: str, alias_name: str, logger):
         logger.debug(f"Using existing Elasticsearch index: {index_name}")
 
 
-def add_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, logger) -> None:
+def add_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, replica: str, logger) -> None:
     try:
+        logger.debug("Adding index data to Elasticsearch index '%s': %s", index_name, json.dumps(index_data, indent=4))
+        initial_mappings = ElasticsearchClient.get(logger).indices.get_mapping(index_name)[index_name]['mappings']
         ElasticsearchClient.get(logger).index(index=index_name,
                                               doc_type=ESDocType.doc.name,
                                               id=bundle_id,
@@ -204,6 +200,41 @@ def add_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str,
         logger.error("Document not indexed. Exception: %s, Index name: %s,  Index data: %s", ex, index_name,
                      json.dumps(index_data, indent=4))
         raise
+
+    try:
+        current_mappings = ElasticsearchClient.get(logger).indices.get_mapping(index_name)[index_name]['mappings']
+        if initial_mappings != current_mappings:
+            refresh_percolate_queries(index_name, replica, logger)
+    except Exception as ex:
+        logger.error("Error refreshing subscription queries for index. Exception: %s, Index name: %s", ex, index_name)
+        raise
+
+
+def refresh_percolate_queries(index_name: str, replica: str, logger) -> None:
+    # When dynamic templates are used and queries for percolation have been added
+    # to an index before the index contains mappings of fields referenced by those queries,
+    # the queries must be reloaded when the mappings are present for the queries to match.
+    # See: https://github.com/elastic/elasticsearch/issues/5750
+    subscription_index_name = Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica])
+    if not ElasticsearchClient.get(logger).indices.exists(subscription_index_name):
+        return
+    subscription_queries = [{'_index': index_name,
+                             '_type': ESDocType.query.name,
+                             '_id': hit['_id'],
+                             '_source': hit['_source']['es_query']
+                             }
+                            for hit in scan(ElasticsearchClient.get(logger),
+                                            index=subscription_index_name,
+                                            doc_type=ESDocType.subscription.name,
+                                            query={'query': {'match_all': {}}})
+                            ]
+
+    if len(subscription_queries) > 0:
+        try:
+            bulk(ElasticsearchClient.get(logger), iter(subscription_queries), refresh=True)
+        except BulkIndexError as ex:
+            logger.error("Error occurred when adding subscription queries to index {} Errors: {}",
+                         index_name, ex.errors)
 
 
 def find_matching_subscriptions(index_data: dict, index_name: str, logger) -> set:

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -229,7 +229,7 @@ def refresh_percolate_queries(index_name: str, replica: str, logger) -> None:
                                             query={'query': {'match_all': {}}})
                             ]
 
-    if len(subscription_queries) > 0:
+    if subscription_queries:
         try:
             bulk(ElasticsearchClient.get(logger), iter(subscription_queries), refresh=True)
         except BulkIndexError as ex:

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -233,7 +233,7 @@ def refresh_percolate_queries(index_name: str, replica: str, logger) -> None:
         try:
             bulk(ElasticsearchClient.get(logger), iter(subscription_queries), refresh=True)
         except BulkIndexError as ex:
-            logger.error("Error occurred when adding subscription queries to index {} Errors: {}",
+            logger.error("Error occurred when adding subscription queries to index %s Errors: %s",
                          index_name, ex.errors)
 
 

--- a/dss/events/handlers/mapping.json
+++ b/dss/events/handlers/mapping.json
@@ -7,6 +7,11 @@
           "filter": ["lowercase"]
         }
       }
+    },
+    "index": {
+      "percolator": {
+        "map_unmapped_fields_as_string": true
+      }
     }
   },
   "mappings": {

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/assay.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/assay.json
@@ -1,0 +1,30 @@
+{
+    "files": [
+        {
+            "format": ".fastq.gz", 
+            "name": "SRR2967608_1.fastq.gz", 
+	    "lane": "1",
+            "type": "read1"
+        }, 
+        {
+            "format": ".fastq.gz", 
+            "name": "SRR2967608_2.fastq.gz", 
+	    "lane": "1",
+            "type": "read2"
+        }
+    ], 
+    "rna": {
+        "primer": "random", 
+        "spike_in": "ERCC"
+    }, 
+    "seq": {
+        "machine": "Illumina HiSeq 2500", 
+        "molecule": "total RNA", 
+        "paired_ends": "yes"
+    }, 
+    "single_cell": {
+        "method": "Fluidigm C1"
+    }, 
+    "sra_experiment": "SRX1457054", 
+    "sra_run": "SRR2967608"
+}

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/cell.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/cell.json
@@ -1,0 +1,3 @@
+{
+    "id": "fetal1_A10_fetal_12wpc_c1"
+}

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/manifest.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/manifest.json
@@ -1,0 +1,14 @@
+{
+    "version": "1",
+    "dir": "http://hgwdev.soe.ucsc.edu/~kent/hca/big_data_files",
+    "files": [
+        {
+            "format": ".fastq.gz", 
+            "name": "SRR2967608_1.fastq.gz"
+        }, 
+        {
+            "format": ".fastq.gz", 
+            "name": "SRR2967608_2.fastq.gz"
+        }
+   ]
+}

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/project.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/project.json
@@ -1,0 +1,32 @@
+{
+    "contact": {
+        "address": "Deutscher Pl. 6; Leipzig,  04103 Germany", 
+        "city": "Leipzig", 
+        "country": "Germany", 
+        "department": "Evolutionary Genetics", 
+        "email": "graycamp@gmail.com", 
+        "institute": "Max Planck Institute for Evolutionary Anthropology", 
+        "name": "Gray,,Camp", 
+        "postal_code": "04103", 
+        "street_address": "Deutscher Pl. 6"
+    }, 
+    "contributor": [
+        "Gray,,Camp", 
+        "Barbara,,Treutlein"
+    ], 
+    "geo_series": "GSE75140", 
+    "last_update_date": "2017-06-02", 
+    "ncbi_bioproject": "PRJNA304502", 
+    "overall_design": "734 single-cell transcriptomes from human fetal neocortex or human cerebral organoids from multiple time points were analyzed in this study. All single cell samples were processed on the microfluidic Fluidigm C1 platform and contain 92 external RNA spike-ins. Fetal neocortex data were generated at 12 weeks post conception (chip 1: 81 cells; chip 2: 83 cells) and 13 weeks post conception (62 cells). Cerebral organoid data were generated from dissociated whole organoids derived from induced pluripotent stem cell line 409B2 (iPSC 409B2) at 33 days (40 cells), 35 days (68 cells), 37 days (71 cells), 41 days (74 cells), and 65 days (80 cells) after the start of embryoid body culture. Cerebral organoid data were also generated from microdissected cortical-like regions from H9 embryonic stem cell derived organoids at 53 days (region 1, 48 cells; region 2, 48 cells) or from iPSC 409B2 organoids at 58 days (region 3, 43 cells; region 4, 36 cells).", 
+    "pmid": "26644564", 
+    "release_status": "Public on Dec 07 2015", 
+    "sra_project": "SRP066834", 
+    "submission_date": "2015-11-18", 
+    "summary": "Cerebral organoids \u2013 three-dimensional cultures of human cerebral tissue derived from pluripotent stem cells \u2013 have emerged as models of human cortical development. However, the extent to which in vitro organoid systems recapitulate neural progenitor cell proliferation and neuronal differentiation programs observed in vivo remains unclear. Here we use single-cell RNA sequencing (scRNA-seq) to dissect and compare cell composition and progenitor-to-neuron lineage relationships in human cerebral organoids and fetal neocortex. Covariation network analysis using the fetal neocortex data reveals known and novel interactions among genes central to neural progenitor proliferation and neuronal differentiation. In the organoid, we detect diverse progenitors and differentiated cell types of neuronal and mesenchymal lineages, and identify cells that derived from regions resembling the fetal neocortex. We find that these organoid cortical cells use gene expression programs remarkably similar to those of the fetal tissue in order to organize into cerebral cortex-like regions. Our comparison of in vivo and in vitro cortical single cell transcriptomes illuminates the genetic features underlying human cortical development that can be studied in organoid cultures.", 
+    "supplementary_files": [
+        "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE75nnn/GSE75140/suppl/GSE75140_hOrg.fetal.master.data.frame.txt.gz", 
+        "ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP/SRP066/SRP066834"
+    ], 
+    "title": "Human cerebral organoids recapitulate gene expression programs of fetal neocortex development.", 
+    "uuid": "15fe881c-f4b8-4d15-a270-092b8e5d850a"
+}

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/sample.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/sample.json
@@ -1,0 +1,46 @@
+{
+    "body_part": {
+        "name": "neocortex", 
+        "organ": "brain"
+    }, 
+    "data_processing": [
+        "\"freeIbis\" was used as an efficient basecaller with calibrated quality scores for Illumina sequencers. (Bioinformatics. 2013 May 1;29(9):1208-9. doi: 10.1093/bioinformatics/btt117. Epub 2013 Mar 6.)", 
+        "\"leeHom\" was used to trim adapters and merge Illumina sequencing reads. (Nucleic Acids Res. 2014 Oct;42(18):e141. doi: 10.1093/nar/gku699. Epub 2014 Aug 6.)", 
+        "\"deML\" was used for robust demultiplexing of Illumina sequences using a likelihood-based approach. (Bioinformatics. 2015 Mar 1;31(5):770-2. doi: 10.1093/bioinformatics/btu719. Epub 2014 Oct 30.)", 
+        "Reads were aligned against the human genome (build GRCh38.77 from ENSEMBLE) using TopHat v2.0.14. The genome was indexed using Bowtie v2.2.6", 
+        "Fragments Per Kilobase of transcript Per Million mapped reads (FPKM) values were computed using cufflinks v2.2.1", 
+        "Genome_build: GRCh38", 
+        "Supplementary_files_format_and_content: Master data frame including sample name, gene ID, and FPKM values for each single cell."
+    ], 
+    "donor": {
+        "age": "12", 
+        "age_unit": "week", 
+        "id": "fetus 1", 
+        "uuid": "6860fb7c-6167-4b6c-9bae-58098f35cc05",
+        "life_stage": "embryo", 
+        "ncbi_taxon": "9606", 
+        "species": "Homo sapiens"
+    }, 
+    "geo_sample": "GSM1957573", 
+    "last_update_date": "2015-12-07", 
+    "long_label": "12 week post conception fetal neocortex", 
+    "ncbi_biosample": "SAMN04303778", 
+    "protocols": [
+        {
+            "description": "Fetuses were 12 to 13 wpc as assessed by ultrasound measurements of crown-rump length and other standard criteria of developmental stage determination.", 
+            "type": "growth protocol"
+        }, 
+        {
+            "description": "Fetal cortices were digested with papain (Miltenyi Biotec, 1ml) for 15 min at 37\u00b0C on a rotating wheel, followed by addition of a papain inhibitor. Dissociated cells were filtered through 40, 30, and 20 \u03bcm diameter strainers to create a single cell suspension.", 
+            "type": "treatment protocol"
+        }, 
+        {
+            "description": "Cells were loaded into the Fluidigm C1 microfluidic platform, where single cells were captured. Lysis of single cells, reverse-transcription of mRNA into cDNA as well as preamplification of cDNA occured within the microfluidic device using reagents provided by Fluidigm as well as the SMARTer Ultra Low RNA kit for Illumina (Clontech). External RNA spike-in transcripts (ERCC spike-in Mix, Ambion) were added to all single cell lysis reactions at a dilution of 1:40,000.", 
+            "type": "nucleic acid library construction protocol"
+        }
+    ], 
+    "short_label": "12w fetal neocortex", 
+    "submission_date": "2015-11-30", 
+    "supplementary_files": "ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByExp/sra/SRX/SRX145/SRX1457054", 
+    "uuid": "c440e605-51fe-4420-ad32-eed24e88fe9d"
+}

--- a/tests/fixtures/populate_lib.py
+++ b/tests/fixtures/populate_lib.py
@@ -108,6 +108,13 @@ def upload(uploader: Uploader):
             "application/json",
         )
 
+    for fname in ["assay.json", "cell.json", "manifest.json", "project.json", "sample.json"]:
+        uploader.checksum_and_upload_file(
+            f"indexing/bundles/unversioned/smartseq2/paired_ends/{fname}",
+            f"fixtures/indexing/bundles/unversioned/smartseq2/paired_ends/{fname}",
+            "application/json",
+        )
+
     # Create a bundle based on data-bundle-examples/smartseq2/paired_ends.
     # The files are accessed from the data-bundle-examples subrepository to avoid
     # duplicating them in our test infrastructure.
@@ -123,6 +130,10 @@ def upload(uploader: Uploader):
                 "application/json",
             )
 
+    # TODO (mbaumann) this block was moved to the new path "fixtures/indexing/bundles/v3/smartseq2/paired_ends"
+    # for better organization of multiple schema version test data. Remove this block when
+    # other work in progress has moved to the new code using the new location.
+    #
     # Create a bundle based on data-bundle-examples/smartseq2/paired_ends.
     # Then add some non-indexed files for a more complete and realistic bundle test.
     target_path = "fixtures/smartseq2/paired_ends"
@@ -134,6 +145,21 @@ def upload(uploader: Uploader):
             "text/plain",
         )
 
+    # Create a bundle based on data-bundle-examples/smartseq2/paired_ends.
+    # Then add some non-indexed files for a more complete and realistic bundle test.
+    target_path = "fixtures/indexing/bundles/v3/smartseq2/paired_ends"
+    load_example_smartseq2_paired_ends(target_path)
+    for fname in ["text_data_file1.txt", "text_data_file2.txt"]:
+        uploader.checksum_and_upload_file(
+            f"indexing/{fname}",
+            f"{target_path}/{fname}",
+            "text/plain",
+        )
+
+    # TODO (mbaumann) this block was moved to the new path "fixtures/indexing/bundles/unparseable_indexed_file"
+    # for better organization of the indexing test data. Remove this block when
+    # other work in progress has moved to the new code using the new location.
+
     # Create an index test bundle that includes a file of with content-type
     # 'application/json' yet cannot be parsed with json.
     # Include that file along with other valid files to ensure the
@@ -141,6 +167,21 @@ def upload(uploader: Uploader):
     # Create a bundle based on data-bundle-examples/smartseq2/paired_ends,
     # for consistency and ease of verifying valid files.
     target_path = "fixtures/unparseable_indexed_file"
+    load_example_smartseq2_paired_ends(target_path)
+    fname = "unparseable_json.json"
+    uploader.checksum_and_upload_file(
+        f"indexing/{fname}",
+        f"{target_path}/{fname}",
+        "application/json",
+    )
+
+    # Create an index test bundle that includes a file of with content-type
+    # 'application/json' yet cannot be parsed with json.
+    # Include that file along with other valid files to ensure the
+    # valid files are still processed.
+    # Create a bundle based on data-bundle-examples/smartseq2/paired_ends,
+    # for consistency and ease of verifying valid files.
+    target_path = "fixtures/indexing/bundles/unparseable_indexed_file"
     load_example_smartseq2_paired_ends(target_path)
     fname = "unparseable_json.json"
     uploader.checksum_and_upload_file(

--- a/tests/sample_search_queries.py
+++ b/tests/sample_search_queries.py
@@ -20,3 +20,32 @@ smartseq2_paired_ends_v3_query = \
             }
         }
     }
+
+smartseq2_paired_ends_v2_or_v3_query = \
+    {
+        'query': {
+            'bool': {
+                'must': [
+                    {'match': {'files.sample_json.ncbi_biosample': "SAMN04303778"}},
+                    {
+                        'bool': {
+                            'should': [
+                                {'match': {'files.assay_json.single_cell.method': "Fluidigm C1"}},
+                                {'match': {'files.assay_json.single_cell.cell_handling': "Fluidigm C1"}}
+                            ],
+                            'minimum_should_match': 1
+                        }
+                    },
+                    {
+                        'bool': {
+                            'should': [
+                                {'match': {'files.sample_json.donor.species': "Homo sapiens"}},
+                                {'match': {'files.sample_json.donor.species.text': "Homo sapiens"}}
+                            ],
+                            'minimum_should_match': 1
+                        }
+                    }
+                ]
+            }
+        }
+    }

--- a/tests/sample_search_queries.py
+++ b/tests/sample_search_queries.py
@@ -1,5 +1,26 @@
 """Sample queries for testing elastic search"""
 
+smartseq2_paired_ends_v2_query = \
+    {
+        'query': {
+            'bool': {
+                'must': [{
+                    'match': {
+                        "files.sample_json.donor.species": "Homo sapiens"
+                    }
+                }, {
+                    'match': {
+                        "files.assay_json.single_cell.method": "Fluidigm C1"
+                    }
+                }, {
+                    'match': {
+                        "files.sample_json.ncbi_biosample": "SAMN04303778"
+                    }
+                }]
+            }
+        }
+    }
+
 smartseq2_paired_ends_v3_query = \
     {
         'query': {

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -47,6 +47,7 @@ logger.setLevel(logging.INFO)
 
 start_verbose_logging()
 
+# TODO: (tsmith) test with multiple doc indexes once indexing by major version is compeleted
 
 #
 # Basic test for DSS indexer:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -37,7 +37,7 @@ logger.setLevel(logging.INFO)
 
 start_verbose_logging()
 
-
+# TODO: (tsmith) test with multiple doc indexes once indexing by major version is compeleted
 class ESInfo:
     server = None
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -329,10 +329,6 @@ class TestSearchBase(DSSAssertMixin):
         self.assertEqual(mapping['doc']['properties']['time2']['type'], 'date')
         self.assertEqual(mapping['doc']['properties']['time3']['type'], 'date')
 
-    @unittest.skip("WIP")
-    def test_search_multiple_indexes_using_alias(self):
-        pass
-
     def populate_search_index(self, index_document: dict, count: int) -> list:
         es_client = ElasticsearchClient.get(logger)
         bundles = []

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -47,6 +47,8 @@ def tearDownModule():
     IndexSuffix.reset()
     os.unsetenv('DSS_ES_PORT')
 
+# TODO: (tsmith) test with multiple doc indexes once indexing by major version is compeleted
+
 class TestSubscriptionsBase(DSSAssertMixin):
     @classmethod
     def subsciption_setup(cls, replica):

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -47,7 +47,6 @@ def tearDownModule():
     IndexSuffix.reset()
     os.unsetenv('DSS_ES_PORT')
 
-# TODO: (tsmith) test with multiple doc indexes once indexing by major version is compeleted
 
 class TestSubscriptionsBase(DSSAssertMixin):
     @classmethod
@@ -112,8 +111,9 @@ class TestSubscriptionsBase(DSSAssertMixin):
         registered_query = response['_source']
         self.assertEqual(self.sample_percolate_query, registered_query)
 
-    @unittest.skip("WIP - Registration will now succeed in this case with the proposed changes.")
-    def test_subscription_registration_fails_when_query_does_not_match_schema(self):
+    def test_subscription_registration_succeeds_when_query_does_not_match_mappings(self):
+        # It is now possible to register a subscription query before the mapping
+        # of the field exists in the mappings (and may never exist in the mapppings)
         es_query = {
             "query": {
                 "bool": {
@@ -125,26 +125,19 @@ class TestSubscriptionsBase(DSSAssertMixin):
                 }
             }
         }
-        self._put_subscription()
 
         url = str(UrlBuilder()
                   .set(path="/v1/subscriptions")
                   .add_query("replica", self.replica.name))
         resp_obj = self.assertPutResponse(
             url,
-            requests.codes.internal_server_error,
+            requests.codes.created,
             json_request_body=dict(
                 es_query=es_query,
                 callback_url=self.callback_url),
-            headers=self._get_auth_header(),
-            expected_error=ExpectedErrorFields(
-                code="elasticsearch_error",
-                status=requests.codes.internal_server_error,
-                expect_stacktrace=True)
+            headers=self._get_auth_header()
         )
-        self.assertIn("No field mapping can be found for the field with name [assay.fake_field]",
-                      resp_obj.json['stacktrace'])
-        self.assertEqual(resp_obj.json['title'], 'Unable to register elasticsearch percolate query!')
+        self.assertIn('uuid', resp_obj.json)
 
     def test_get(self):
         find_uuid = self._put_subscription()
@@ -192,10 +185,6 @@ class TestSubscriptionsBase(DSSAssertMixin):
         self.assertEqual(self.sample_percolate_query, json_response['subscriptions'][0]['es_query'])
         self.assertEqual(self.callback_url, json_response['subscriptions'][0]['callback_url'])
         self.assertEqual(NUM_ADDITIONS, len(json_response['subscriptions']))
-
-    @unittest.skip("WIP")
-    def test_subscribe_when_multiple_indexes_using_alias(self):
-        pass
 
     def test_delete(self):
         find_uuid = self._put_subscription()


### PR DESCRIPTION
Ensure subscription queries are added to indices, and do so in a way
that allows queries including fields not defined in the index mappings.
This enables subscription of queries that work across metadata schema versions,
including fields that are not present in a schema version or have
changed between versions, such as a field changing from type text to type object.
This also resolves internal constraints of needing to have the mappings defined
in an index before a subscription query for percolation can be added to the index.

This is accomplished by setting `index.percolator.map_unmapped_fields_as_string` to true,
which also works in the case of other field types (e.g. numeric, date).
Note when dynamic templates are used and queries for percolation have been added
to an index before the index contains mappings of fields referenced by those queries,
the queries must be reloaded when the mappings change for the queries to match.
For more information, see: https://github.com/elastic/elasticsearch/issues/5750

### Test plan
- Existing unit tests were updated and new unit tests were added
- Additional unit testing of exception cases is needed to increase code coverage
- Manual interactive testing with deployed system

### Deployment instructions & migrations
When updating existing deployments:
The subscription index mapping must be updated. This may be done in a way that
preserves the existing subscriptions using an appropriate script utilizing
Elasticsearch Curator.
The document indices also have a new setting, yet because this change uses a different pattern for index naming, new version-specific indices, no specific additional migration is required for this setting. 

### Release notes
- Subscription registration may now be performed before prior to loading bundles and indexing
- `put subscription` attempts to add the percolate query to every index under the `alias_name`.
- delete subscription removes percolate query from all indices to which it was added

Connects to #598 
Related to #530 and #539 