### PR TITLE
Apply checkout bucket expiration policy

### DIFF
--- a/daemons/Makefile
+++ b/daemons/Makefile
@@ -5,7 +5,7 @@ deploy-serial: dss-sync dss-index
 deploy-parallel: dss-gs-event-relay chained-aws-lambda dss-checkout-sfn
 
 dss-sync dss-index dss-checkout-sfn:
-	git clean -df $@/domovoilib $@/vendor
+	#git clean -df $@/domovoilib $@/vendor
 	shopt -s nullglob; for wheel in $@/vendor.in/*/*.whl; do unzip -q -o -d $@/vendor $$wheel; done
 	cp -R ../dss ../dss-api.yml $@/domovoilib
 	cp "$(GOOGLE_APPLICATION_CREDENTIALS)" $@/domovoilib/gcp-credentials.json
@@ -15,6 +15,8 @@ dss-sync dss-index dss-checkout-sfn:
 		./invoke_lambda.sh $@ $(DSS_DEPLOYMENT_STAGE) \
 			../tests/daemons/sample_s3_bundle_created_event.json.template \
 			../tests/daemons/a47b90b2-0967-4fbf-87bc-c6c12db3fedf.2017-07-12T055120.037644Z; \
+	else \
+	    $(DSS_HOME)/scripts/deploy_checkout_lifecycle.py; \
 	fi
 
 chainedawslambdatargets := chained-aws-lambda-s3-parallel-copy-supervisor chained-aws-lambda-s3-parallel-copy-worker

--- a/daemons/Makefile
+++ b/daemons/Makefile
@@ -5,7 +5,7 @@ deploy-serial: dss-sync dss-index
 deploy-parallel: dss-gs-event-relay chained-aws-lambda dss-checkout-sfn
 
 dss-sync dss-index dss-checkout-sfn:
-	#git clean -df $@/domovoilib $@/vendor
+	git clean -df $@/domovoilib $@/vendor
 	shopt -s nullglob; for wheel in $@/vendor.in/*/*.whl; do unzip -q -o -d $@/vendor $$wheel; done
 	cp -R ../dss ../dss-api.yml $@/domovoilib
 	cp "$(GOOGLE_APPLICATION_CREDENTIALS)" $@/domovoilib/gcp-credentials.json

--- a/scripts/deploy_checkout_lifecycle.py
+++ b/scripts/deploy_checkout_lifecycle.py
@@ -3,11 +3,11 @@
 import os
 import boto3
 
-checkout_buket = os.environ["DSS_S3_CHECKOUT_BUCKET"]
+checkout_bucket = os.environ["DSS_S3_CHECKOUT_BUCKET"]
 s3_client = boto3.client('s3')
 
 s3_client.put_bucket_lifecycle_configuration(
-    Bucket=checkout_buket,
+    Bucket=checkout_bucket,
     LifecycleConfiguration={
         "Rules": [
             {

--- a/scripts/deploy_checkout_lifecycle.py
+++ b/scripts/deploy_checkout_lifecycle.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import os
+import boto3
+
+checkout_buket = os.environ["DSS_S3_CHECKOUT_BUCKET"]
+s3_client = boto3.client('s3')
+
+s3_client.put_bucket_lifecycle_configuration(
+    Bucket=checkout_buket,
+    LifecycleConfiguration={
+        "Rules": [
+            {
+            'Filter': {},
+            'Status': 'Enabled',
+            "Expiration": {
+                "Days": 30,
+            },
+            'ID': "dss_checkout_expiration",
+        }]
+    }
+)


### PR DESCRIPTION
Apply S3 lifecycle rule to the checkout bucket to automatically expire files based on the creation date. Connects to #641  


### Test plan
Manually validated via AWS S3 console - confirmed that lifecycle rule is installed. 
Also set shortest possible expiration period 1 day and confirmed:
- files are deleted next day
- checkout of the same bundle updates date created and resets the "timer"
