### PR TITLE
DSS-582: only return _source info on 'raw' output_format

### DIFF
--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -28,6 +28,11 @@ def post(json_request_body: dict,
          output_format: str,
          _scroll_id: typing.Optional[str] = None) -> dict:
     es_query = json_request_body['es_query']
+
+    # Do not return the raw indexed data unless it is requested
+    if output_format != 'raw':
+        es_query['_source'] = False
+
     get_logger().debug("Received posted query. Replica: %s Query: %s Per_page: %i Timeout: %s Scroll_id: %s",
                        replica, json.dumps(es_query, indent=4), per_page, _scroll_id)
     if replica is None:

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -2,6 +2,7 @@ import json
 import typing
 
 import requests
+from copy import deepcopy
 from elasticsearch.exceptions import ElasticsearchException, TransportError
 from flask import request, jsonify, make_response
 
@@ -17,7 +18,7 @@ class PerPageBounds:
 
     @classmethod
     def check(cls, n):
-        '''Limits per_page from exceed its min and max value'''
+        """Limits per_page from exceed its min and max value"""
         return max(min(cls.per_page_max, n), cls.per_page_min)
 
 
@@ -28,76 +29,28 @@ def post(json_request_body: dict,
          output_format: str,
          _scroll_id: typing.Optional[str] = None) -> dict:
     es_query = json_request_body['es_query']
+    per_page = PerPageBounds.check(per_page)
 
-    # Do not return the raw indexed data unless it is requested
-    if output_format != 'raw':
-        es_query['_source'] = False
+    if replica is None:
+        replica = "aws"
 
     get_logger().debug("Received posted query. Replica: %s Query: %s Per_page: %i Timeout: %s Scroll_id: %s",
                        replica, json.dumps(es_query, indent=4), per_page, _scroll_id)
-    if replica is None:
-        replica = "aws"
-    per_page = PerPageBounds.check(per_page)
-
-    # The time for a scroll search context to stay open per page. A page of results must be retreived before this
-    # timeout expires. Subsequent calls to search will refresh the scroll timeout. For more details on time format see:
-    # https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units
-    scroll = '2m'  # set a timeout of 2min to keep the search context alive. This is reset
-
-    # From: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
-    # Scroll requests have optimizations that make them faster when the sort order is _doc. If you want to iterate over
-    # all documents regardless of the order, this is the most efficient option:
-    # {
-    #   "sort": [
-    #     "_doc"
-    #   ]
-    # }
-    sort = {"sort": ["_doc"]}
-
     # TODO: (tsmith12) determine if a search operation timeout limit is needed
+    # TODO: (tsmith12) allow users to retrieve previous search results
+    # TODO: (tsmith12) if page returns 0 hits, then all results have been found. delete search id
     try:
-        es_client = ElasticsearchClient.get(get_logger())
-        if _scroll_id is None:
-            page = es_client.search(index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
-                                    doc_type=ESDocType.doc.name,
-                                    scroll=scroll,
-                                    size=per_page,
-                                    body=es_query,
-                                    sort=sort
-                                    )
-            get_logger().debug("Created ES scroll instance")
-        else:
-            get_logger().debug("%s", f"Retrieve ES results from scroll instance Scroll_id: {_scroll_id}")
-            page = es_client.scroll(scroll_id=_scroll_id, scroll=scroll)
+        page = _es_search_page(es_query, replica, per_page, _scroll_id, output_format)
+        request_dict = _format_request_body(page, es_query, replica, output_format)
+        request_body = jsonify(request_dict)
 
