### PR TITLE
[WIP] Run `make deploy` and smoketest during PR builds [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,14 @@ requirements.txt requirements-dev.txt : %.txt : %.txt.in
 
 requirements-dev.txt : requirements.txt.in
 
+lock-stage:
+	# The lock on the mutex expires after 30 min
+	python -m dyndbmutex.cli $$DSS_DEPLOYMENT_STAGE lock --blocking --expiration 1800
+
+unlock-stage:
+	python -m dyndbmutex.cli $$DSS_DEPLOYMENT_STAGE release
+
 .PHONY: lint mypy
 .PHONY: test all_test integration_test standalone_test $(test_srcs) $(integration_test_srcs) $(standalone_test_srcs)
 .PHONY: deploy deploy-chalice deploy-daemons
+.PHONY lock-stage unlock-stage

--- a/Makefile
+++ b/Makefile
@@ -79,14 +79,14 @@ requirements.txt requirements-dev.txt : %.txt : %.txt.in
 
 requirements-dev.txt : requirements.txt.in
 
-lock-stage:
+lock_stage:
 	# The lock on the mutex expires after 30 min
 	python -m dyndbmutex.cli $$DSS_DEPLOYMENT_STAGE lock --blocking --expiration 1800
 
-unlock-stage:
+unlock_stage:
 	python -m dyndbmutex.cli $$DSS_DEPLOYMENT_STAGE release
 
 .PHONY: lint mypy
 .PHONY: test all_test integration_test standalone_test $(test_srcs) $(integration_test_srcs) $(standalone_test_srcs)
 .PHONY: deploy deploy-chalice deploy-daemons
-.PHONY lock-stage unlock-stage
+.PHONY: lock_stage unlock_stage

--- a/common.mk
+++ b/common.mk
@@ -19,7 +19,3 @@ endif
 ifeq ($(findstring Python 3.6, $(shell python --version 2>&1)),)
 $(error Please run make commands from a Python 3.6 virtualenv)
 endif
-
-ifneq ($(shell python -c 'import dyndbmutex' && echo yes), yes)
-$(error The dyndbmutex package is missing. Installing build requirements from requirements-dev.txt should fix that)
-endif

--- a/common.mk
+++ b/common.mk
@@ -19,3 +19,7 @@ endif
 ifeq ($(findstring Python 3.6, $(shell python --version 2>&1)),)
 $(error Please run make commands from a Python 3.6 virtualenv)
 endif
+
+ifneq ($(shell python -c 'import dyndbmutex' && echo yes), yes)
+$(error The dyndbmutex package is missing. Installing build requirements from requirements-dev.txt should fix that)
+endif

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,6 +27,7 @@ docker==2.6.1
 docker-pycreds==0.2.1
 docutils==0.14
 domovoi==1.4.5
+-e git://github.com/hannes-ucsc/lambda-mutex@f8f4d694546075d839edd216af89eccd6d3e3b81#egg=dyndbmutex
 elasticsearch==5.5.1
 elasticsearch-dsl==5.3.0
 flake8==3.5.0

--- a/requirements-dev.txt.in
+++ b/requirements-dev.txt.in
@@ -9,4 +9,5 @@ moto  >= 1.1.21
 crcmod  >= 1.7
 httpie  >= 0.9.9
 yq  >= 2.3.3
+-e git+git://github.com/hannes-ucsc/lambda-mutex@master#egg=dyndbmutex
 -r requirements.txt


### PR DESCRIPTION
This enables `make deploy` and `make smoketest` for PR builds in Travis CI. All builds hit the dev stage. To serialize access of CI builds to dev, mutexes are used.

The mutexes use DynamoDB conditional row updates and have a configurable expiration. They are implemented in a separate Python package at https://github.com/hannes-ucsc/lambda-mutex, a fork of https://github.com/chiradeep/lambda-mutex. I added a fix for a race condition when the utility is run for the first time in an AWS region, added blocking mode (with timeout) for mutex.lock() and added a CLI.

Reviewers should pay special attention to the Travis config.

The biggest problem with this is that master and PR builds still share the dev stage. A failed `make deploy` from a PR build could pollute that stage beyond repair, breaking subsequent builds. I think we should create a special sandbox environment for PR builds in order to decouple them from master.

