### PR TITLE
Unit tests for multiple schema version indexing, search and subscription/notification

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -206,8 +206,6 @@ class Config:
         index = f"dss-{deployment_stage}-{replica.name}-{index_type.name}"
         if version:
             index = f"{index}-{version}"
-        if version:
-            index = f"{index}-{version}"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/assay.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/assay.json
@@ -1,0 +1,30 @@
+{
+    "files": [
+        {
+            "format": ".fastq.gz", 
+            "name": "SRR2967608_1.fastq.gz", 
+	    "lane": "1",
+            "type": "read1"
+        }, 
+        {
+            "format": ".fastq.gz", 
+            "name": "SRR2967608_2.fastq.gz", 
+	    "lane": "1",
+            "type": "read2"
+        }
+    ], 
+    "rna": {
+        "primer": "random", 
+        "spike_in": "ERCC"
+    }, 
+    "seq": {
+        "machine": "Illumina HiSeq 2500", 
+        "molecule": "total RNA", 
+        "paired_ends": "yes"
+    }, 
+    "single_cell": {
+        "method": "Fluidigm C1"
+    }, 
+    "sra_experiment": "SRX1457054", 
+    "sra_run": "SRR2967608"
+}

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/cell.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/cell.json
@@ -1,0 +1,3 @@
+{
+    "id": "fetal1_A10_fetal_12wpc_c1"
+}

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/manifest.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/manifest.json
@@ -1,0 +1,14 @@
+{
+    "version": "1",
+    "dir": "http://hgwdev.soe.ucsc.edu/~kent/hca/big_data_files",
+    "files": [
+        {
+            "format": ".fastq.gz", 
+            "name": "SRR2967608_1.fastq.gz"
+        }, 
+        {
+            "format": ".fastq.gz", 
+            "name": "SRR2967608_2.fastq.gz"
+        }
+   ]
+}

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/project.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/project.json
@@ -1,0 +1,32 @@
+{
+    "contact": {
+        "address": "Deutscher Pl. 6; Leipzig,  04103 Germany", 
+        "city": "Leipzig", 
+        "country": "Germany", 
+        "department": "Evolutionary Genetics", 
+        "email": "graycamp@gmail.com", 
+        "institute": "Max Planck Institute for Evolutionary Anthropology", 
+        "name": "Gray,,Camp", 
+        "postal_code": "04103", 
+        "street_address": "Deutscher Pl. 6"
+    }, 
+    "contributor": [
+        "Gray,,Camp", 
+        "Barbara,,Treutlein"
+    ], 
+    "geo_series": "GSE75140", 
+    "last_update_date": "2017-06-02", 
+    "ncbi_bioproject": "PRJNA304502", 
+    "overall_design": "734 single-cell transcriptomes from human fetal neocortex or human cerebral organoids from multiple time points were analyzed in this study. All single cell samples were processed on the microfluidic Fluidigm C1 platform and contain 92 external RNA spike-ins. Fetal neocortex data were generated at 12 weeks post conception (chip 1: 81 cells; chip 2: 83 cells) and 13 weeks post conception (62 cells). Cerebral organoid data were generated from dissociated whole organoids derived from induced pluripotent stem cell line 409B2 (iPSC 409B2) at 33 days (40 cells), 35 days (68 cells), 37 days (71 cells), 41 days (74 cells), and 65 days (80 cells) after the start of embryoid body culture. Cerebral organoid data were also generated from microdissected cortical-like regions from H9 embryonic stem cell derived organoids at 53 days (region 1, 48 cells; region 2, 48 cells) or from iPSC 409B2 organoids at 58 days (region 3, 43 cells; region 4, 36 cells).", 
+    "pmid": "26644564", 
+    "release_status": "Public on Dec 07 2015", 
+    "sra_project": "SRP066834", 
+    "submission_date": "2015-11-18", 
+    "summary": "Cerebral organoids \u2013 three-dimensional cultures of human cerebral tissue derived from pluripotent stem cells \u2013 have emerged as models of human cortical development. However, the extent to which in vitro organoid systems recapitulate neural progenitor cell proliferation and neuronal differentiation programs observed in vivo remains unclear. Here we use single-cell RNA sequencing (scRNA-seq) to dissect and compare cell composition and progenitor-to-neuron lineage relationships in human cerebral organoids and fetal neocortex. Covariation network analysis using the fetal neocortex data reveals known and novel interactions among genes central to neural progenitor proliferation and neuronal differentiation. In the organoid, we detect diverse progenitors and differentiated cell types of neuronal and mesenchymal lineages, and identify cells that derived from regions resembling the fetal neocortex. We find that these organoid cortical cells use gene expression programs remarkably similar to those of the fetal tissue in order to organize into cerebral cortex-like regions. Our comparison of in vivo and in vitro cortical single cell transcriptomes illuminates the genetic features underlying human cortical development that can be studied in organoid cultures.", 
+    "supplementary_files": [
+        "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE75nnn/GSE75140/suppl/GSE75140_hOrg.fetal.master.data.frame.txt.gz", 
+        "ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP/SRP066/SRP066834"
+    ], 
+    "title": "Human cerebral organoids recapitulate gene expression programs of fetal neocortex development.", 
+    "uuid": "15fe881c-f4b8-4d15-a270-092b8e5d850a"
+}

