### PR TITLE
Grant permission to create state machine to the Travis CI group

### DIFF
--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -103,7 +103,8 @@
         "es:*",
         "sns:*",
         "states:StartExecution",
-        "states:DescribeExecution"
+        "states:DescribeExecution",
+        "states:CreateStateMachine"
       ],
       "Resource": [
         "arn:aws:lambda:*:$account_id:function:dss-*",


### PR DESCRIPTION
Grant Travis CI group permission to create state machine. This is needed as port of the deployment performed by Travis