### PR TITLE
Definition for a parallelized s3 copy state machine that also writes file metadata.

### DIFF
--- a/dss/stepfunctions/s3copyclient/__init__.py
+++ b/dss/stepfunctions/s3copyclient/__init__.py
@@ -1,4 +1,4 @@
-from .implementation import Key, sfn
+from .implementation import CopyWriteMetadataKey, Key, sfn, copy_write_metadata_sfn
 
 
 def copy_sfn_event(source_bucket: str, source_key: str, destination_bucket: str, destination_key: str) -> dict:
@@ -9,3 +9,21 @@ def copy_sfn_event(source_bucket: str, source_key: str, destination_bucket: str,
         Key.DESTINATION_BUCKET: destination_bucket,
         Key.DESTINATION_KEY: destination_key,
     }
+
+
+def copy_write_metadata_sfn_event(
+        source_bucket: str, source_key: str,
+        destination_bucket: str, destination_key: str,
+        file_uuid: str, file_version: str,
+        metadata: str,
+) -> dict:
+    """
+    Returns the initial event object to start the stepfunction that performs a s3-s3 copy and writes the HCA /files
+    metadata file.
+    """
+    base = copy_sfn_event(source_bucket, source_key, destination_bucket, destination_key)
+    base[CopyWriteMetadataKey.FILE_UUID] = file_uuid
+    base[CopyWriteMetadataKey.FILE_VERSION] = file_version
+    base[CopyWriteMetadataKey.METADATA] = metadata
+
+    return base


### PR DESCRIPTION
Most of the code is lifted from dss/events/chunkedtask/s3copyclient.py.

Connects to #592.
Depends on #704, #707.