--- a/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/sample.json
+++ b/tests/fixtures/datafiles/indexing/bundles/unversioned/smartseq2/paired_ends/sample.json
@@ -1,0 +1,46 @@
+{
+    "body_part": {
+        "name": "neocortex", 
+        "organ": "brain"
+    }, 
+    "data_processing": [
+        "\"freeIbis\" was used as an efficient basecaller with calibrated quality scores for Illumina sequencers. (Bioinformatics. 2013 May 1;29(9):1208-9. doi: 10.1093/bioinformatics/btt117. Epub 2013 Mar 6.)", 
+        "\"leeHom\" was used to trim adapters and merge Illumina sequencing reads. (Nucleic Acids Res. 2014 Oct;42(18):e141. doi: 10.1093/nar/gku699. Epub 2014 Aug 6.)", 
+        "\"deML\" was used for robust demultiplexing of Illumina sequences using a likelihood-based approach. (Bioinformatics. 2015 Mar 1;31(5):770-2. doi: 10.1093/bioinformatics/btu719. Epub 2014 Oct 30.)", 
+        "Reads were aligned against the human genome (build GRCh38.77 from ENSEMBLE) using TopHat v2.0.14. The genome was indexed using Bowtie v2.2.6", 
+        "Fragments Per Kilobase of transcript Per Million mapped reads (FPKM) values were computed using cufflinks v2.2.1", 
+        "Genome_build: GRCh38", 
+        "Supplementary_files_format_and_content: Master data frame including sample name, gene ID, and FPKM values for each single cell."
+    ], 
+    "donor": {
+        "age": "12", 
+        "age_unit": "week", 
+        "id": "fetus 1", 
+        "uuid": "6860fb7c-6167-4b6c-9bae-58098f35cc05",
+        "life_stage": "embryo", 
+        "ncbi_taxon": "9606", 
+        "species": "Homo sapiens"
+    }, 
+    "geo_sample": "GSM1957573", 
+    "last_update_date": "2015-12-07", 
+    "long_label": "12 week post conception fetal neocortex", 
+    "ncbi_biosample": "SAMN04303778", 
+    "protocols": [
+        {
+            "description": "Fetuses were 12 to 13 wpc as assessed by ultrasound measurements of crown-rump length and other standard criteria of developmental stage determination.", 
+            "type": "growth protocol"
+        }, 
+        {
+            "description": "Fetal cortices were digested with papain (Miltenyi Biotec, 1ml) for 15 min at 37\u00b0C on a rotating wheel, followed by addition of a papain inhibitor. Dissociated cells were filtered through 40, 30, and 20 \u03bcm diameter strainers to create a single cell suspension.", 
+            "type": "treatment protocol"
+        }, 
+        {
+            "description": "Cells were loaded into the Fluidigm C1 microfluidic platform, where single cells were captured. Lysis of single cells, reverse-transcription of mRNA into cDNA as well as preamplification of cDNA occured within the microfluidic device using reagents provided by Fluidigm as well as the SMARTer Ultra Low RNA kit for Illumina (Clontech). External RNA spike-in transcripts (ERCC spike-in Mix, Ambion) were added to all single cell lysis reactions at a dilution of 1:40,000.", 
+            "type": "nucleic acid library construction protocol"
+        }
+    ], 
+    "short_label": "12w fetal neocortex", 
+    "submission_date": "2015-11-30", 
+    "supplementary_files": "ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByExp/sra/SRX/SRX145/SRX1457054", 
+    "uuid": "c440e605-51fe-4420-ad32-eed24e88fe9d"
+}

