### PR TITLE
Enable dss Lambda to use "es:ESHttpPost" to ES server

### DIFF
--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -41,6 +41,7 @@
         "es:ESHttpGet",
         "es:ESHttpHead",
         "es:ESHttpPut",
+        "es:ESHttpPost",
         "es:ESHttpDelete"
       ],
       "Resource": "arn:aws:es:*:$account_id:domain/$dss_es_domain/*"


### PR DESCRIPTION
Fixes #699 (please see this issue for details)

With this change, smoketest passes on master.