### PR TITLE
Finish changes for schema version specific subscription/notification

### DIFF
--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -157,7 +157,7 @@ def delete(uuid: str, replica: str):
 
     #  get all indexes that use current alias
     alias_name = Config.get_es_alias_name(ESIndexType.docs, Replica[replica])
-    doc_indexes = [i['i'] for i in es_client.cat.aliases(name=alias_name, h=['a', 'i'], format='json')]
+    doc_indexes = [indexes['i'] for indexes in es_client.cat.aliases(name=alias_name, h=['i'], format='json')]
     _unregister_percolate(es_client, doc_indexes, uuid)
 
     es_client.delete(index=Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica]),
@@ -170,11 +170,12 @@ def delete(uuid: str, replica: str):
     return jsonify({'timeDeleted': time_deleted}), requests.codes.okay
 
 
-def _unregister_percolate(es_client: Elasticsearch, subscribed_indexes: List[str], uuid: str):
-    es_client.delete(index=subscribed_indexes,
-                     doc_type=ESDocType.query.name,
-                     id=uuid,
-                     refresh=True)
+def _unregister_percolate(es_client: Elasticsearch, subscribed_indexes: list, uuid: str):
+    for index in subscribed_indexes:
+        es_client.delete(index=index,
+                         doc_type=ESDocType.query.name,
+                         id=uuid,
+                         refresh=True)
 
 
 def _register_percolate(es_client: Elasticsearch, index_name: str, uuid: str, es_query: dict, replica: str):

--- a/dss/config.py
+++ b/dss/config.py
@@ -216,7 +216,7 @@ class Config:
     def get_es_alias_name(index_type: ESIndexType, replica: Replica) -> str:
         """Returns the alias for indexes"""
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
-        index = f"dss-{index_type.name}-{deployment_stage}-{replica.name}"
+        index = f"dss-{index_type.name}-{replica.name}-{deployment_stage}-alias"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse, unquote
 import requests
 from cloud_blobstore import BlobStore, BlobStoreError
 from collections import defaultdict
-from elasticsearch.helpers import scan
+from elasticsearch.helpers import scan, bulk, streaming_bulk, BulkIndexError
 from requests_http_signature import HTTPSignatureAuth
 
 from dss import Config, DeploymentStage, ESIndexType, ESDocType, Replica
@@ -56,8 +56,8 @@ def process_new_indexable_object(bucket_name: str, key: str, replica: str, logge
         index_shape_identifier = get_index_shape_identifier(index_data, logger)
         index_name = Config.get_es_index_name(ESIndexType.docs, Replica[replica], index_shape_identifier)
         get_elasticsearch_index(index_name, alias_name, logger)
-        add_data_to_elasticsearch(bundle_id, index_data, index_name, logger)
-        subscriptions = find_matching_subscriptions(index_data, alias_name, logger)
+        add_data_to_elasticsearch(bundle_id, index_data, index_name, replica, logger)
+        subscriptions = find_matching_subscriptions(index_data, index_name, logger)
         process_notifications(bundle_id, subscriptions, replica, logger)
         logger.debug(f"Finished index processing of {replica} creation event for bundle: {key}")
     else:
@@ -177,12 +177,6 @@ def get_bundle_id_from_key(bundle_key: str) -> str:
     raise Exception(f"This is not a key for a bundle: {bundle_key}")
 
 
-def add_index_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, alias_name: str, logger) -> None:
-    get_elasticsearch_index(index_name, alias_name, logger)
-    logger.debug("Adding index data to Elasticsearch index '%s': %s", index_name, json.dumps(index_data, indent=4))
-    add_data_to_elasticsearch(bundle_id, index_data, index_name, logger)
-
-
 def get_elasticsearch_index(index_name: str, alias_name: str, logger):
     if not ElasticsearchClient.get(logger).indices.exists(index_name):
         with open(os.path.join(os.path.dirname(__file__), "mapping.json"), "r") as fh:
@@ -194,8 +188,10 @@ def get_elasticsearch_index(index_name: str, alias_name: str, logger):
         logger.debug(f"Using existing Elasticsearch index: {index_name}")
 
 
-def add_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, logger) -> None:
+def add_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str, replica: str, logger) -> None:
     try:
