### PR TITLE
Index documents according to metadata schema major version number.

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -206,6 +206,8 @@ class Config:
         index = f"dss-{index_type.name}-{deployment_stage}-{replica.name}"
         if version:
             index = f"{index}-{version}"
+        if version:
+            index = f"{index}-{version}"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -167,7 +167,7 @@ def get_index_shape_identifier(index_document: dict, logger) -> str:
             "The bundle contains mixed schema major version numbers: {}".format(sorted(list(schema_version_map.keys())))
         return "v" + list(schema_version_map.keys())[0]
     else:
-        return ""  # No files with schema identifiers were found
+        return None  # No files with schema identifiers were found
 
 
 def get_bundle_id_from_key(bundle_key: str) -> str:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -288,21 +288,21 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
                 }
             }
         }
-        with self.subtest("Same major version."):
+        with self.subTest("Same major version."):
             self.assertEqual(get_index_shape_identifier(index_document, logger), "v3")
 
         index_document['files']['assay_json']['core']['schema_version'] = "4.0.0"
-        with self.subtest("Mixed/inconsistent metadata schema release versions in the same bundle"):
+        with self.subTest("Mixed/inconsistent metadata schema release versions in the same bundle"):
             with self.assertRaisesRegex(AssertionError,
                                         "The bundle contains mixed schema major version numbers: \['3', '4'\]"):
                 get_index_shape_identifier(index_document, logger)
 
         index_document['files']['sample_json']['core']['schema_version'] = "4.0.0"
-        with self.subtest("Consistent versions, with a different version value"):
+        with self.subTest("Consistent versions, with a different version value"):
             self.assertEqual(get_index_shape_identifier(index_document, logger), "v4")
 
         index_document['files']['assay_json'].pop('core')
-        with self.subtest("An version file and unversioned file"):
+        with self.subTest("An version file and unversioned file"):
             with self.assertLogs(logger, level="INFO") as log_monitor:
                 get_index_shape_identifier(index_document, logger)
             self.assertRegex(log_monitor.output[0], ("INFO:.*File assay_json does not contain a 'core' section "
@@ -310,7 +310,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
             self.assertEqual(get_index_shape_identifier(index_document, logger), "v4")
 
         index_document['files']['sample_json'].pop('core')
-        with self.subtest("no versioned file"):
+        with self.subTest("no versioned file"):
             self.assertEqual(get_index_shape_identifier(index_document, logger), None)
 
     def test_alias_and_versioned_index_exists(self):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -270,25 +270,24 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
 
     def test_get_index_shape_identifier(self):
         from dss.events.handlers.index import get_index_shape_identifier
-        index_document = \
-            {
-                'files': {
-                    'assay_json': {
-                        'core': {
-                            'schema_url': "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json",
-                            'schema_version': "3.0.0",
-                            'type': "assay"
-                        }
-                    },
-                    'sample_json': {
-                        'core': {
-                            'schema_url': "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/sample.json",
-                            'schema_version': "3.0.0",
-                            'type': "sample"
-                        }
+        index_document = {
+            'files': {
+                'assay_json': {
+                    'core': {
+                        'schema_url': "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json",
+                        'schema_version': "3.0.0",
+                        'type': "assay"
+                    }
+                },
+                'sample_json': {
+                    'core': {
+                        'schema_url': "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/sample.json",
+                        'schema_version': "3.0.0",
+                        'type': "sample"
                     }
                 }
             }
+        }
         with self.subtest("Same major version."):
             self.assertEqual(get_index_shape_identifier(index_document, logger), "v3")
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -311,7 +311,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
 
         index_document['files']['sample_json'].pop('core')
         with self.subtest("no versioned file"):
-            self.assertEqual(get_index_shape_identifier(index_document, logger), "")
+            self.assertEqual(get_index_shape_identifier(index_document, logger), None)
 
     def test_alias_and_versioned_index_exists(self):
         sample_event = self.create_sample_bundle_created_event(self.bundle_key)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -268,11 +268,60 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
                          f"WARNING:.*:Failed notification for subscription {subscription_id}"
                          f" for bundle {bundle_id} with transaction id .+ Code: {error_response_code}")
 
-    def test_alias_exists(self):
+    def test_get_index_shape_identifier(self):
+        from dss.events.handlers.index import get_index_shape_identifier
+        index_document = \
+            {
+                'files': {
+                    'assay_json': {
+                        'core': {
+                            'schema_url': "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/assay.json",
+                            'schema_version': "3.0.0",
+                            'type': "assay"
+                        }
+                    },
+                    'sample_json': {
+                        'core': {
+                            'schema_url': "http://hgwdev.soe.ucsc.edu/~kent/hca/schema/sample.json",
+                            'schema_version': "3.0.0",
+                            'type': "sample"
+                        }
+                    }
+                }
+            }
+        self.assertEqual(get_index_shape_identifier(index_document, logger), "v3")
+
+        # Test with mixed/inconsistent metadata schema release versions in the same bundle
+        index_document['files']['assay_json']['core']['schema_version'] = "4.0.0"
+        with self.assertRaisesRegex(AssertionError,
+                                    "The bundle contains mixed schema major version numbers: \['3', '4'\]"):
+            get_index_shape_identifier(index_document, logger)
+
+        # Test with consistent versions, with a different version value
+        index_document['files']['sample_json']['core']['schema_version'] = "4.0.0"
+        self.assertEqual(get_index_shape_identifier(index_document, logger), "v4")
+
+        # Test with an version file and unversioned file
+        index_document['files']['assay_json'].pop('core')
+        with self.assertLogs(logger, level="INFO") as log_monitor:
+            get_index_shape_identifier(index_document, logger)
+        self.assertRegex(log_monitor.output[0], ("INFO:.*File assay_json does not contain a 'core' section "
+                                                 "to identify the schema and schema version."))
+        self.assertEqual(get_index_shape_identifier(index_document, logger), "v4")
+
+        # Test with no versioned file
+        index_document['files']['sample_json'].pop('core')
+        self.assertEqual(get_index_shape_identifier(index_document, logger), "")
+
+    def test_alias_and_versioned_index_exists(self):
         sample_event = self.create_sample_bundle_created_event(self.bundle_key)
         self.process_new_indexable_object(sample_event, logger)
         es_client = ElasticsearchClient.get(logger)
         self.assertTrue(es_client.indices.exists_alias(name=[self.dss_alias_name]))
+        alias = es_client.indices.get_alias(name=[self.dss_alias_name])
+        doc_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[self.replica], "v3")
+        self.assertTrue(doc_index_name in alias)
+        self.assertTrue(es_client.indices.exists(index=doc_index_name))
 
     @unittest.skip("WIP")
     def test_index_when_multiple_indexes_using_alias(self):


### PR DESCRIPTION
Place bundle index document in an ES index appropriate for the shape/structure/format 
of the metadata in the index document, so that it may be indexed successfully
without conflict.

The name of the index includes identification of the metadata schema release major number:
For example:
    v3 - Bundle contains metadata in the version 3 format
    v4 - Bundle contains metadata in the version 4 format
    ...

If no metadata version information is contained in the bundle, the bundle index document
is (attempted to be) added to the an index without a version identifier.
Currently this occurs in the case of the empty bundle used for deployment testing,
and perhaps other test data.

If/when bundle schemas are available, indexing should be updated to reflect the
bundle schema type and major version number.

Fixes #594 

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