-        # TODO: (tsmith12) allow users to retrieve previous search results
-        _scroll_id = page['_scroll_id']
-
-        result_list = []  # type: typing.List[dict]
-        for hit in page['hits']['hits']:
-            result = {'bundle_id': hit['_id'],
-                      'bundle_url': _build_bundle_url(hit, replica),
-                      'search_score': hit['_score']
-                      }
-            if output_format == 'raw':
-                result['metadata'] = hit['_source']
-            result_list.append(result)
-
-        # TODO: (tsmith12) if page returns 0 hits, then all results have been found. delete search id
-        request_body = jsonify({'es_query': es_query, 'results': result_list, 'total_hits': page['hits']['total']})
-
-        if len(result_list) < per_page:
+        if len(request_dict['results']) < per_page:
             response = make_response(request_body, requests.codes.ok)
         else:
             response = make_response(request_body, requests.codes.partial)
-            next_url = request.host_url + str(UrlBuilder().set(path="v1/search")
-                                              .add_query('per_page', str(per_page))
-                                              .add_query("replica", replica)
-                                              .add_query("_scroll_id", _scroll_id)
-                                              .add_query("output_format", output_format))
-            response.headers['Link'] = build_link_header({next_url: {"rel": "next"}})
+            next_url = _build_scroll_url(page['_scroll_id'], per_page, replica, output_format)
+            response.headers['Link'] = _build_link_header({next_url: {"rel": "next"}})
         return response
-
     except TransportError as ex:
         if ex.status_code == requests.codes.bad_request:
             get_logger().debug("%s", f"Invalid Query Recieved. Exception: {ex}")
@@ -127,15 +80,88 @@ def post(json_request_body: dict,
                            "Elasticsearch Internal Server Error")
 
 
+def _es_search_page(es_query: dict,
+                    replica: str,
+                    per_page: int,
+                    _scroll_id: typing.Optional[str],
+                    output_format: str) -> dict:
+    es_query = deepcopy(es_query)
+    es_client = ElasticsearchClient.get(get_logger())
+
+    # Do not return the raw indexed data unless it is requested
+    if output_format != 'raw':
+        es_query['_source'] = False
+
+    # The time for a scroll search context to stay open per page. A page of results must be retreived before this
+    # timeout expires. Subsequent calls to search will refresh the scroll timeout. For more details on time format see:
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units
+    scroll = '2m'  # set a timeout of 2min to keep the search context alive. This is reset
+
+    # From: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
+    # Scroll requests have optimizations that make them faster when the sort order is _doc. If you want to iterate over
+    # all documents regardless of the order, this is the most efficient option:
+    # {
+    #   "sort": [
+    #     "_doc"
+    #   ]
+    # }
+    sort = {"sort": ["_doc"]}
+    if _scroll_id is None:
+        page = es_client.search(index=Config.get_es_index_name(ESIndexType.docs, Replica[replica]),
+                                doc_type=ESDocType.doc.name,
+                                scroll=scroll,
+                                size=per_page,
+                                body=es_query,
+                                sort=sort
+                                )
+        get_logger().debug("Created ES scroll instance")
+    else:
+        page = es_client.scroll(scroll_id=_scroll_id, scroll=scroll)
+        get_logger().debug(f"Retrieved ES results from scroll instance Scroll_id: {_scroll_id}")
+    return page
+
+
+def _format_request_body(page: dict, es_query: dict, replica: str, output_format: str) -> dict:
+    result_list = []  # type: typing.List[dict]
+    for hit in page['hits']['hits']:
+        result = {
+            'bundle_id': hit['_id'],
+            'bundle_url': _build_bundle_url(hit, replica),
+            'search_score': hit['_score']
+        }
+        if output_format == 'raw':
+            result['metadata'] = hit['_source']
+        result_list.append(result)
+
+    return {
+        'es_query': es_query,
+        'results': result_list,
+        'total_hits': page['hits']['total']
+    }
+
+
 def _build_bundle_url(hit: dict, replica: str) -> str:
     uuid, version = hit['_id'].split('.', 1)