+        logger.debug("Adding index data to Elasticsearch index '%s': %s", index_name, json.dumps(index_data, indent=4))
+        initial_mappings = ElasticsearchClient.get(logger).indices.get_mapping(index_name)[index_name]['mappings']
         ElasticsearchClient.get(logger).index(index=index_name,
                                               doc_type=ESDocType.doc.name,
                                               id=bundle_id,
@@ -204,6 +200,41 @@ def add_data_to_elasticsearch(bundle_id: str, index_data: dict, index_name: str,
         logger.error("Document not indexed. Exception: %s, Index name: %s,  Index data: %s", ex, index_name,
                      json.dumps(index_data, indent=4))
         raise
+
+    try:
+        current_mappings = ElasticsearchClient.get(logger).indices.get_mapping(index_name)[index_name]['mappings']
+        if initial_mappings != current_mappings:
+            refresh_percolate_queries(index_name, replica, logger)
+    except Exception as ex:
+        logger.error("Error refreshing subscription queries for index. Exception: %s, Index name: %s", ex, index_name)
+        raise
+
+
+def refresh_percolate_queries(index_name: str, replica: str, logger) -> None:
+    # When dynamic templates are used and queries for percolation have been added
+    # to an index before the index contains mappings of fields referenced by those queries,
+    # the queries must be reloaded when the mappings are present for the queries to match.
+    # See: https://github.com/elastic/elasticsearch/issues/5750
+    subscription_index_name = Config.get_es_index_name(ESIndexType.subscriptions, Replica[replica])
+    if not ElasticsearchClient.get(logger).indices.exists(subscription_index_name):
+        return
+    subscription_queries = [{'_index': index_name,
+                             '_type': ESDocType.query.name,
+                             '_id': hit['_id'],
+                             '_source': hit['_source']['es_query']
+                             }
+                            for hit in scan(ElasticsearchClient.get(logger),
+                                            index=subscription_index_name,
+                                            doc_type=ESDocType.subscription.name,
+                                            query={'query': {'match_all': {}}})
+                            ]
+
+    if len(subscription_queries) > 0:
+        try:
+            bulk(ElasticsearchClient.get(logger), iter(subscription_queries), refresh=True)
+        except BulkIndexError as ex:
+            logger.error("Error occurred when adding subscription queries to index {} Errors: {}",
+                         index_name, ex.errors)
 
 
 def find_matching_subscriptions(index_data: dict, index_name: str, logger) -> set:

--- a/dss/events/handlers/mapping.json
+++ b/dss/events/handlers/mapping.json
@@ -7,6 +7,11 @@
           "filter": ["lowercase"]
         }
       }
+    },
+    "index": {
+      "percolator": {
+        "map_unmapped_fields_as_string": true
+      }
     }
   },
   "mappings": {

--- a/tests/sample_search_queries.py
+++ b/tests/sample_search_queries.py
@@ -20,3 +20,32 @@ smartseq2_paired_ends_v3_query = \
             }
         }
     }
+
+smartseq2_paired_ends_v2_or_v3_query = \
+    {
+        'query': {
+            'bool': {
+                'must': [
+                    {'match': {'files.sample_json.ncbi_biosample': "SAMN04303778"}},
+                    {
+                        'bool': {
+                            'should': [
+                                {'match': {'files.assay_json.single_cell.method': "Fluidigm C1"}},
+                                {'match': {'files.assay_json.single_cell.cell_handling': "Fluidigm C1"}}
+                            ],
+                            'minimum_should_match': 1
+                        }
+                    },
+                    {
+                        'bool': {
+                            'should': [
+                                {'match': {'files.sample_json.donor.species': "Homo sapiens"}},
+                                {'match': {'files.sample_json.donor.species.text': "Homo sapiens"}}
+                            ],
+                            'minimum_should_match': 1
+                        }
+                    }
+                ]
+            }
+        }
+    }


### PR DESCRIPTION
Ensure subscription queries are added to indices, and do so in a way
that allows queries including fields not defined in the index mappings.
This enables subscription of queries that work across metadata schema versions,
including fields that are not present in a schema version or have
changed between versions, such as a field changing from type text to type object.
This also resolves internal constraints of needing to have the mappings defined
in an index before a subscription query for percolation can be added to the index.

This is accomplished by setting index.percolator.map_unmapped_fields_as_string to true,
which also works in the case of other field types (e.g. numeric, date).
Note when dynamic templates are used and queries for percolation have been added
to an index before the index contains mappings of fields referenced by those queries,
the queries must be reloaded when the mappings change for the queries to match.
For more information, see: https://github.com/elastic/elasticsearch/issues/5750
### Test plan

- Unit tests updated
- Manual interactive testing with deployed system

### Deployment instructions & migrations
When updating existing deployments:
The subscription index mapping must be updated. This may be done in a way that
preserves the existing subscriptions using an appropriate script utilizing
Elasticsearch Curator.
The document indicies also have a new setting, yet because this change is expected
to be merged with the schema specific indexing change, which will create new 
version-specific indicies, no specific additional migration is required for this setting. 

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->

Connects to #598 