--- a/tests/fixtures/populate_lib.py
+++ b/tests/fixtures/populate_lib.py
@@ -108,6 +108,13 @@ def upload(uploader: Uploader):
             "application/json",
         )
 
+    for fname in ["assay.json", "cell.json", "manifest.json", "project.json", "sample.json"]:
+        uploader.checksum_and_upload_file(
+            f"indexing/bundles/unversioned/smartseq2/paired_ends/{fname}",
+            f"fixtures/indexing/bundles/unversioned/smartseq2/paired_ends/{fname}",
+            "application/json",
+        )
+
     # Create a bundle based on data-bundle-examples/smartseq2/paired_ends.
     # The files are accessed from the data-bundle-examples subrepository to avoid
     # duplicating them in our test infrastructure.
@@ -125,7 +132,7 @@ def upload(uploader: Uploader):
 
     # Create a bundle based on data-bundle-examples/smartseq2/paired_ends.
     # Then add some non-indexed files for a more complete and realistic bundle test.
-    target_path = "fixtures/smartseq2/paired_ends"
+    target_path = "fixtures/indexing/bundles/v3/smartseq2/paired_ends"
     load_example_smartseq2_paired_ends(target_path)
     for fname in ["text_data_file1.txt", "text_data_file2.txt"]:
         uploader.checksum_and_upload_file(
@@ -140,7 +147,7 @@ def upload(uploader: Uploader):
     # valid files are still processed.
     # Create a bundle based on data-bundle-examples/smartseq2/paired_ends,
     # for consistency and ease of verifying valid files.
-    target_path = "fixtures/unparseable_indexed_file"
+    target_path = "fixtures/indexing/bundles/unparseable_indexed_file"
     load_example_smartseq2_paired_ends(target_path)
     fname = "unparseable_json.json"
     uploader.checksum_and_upload_file(

--- a/tests/sample_search_queries.py
+++ b/tests/sample_search_queries.py
@@ -1,5 +1,26 @@
 """Sample queries for testing elastic search"""
 
+smartseq2_paired_ends_v2_query = \
+    {
+        'query': {
+            'bool': {
+                'must': [{
+                    'match': {
+                        "files.sample_json.donor.species": "Homo sapiens"
+                    }
+                }, {
+                    'match': {
+                        "files.assay_json.single_cell.method": "Fluidigm C1"
+                    }
+                }, {
+                    'match': {
+                        "files.sample_json.ncbi_biosample": "SAMN04303778"
+                    }
+                }]
+            }
+        }
+    }
+
 smartseq2_paired_ends_v3_query = \
     {
         'query': {

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -33,7 +33,8 @@ from tests import get_version
 from tests.es import elasticsearch_delete_index
 from tests.infra import DSSAssertMixin, DSSUploadMixin, DSSStorageMixin, TestBundle, start_verbose_logging
 from tests.infra.server import ThreadedLocalServer
-from tests.sample_search_queries import smartseq2_paired_ends_v2_or_v3_query
+from tests.sample_search_queries import (smartseq2_paired_ends_v2_query, smartseq2_paired_ends_v3_query,
+                                         smartseq2_paired_ends_v2_or_v3_query)
 
 # The moto mock has two defects that show up when used by the dss core storage system.
 # Use actual S3 until these defects are fixed in moto.
@@ -108,7 +109,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
     def setUp(self):
         if self.replica not in TestIndexerBase.bundle_key_by_replica:
             TestIndexerBase.bundle_key_by_replica[self.replica] = self.load_test_data_bundle_for_path(
-                "fixtures/smartseq2/paired_ends")
+                "fixtures/indexing/bundles/v3/smartseq2/paired_ends")
         self.bundle_key = TestIndexerBase.bundle_key_by_replica[self.replica]
         self.smartseq2_paired_ends_query = smartseq2_paired_ends_v2_or_v3_query
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
@@ -126,7 +127,8 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
                                                          files=smartseq2_paried_ends_indexed_file_list)
 
     def test_indexed_file_with_invalid_content_type(self):
-        bundle = TestBundle(self.blobstore, "fixtures/smartseq2/paired_ends", self.test_fixture_bucket, self.replica)
+        bundle = TestBundle(self.blobstore, "fixtures/indexing/bundles/v3/smartseq2/paired_ends",
+                            self.test_fixture_bucket, self.replica)
         # Configure a file to be indexed that is not of context type 'application/json'
         for file in bundle.files:
             if file.name == "text_data_file1.txt":
@@ -171,7 +173,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         self.assertRegex(log_monitor.output[0], "ERROR:.*Exception occurred while processing .* event:.*")
 
     def test_indexed_file_unparsable(self):
-        bundle_key = self.load_test_data_bundle_for_path("fixtures/unparseable_indexed_file")
+        bundle_key = self.load_test_data_bundle_for_path("fixtures/indexing/bundles/unparseable_indexed_file")
         sample_event = self.create_sample_bundle_created_event(bundle_key)
         with self.assertLogs(logger, level="WARNING") as log_monitor:
             self.process_new_indexable_object(sample_event, logger)
@@ -186,7 +188,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
     def test_indexed_file_access_error(self):
         inaccesssible_filename = "inaccessible_file.json"
         bundle_key = self.load_test_data_bundle_with_inaccessible_file(
-            "fixtures/smartseq2/paired_ends", inaccesssible_filename, "application/json", True)
+            "fixtures/indexing/bundles/v3/smartseq2/paired_ends", inaccesssible_filename, "application/json", True)
         sample_event = self.create_sample_bundle_created_event(bundle_key)
         with self.assertLogs(logger, level="WARNING") as log_monitor:
             self.process_new_indexable_object(sample_event, logger)
@@ -254,7 +256,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
                                                           hmac_secret_key=PostTestHandler.hmac_secret_key,
                                                           hmac_key_id="test")
 
