### PR TITLE
Serialize the deployment for dss-sync and dss-index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,18 @@ $(test_srcs): %.py :
 smoketest:
 	tests/smoketest.py
 
-deploy:
+deploy: deploy-chalice deploy-daemons
+
+deploy-chalice:
 	$(MAKE) -C chalice deploy
-	$(MAKE) -C daemons deploy
+
+deploy-daemons: deploy-daemons-serial deploy-daemons-parallel
+
+deploy-daemons-serial:
+	$(MAKE) -j1 -C daemons deploy-serial
+
+deploy-daemons-parallel:
+	$(MAKE) -C daemons deploy-parallel
 
 release_staging:
 	scripts/release.sh master staging
@@ -46,4 +55,4 @@ requirements.txt requirements-dev.txt : %.txt : %.txt.in
 
 requirements-dev.txt : requirements.txt.in
 
-.PHONY: test lint mypy $(test_srcs)
+.PHONY: test lint mypy $(test_srcs) deploy deploy-chalice deploy-daemons

--- a/daemons/Makefile
+++ b/daemons/Makefile
@@ -1,6 +1,8 @@
 include ../common.mk
 
-deploy: dss-sync dss-index dss-gs-event-relay chained-aws-lambda dss-checkout-sfn
+deploy: deploy-serial deploy-parallel
+deploy-serial: dss-sync dss-index
+deploy-parallel: dss-gs-event-relay chained-aws-lambda dss-checkout-sfn
 
 dss-sync dss-index dss-checkout-sfn:
 	git clean -df $@/domovoilib $@/vendor
@@ -61,4 +63,4 @@ dss-s3-copy-write-metadata: dss-%:
 dss-gs-event-relay:
 	$(DSS_HOME)/scripts/deploy_gcf.py $@ --entry-point "dss_gs_bucket_events_$(subst -,_,$(DSS_GS_BUCKET))"
 
-.PHONY: dss-sync dss-index $(chainedawslambdatargets) $(dsschainedawslambdatargets) dss-gs-event-relay dss-checkout-sfn
+.PHONY: deploy deploy-serial deploy-parallel dss-sync dss-index $(chainedawslambdatargets) $(dsschainedawslambdatargets) dss-gs-event-relay dss-checkout-sfn


### PR DESCRIPTION
They both edit the bucket notifications, which can conflict when run in parallel.

To compensate for this, I parallelized chalice deploy with daemon deploy. :)

Connects to #668
