### PR TITLE
Clear index per test

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -61,19 +61,11 @@ class Replica(Enum):
 
 class IndexSuffix:
     '''Creates a test specific index when in test config.'''
-    __suf__ = ''  # index suffix to use
+    name = ''  # type: typing.Optional[str]
 
-    @property
-    def name(self):
-        return self.__suf__
-
-    @name.setter
-    def name(self, value: str):
-        self.__suf__ = value
-
-    @classmethod
-    def reset(cls):
-        cls.name = ''
+    @staticmethod
+    def reset():
+        IndexSuffix.name = ''
 
 
 class Config:
@@ -245,6 +237,7 @@ class Config:
         Config._NOTIFICATION_SENDER_EMAIL = os.environ[envvar]
 
         return Config._NOTIFICATION_SENDER_EMAIL
+
 
 @contextmanager
 def override_bucket_config(temp_config: BucketConfig):

--- a/tests/es/__init__.py
+++ b/tests/es/__init__.py
@@ -1,5 +1,6 @@
 import logging
-
+from typing import List
+from dss.config import IndexSuffix, Config, BucketConfig
 from dss.util.es import ElasticsearchClient
 
 logging.basicConfig(level=logging.INFO)
@@ -8,6 +9,11 @@ logger.setLevel(logging.INFO)
 
 
 def elasticsearch_delete_index(index_name: str):
+    # ensure the indexes are test index.
+    assert Config._CURRENT_CONFIG == BucketConfig.TEST
+    assert IndexSuffix.name
+    assert index_name.endswith(IndexSuffix.name)
+
     try:
         es_client = ElasticsearchClient.get(logger)
         es_client.indices.delete(index=index_name, ignore=[404])
@@ -19,3 +25,22 @@ def elasticsearch_delete_index(index_name: str):
 def close_elasticsearch_connections(es_client):
     for conn in es_client.transport.connection_pool.connections:
         conn.pool.close()
+
+
+def clear_indexes(index_names: List[str], doctypes: List[str]):
+    '''erases all of the documents in indexes with any of the doctypes provided. This can only be used in TEST
+    configuration with IndexSuffix.name set. Only indexes with the same IndexSuffix.name can be erased.'''
+
+    # ensure the indexes are test index.
+    assert Config._CURRENT_CONFIG == BucketConfig.TEST
+    assert IndexSuffix.name
+    for index_name in index_names:
+        assert index_name.endswith(IndexSuffix.name)
+
+    es_client = ElasticsearchClient.get(logger)
+    if es_client.indices.exists(index_names):
+        es_client.delete_by_query(index=index_names,
+                                  body={'query': {'match_all': {}}},
+                                  doc_type=doctypes,
+                                  refresh=True,
+                                  conflicts='proceed')

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -102,7 +102,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         Config.set_config(BucketConfig.TEST)
         _, _, cls.test_bucket = Config.get_cloud_specific_handles(cls.replica)
         cls.dss_alias_name = dss.Config.get_es_alias_name(dss.ESIndexType.docs, dss.Replica[cls.replica])
-        create_elasticsearch_index(f"initial_{IndexSuffix.name}", cls.replica, logger)
+        create_elasticsearch_index(f"initial_{IndexSuffix.name}", dss.Replica[cls.replica], logger)
         cls.subscription_index_name = dss.Config.get_es_index_name(dss.ESIndexType.subscriptions,
                                                                    dss.Replica[cls.replica])
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -198,6 +198,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
 
     def test_indexed_file_access_error(self):
         inaccesssible_filename = "inaccessible_file.json"
+        elasticsearch_delete_index(f'*{IndexSuffix.name}')
         bundle_key = self.load_test_data_bundle_with_inaccessible_file(
             "fixtures/indexing/bundles/v3/smartseq2/paired_ends", inaccesssible_filename, "application/json", True)
         sample_event = self.create_sample_bundle_created_event(bundle_key)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -24,7 +24,7 @@ from dss.config import IndexSuffix
 from dss.events.handlers.index import create_elasticsearch_index
 from dss.util.es import ElasticsearchServer, ElasticsearchClient
 from tests import get_version
-from tests.es import elasticsearch_delete_index
+from tests.es import elasticsearch_delete_index, clear_indexes
 from tests.infra import DSSAssertMixin, ExpectedErrorFields, start_verbose_logging
 from tests.infra.server import ThreadedLocalServer
 from tests.sample_search_queries import smartseq2_paired_ends_v3_query
@@ -63,15 +63,16 @@ class TestSearchBase(DSSAssertMixin):
         cls.dss_index_name = "search-unittest"
         with open(os.path.join(os.path.dirname(__file__), "sample_v3_index_doc.json"), "r") as fh:
             cls.index_document = json.load(fh)
+        create_elasticsearch_index(cls.dss_index_name, cls.replica_name, logger)
 
     @classmethod
     def tearDownClass(cls):
+        elasticsearch_delete_index(f"*{IndexSuffix.name}")
         cls.app.shutdown()
 
-    def setUp(self):
-        dss.Config.set_config(dss.BucketConfig.TEST)
-        elasticsearch_delete_index(f"*{IndexSuffix.name}")
-        create_elasticsearch_index(self.dss_index_name, self.replica, logger)
+    def tearDown(self):
+        clear_indexes([self.dss_alias_name],
+                      [ESDocType.doc.name, ESDocType.query.name])
 
     def test_es_search_page(self):
         """Confirm that elasaticsearch is returning _source info only when necessary."""
@@ -319,7 +320,9 @@ class TestSearchBase(DSSAssertMixin):
             es_client.index(index=self.dss_alias_name,
                             doc_type=ESDocType.doc.name,
                             id=bundle_id,
-                            body=index_document)
+                            body=index_document,
+                            refresh=(i == count - 1)
+                            )
             bundles.append((bundle_id, bundle_url))
         return bundles
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -63,7 +63,7 @@ class TestSearchBase(DSSAssertMixin):
         cls.dss_index_name = "search-unittest"
         with open(os.path.join(os.path.dirname(__file__), "sample_v3_index_doc.json"), "r") as fh:
             cls.index_document = json.load(fh)
-        create_elasticsearch_index(cls.dss_index_name, cls.replica_name, logger)
+        create_elasticsearch_index(cls.dss_index_name, cls.replica, logger)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -62,11 +62,11 @@ class TestSubscriptionsBase(DSSAssertMixin):
 
         logger.debug("Setting up Elasticsearch")
         es_client = ElasticsearchClient.get(logger)
-        index_shape_identifier = index_document.get_index_shape_identifier()
+        index_shape_identifier = index_document.get_shape_descriptor()
         cls.alias_name = dss.Config.get_es_alias_name(dss.ESIndexType.docs, replica)
         cls.sub_index_name = dss.Config.get_es_index_name(dss.ESIndexType.subscriptions, replica)
         cls.doc_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, replica, index_shape_identifier)
-        create_elasticsearch_index(cls.doc_index_name, cls.replica.name, logger)
+        create_elasticsearch_index(cls.doc_index_name, cls.replica, logger)
         es_client.index(index=cls.doc_index_name,
                         doc_type=dss.ESDocType.doc.name,
                         id=str(uuid.uuid4()),


### PR DESCRIPTION
Clear the contents of ES indices between tests instead of removing the indices completely.
Index creation is time consuming and this improves the performance of the tests.

Fixes #654 
Fixes #644 

### Deployment instructions & migrations
No conflicts