-        bundle_key = self.load_test_data_bundle_for_path("fixtures/smartseq2/paired_ends")
+        bundle_key = self.load_test_data_bundle_for_path("fixtures/indexing/bundles/v3/smartseq2/paired_ends")
         sample_event = self.create_sample_bundle_created_event(bundle_key)
         error_response_code = 500
         PostTestHandler.set_response_code(error_response_code)
@@ -327,12 +329,61 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         self.assertTrue(es_client.indices.exists_alias(name=[self.dss_alias_name]))
         alias = es_client.indices.get_alias(name=[self.dss_alias_name])
         doc_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[self.replica], "v3")
-        self.assertTrue(doc_index_name in alias)
+        self.assertIn(doc_index_name, alias)
         self.assertTrue(es_client.indices.exists(index=doc_index_name))
 
-    @unittest.skip("WIP")
-    def test_index_when_multiple_indexes_using_alias(self):
-        pass
+    def test_alias_and_multiple_schema_version_index_exists(self):
+        # Load and test an unversioned bundle
+        bundle_key = self.load_test_data_bundle_for_path("fixtures/indexing/bundles/unversioned/smartseq2/paired_ends")
+        sample_event = self.create_sample_bundle_created_event(bundle_key)
+        self.process_new_indexable_object(sample_event, logger)
+        es_client = ElasticsearchClient.get(logger)
+        alias = es_client.indices.get_alias(name=[self.dss_alias_name])
+        unversioned_doc_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[self.replica], None)
+        self.assertIn(unversioned_doc_index_name, alias)
+        self.assertTrue(es_client.indices.exists(index=unversioned_doc_index_name))
+
+        # Load and test a v3 bundle
+        sample_event = self.create_sample_bundle_created_event(self.bundle_key)
+        self.process_new_indexable_object(sample_event, logger)
+        self.assertTrue(es_client.indices.exists_alias(name=[self.dss_alias_name]))
+        alias = es_client.indices.get_alias(name=[self.dss_alias_name])
+        doc_index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, dss.Replica[self.replica], "v3")
+        # Ensure the alias references both indices
+        self.assertIn(unversioned_doc_index_name, alias)
+        self.assertIn(doc_index_name, alias)
+        self.assertTrue(es_client.indices.exists(index=doc_index_name))
+
+    def test_multiple_schema_version_indexing_and_search(self):
+        # Load a schema version 2 (unversioned) bundle
+        bundle_key = self.load_test_data_bundle_for_path("fixtures/indexing/bundles/unversioned/smartseq2/paired_ends")
+        sample_event = self.create_sample_bundle_created_event(bundle_key)
+        self.process_new_indexable_object(sample_event, logger)
+
+        # Search using a v2-specific query - should match
+        search_results = self.get_search_results(smartseq2_paired_ends_v2_query, 1)
+        self.assertEqual(1, len(search_results))
+        self.verify_index_document_structure_and_content(search_results[0], bundle_key,
+                                                         files=smartseq2_paried_ends_indexed_file_list)
+        # Search using a query that works for v2 or v3 - should match
+        search_results = self.get_search_results(smartseq2_paired_ends_v2_or_v3_query, 1)
+        self.assertEqual(1, len(search_results))
+
+        # Search using a v3-specific query - should not match
+        search_results = self.get_search_results(smartseq2_paired_ends_v3_query, 0)
+        self.assertEqual(0, len(search_results))
+
+        # Load a v3 bundle
+        sample_event = self.create_sample_bundle_created_event(self.bundle_key)
+        self.process_new_indexable_object(sample_event, logger)
+
+        # Search using a v3-specific query - should match
+        search_results = self.get_search_results(smartseq2_paired_ends_v3_query, 1)
+        self.assertEqual(1, len(search_results))
+
+        # Search using a query that works for v2 or v3 - should match both v2 and v3 bundles
+        search_results = self.get_search_results(smartseq2_paired_ends_v2_or_v3_query, 2)
+        self.assertEqual(2, len(search_results))
 
     def verify_notification(self, subscription_id, es_query, bundle_id):
         posted_payload_string = self.get_notification_payload()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -329,10 +329,6 @@ class TestSearchBase(DSSAssertMixin):
         self.assertEqual(mapping['doc']['properties']['time2']['type'], 'date')
         self.assertEqual(mapping['doc']['properties']['time3']['type'], 'date')
 