-    return request.host_url + str(UrlBuilder().set(path='v1/bundles/' + uuid)
+    return request.host_url + str(UrlBuilder()
+                                  .set(path='v1/bundles/' + uuid)
                                   .add_query("version", version)
-                                  .add_query("replica", replica))
+                                  .add_query("replica", replica)
+                                  )
 
 
-def build_link_header(links):
-    """Builds a Link header according to RFC 5988.
+def _build_scroll_url(_scroll_id: str, per_page: int, replica: str, output_format: str) -> str:
+    return request.host_url + str(UrlBuilder()
+                                  .set(path="v1/search")
+                                  .add_query('per_page', str(per_page))
+                                  .add_query("replica", replica)
+                                  .add_query("_scroll_id", _scroll_id)
+                                  .add_query("output_format", output_format)
+                                  )
+
+
+def _build_link_header(links):
+    """
+    Builds a Link header according to RFC 5988.
     The format is a dict where the keys are the URI with the value being
     a dict of link parameters:
         {

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -20,6 +20,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
+from copy import deepcopy
 from dss.config import IndexSuffix
 from dss.events.handlers.index import create_elasticsearch_index
 from dss.util.es import ElasticsearchServer, ElasticsearchClient
@@ -99,6 +100,7 @@ class TestSearchBase(DSSAssertMixin):
     def test_search_returns_no_result_when_query_does_not_match_indexed_documents(self):
         query = \
             {
+                "_source": False,
                 "query": {
                     "match": {
                         "files.sample_json.donor.species": "xxx"
@@ -343,7 +345,7 @@ class TestSearchBase(DSSAssertMixin):
         return str(url)
 
     def verify_search_result(self, search_json, es_query, total_hits, expected_result_length=0):
-        self.assertDictEqual(search_json['es_query'], es_query)
+        self.assertDictEqual(search_json['es_query']['query'], es_query['query'])
         self.assertEqual(len(search_json['results']), expected_result_length)
         self.assertEqual(search_json['total_hits'], total_hits)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,7 +31,6 @@ from tests.infra import DSSAssertMixin, ExpectedErrorFields, start_verbose_loggi
 from tests.infra.server import ThreadedLocalServer
 from tests.sample_search_queries import smartseq2_paired_ends_v3_query
 
-
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -108,15 +107,13 @@ class TestSearchBase(DSSAssertMixin):
         self.verify_search_result(search_obj.json, smartseq2_paired_ends_v3_query, 0)
 
     def test_search_returns_no_result_when_query_does_not_match_indexed_documents(self):
-        query = \
-            {
-                "_source": False,
-                "query": {
-                    "match": {
-                        "files.sample_json.donor.species": "xxx"
-                    }
+        query = {
+            "query": {
+                "match": {
+                    "files.sample_json.donor.species": "xxx"
                 }
             }
+        }
         self.populate_search_index(self.index_document, 1)
         url = self.build_url()
         search_obj = self.assertPostResponse(
@@ -239,7 +236,7 @@ class TestSearchBase(DSSAssertMixin):
         self.verify_bundles(found_bundles, bundles)
 
     def test_page_has_N_results_when_per_page_is_N(self):
-                        # per_page, expected
+        # per_page, expected
         per_page_tests = [(10, 10),
                           (100, 100),
                           (500, 500)]  # max is 500
@@ -306,6 +303,7 @@ class TestSearchBase(DSSAssertMixin):
             expected_code=requests.codes.not_found,
             expected_error=ExpectedErrorFields(code="elasticsearch_context_not_found",
                                                status=requests.codes.not_found))
+
     def test_verify_dynamic_mapping(self):
         doc1 = {
             "manifest": {"data": "hello world!"},


### PR DESCRIPTION
<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->
Fixes https://github.com/HumanCellAtlas/data-store/issues/582
Connects to https://waffle.io/HumanCellAtlas/data-store/cards/59f0d13a29243f01cc41eb1d

### Test plan
TODO: The absence of the `metadata` field in non-raw output queries is tested for. The presence of `_source` information in the `metadata` field is tested for in raw output queries.

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