-    @unittest.skip("WIP")
-    def test_search_multiple_indexes_using_alias(self):
-        pass
-
     def populate_search_index(self, index_document: dict, count: int) -> list:
         es_client = ElasticsearchClient.get(logger)
         bundles = []

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -47,7 +47,6 @@ def tearDownModule():
     IndexSuffix.reset()
     os.unsetenv('DSS_ES_PORT')
 
-# TODO: (tsmith) test with multiple doc indexes once indexing by major version is compeleted
 
 class TestSubscriptionsBase(DSSAssertMixin):
     @classmethod
@@ -192,10 +191,6 @@ class TestSubscriptionsBase(DSSAssertMixin):
         self.assertEqual(self.sample_percolate_query, json_response['subscriptions'][0]['es_query'])
         self.assertEqual(self.callback_url, json_response['subscriptions'][0]['callback_url'])
         self.assertEqual(NUM_ADDITIONS, len(json_response['subscriptions']))
-
-    @unittest.skip("WIP")
-    def test_subscribe_when_multiple_indexes_using_alias(self):
-        pass
 
     def test_delete(self):
         find_uuid = self._put_subscription()


### PR DESCRIPTION
Test with version 2 (unversioned) data bundles, in addition to current (version 3)
data bundles. Verify correct aliases and indices are crated and that both version-specific
and multi-version searches and subscriptions/notifications work as expected.

**The populate.py script must be run to update the text fixture buckets for these tests
to pass.**

Tests with version 4 and later data will be added when the data is available.
