### PR TITLE
Extract BundleDocument class from indexer

### DIFF
--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -225,10 +225,10 @@ class BundleDocument(dict):
                               json.dumps(self, indent=4))  # noqa
             initial_mappings = es_client.indices.get_mapping(index_name)[index_name]['mappings']
             es_client.index(index=index_name,
-                      doc_type=ESDocType.doc.name,
-                      id=self.bundle_id,
-                      # FIXME: (hannes) Can this be json.dumps(self, indent=4) ?
-                                                       body=json.dumps(self))  # Don't use refresh here.
+                            doc_type=ESDocType.doc.name,
+                            id=self.bundle_id,
+                            # FIXME: (hannes) Can this be json.dumps(self, indent=4) ?
+                            body=json.dumps(self))  # Don't use refresh here.
         except Exception as ex:
             self.logger.error("Document not indexed. Exception: %s, Index name: %s,  Index data: %s",
                               ex, index_name, json.dumps(self, indent=4))

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -155,7 +155,7 @@ class BundleDocument(dict):
                 index_files[index_filename] = file_json
         return index_files
 
-    def get_index_shape_identifier(self) -> str:
+    def get_index_shape_identifier(self) -> typing.Optional[str]:
         """ Return string identifying the shape/structure/format of the data in the index document,
         so that it may be indexed appropriately.
 

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -119,24 +119,24 @@ class BundleDocument(dict):
         for file_info in files_info:
             if file_info[BundleFileMetadata.INDEXED] is True:
                 if not file_info[BundleFileMetadata.CONTENT_TYPE].startswith('application/json'):
-                    self.logger.warning(f"In bundle {self.bundle_id} the file \"{file_info[BundleFileMetadata.NAME]}\""
+                    self.logger.warning(f"In bundle {self.bundle_id} the file '{file_info[BundleFileMetadata.NAME]}'"
                                         " is marked for indexing yet has content type"
-                                        f" \"{file_info[BundleFileMetadata.CONTENT_TYPE]}\""
-                                        " instead of the required content type \"application/json\"."
+                                        f" '{file_info[BundleFileMetadata.CONTENT_TYPE]}'"
+                                        " instead of the required content type 'application/json'."
                                         " This file will not be indexed.")
                     continue
+                file_blob_key = create_blob_key(file_info)
                 try:
-                    file_blob_key = create_blob_key(file_info)
                     file_string = handle.get(bucket_name, file_blob_key).decode("utf-8")
                     file_json = json.loads(file_string)
                 # TODO (mbaumann) Are there other JSON-related exceptions that should be checked below?
                 except json.decoder.JSONDecodeError as ex:
-                    self.logger.warning(f"In bundle {self.bundle_id} the file \"{file_info[BundleFileMetadata.NAME]}\""
+                    self.logger.warning(f"In bundle {self.bundle_id} the file '{file_info[BundleFileMetadata.NAME]}'"
                                         " is marked for indexing yet could not be parsed."
                                         " This file will not be indexed. Exception: %s", ex)
                     continue
                 except BlobStoreError as ex:
-                    self.logger.warning(f"In bundle {self.bundle_id} the file \"{file_info[BundleFileMetadata.NAME]}\""
+                    self.logger.warning(f"In bundle {self.bundle_id} the file '{file_info[BundleFileMetadata.NAME]}'"
                                         " is marked for indexing yet could not be accessed."
                                         " This file will not be indexed. Exception: %s, File blob key: %s",
                                         type(ex).__name__, file_blob_key)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -25,7 +25,7 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss import Config, BucketConfig, DeploymentStage
 from dss.config import IndexSuffix
-from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object, notify
+from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object, BundleDocument
 from dss.hcablobstore import BundleMetadata, BundleFileMetadata, FileMetadata
 from dss.util import create_blob_key, networking, UrlBuilder
 from dss.util.es import ElasticsearchClient, ElasticsearchServer
@@ -205,7 +205,8 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
 
     def test_notify(self):
         def _notify(subscription, bundle_id="i.v"):
-            notify(subscription_id=subscription["id"], subscription=subscription, bundle_id=bundle_id, logger=logger)
+            document = BundleDocument.from_json(self.replica, bundle_id, {}, logger)
+            document.notify(subscription_id=subscription["id"], subscription=subscription)
         with self.assertRaisesRegex(requests.exceptions.InvalidURL, "Invalid URL 'http://': No host supplied"):
             _notify(subscription=dict(id="", es_query={}, callback_url="http://"))
         with self.assertRaisesRegex(AssertionError, "Unexpected scheme for callback URL"):
@@ -330,8 +331,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         self.delete_subscription(subscription_id)
 
     def test_get_index_shape_identifier(self):
-        from dss.events.handlers.index import get_index_shape_identifier
-        index_document = {
+        index_document = BundleDocument.from_json(self.replica, 'uuid.version', {
             'files': {
                 'assay_json': {
                     'core': {
@@ -348,31 +348,31 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
                     }
                 }
             }
-        }
+        }, logger)
         with self.subTest("Same major version."):
-            self.assertEqual(get_index_shape_identifier(index_document, logger), "v3")
+            self.assertEqual(index_document.get_index_shape_identifier(), "v3")
 
         index_document['files']['assay_json']['core']['schema_version'] = "4.0.0"
         with self.subTest("Mixed/inconsistent metadata schema release versions in the same bundle"):
             with self.assertRaisesRegex(AssertionError,
                                         "The bundle contains mixed schema major version numbers: \['3', '4'\]"):
-                get_index_shape_identifier(index_document, logger)
+                index_document.get_index_shape_identifier()
 
         index_document['files']['sample_json']['core']['schema_version'] = "4.0.0"
         with self.subTest("Consistent versions, with a different version value"):
-            self.assertEqual(get_index_shape_identifier(index_document, logger), "v4")
+            self.assertEqual(index_document.get_index_shape_identifier(), "v4")
 
         index_document['files']['assay_json'].pop('core')
         with self.subTest("An version file and unversioned file"):
             with self.assertLogs(logger, level="INFO") as log_monitor:
-                get_index_shape_identifier(index_document, logger)
+                index_document.get_index_shape_identifier()
             self.assertRegex(log_monitor.output[0], ("INFO:.*File assay_json does not contain a 'core' section "
                                                      "to identify the schema and schema version."))
-            self.assertEqual(get_index_shape_identifier(index_document, logger), "v4")
+            self.assertEqual(index_document.get_index_shape_identifier(), "v4")
 
         index_document['files']['sample_json'].pop('core')
         with self.subTest("no versioned file"):
-            self.assertEqual(get_index_shape_identifier(index_document, logger), None)
+            self.assertEqual(index_document.get_index_shape_identifier(), None)
 
     def test_alias_and_versioned_index_exists(self):
         sample_event = self.create_sample_bundle_created_event(self.bundle_key)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -138,9 +138,9 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         with self.assertLogs(logger, level="WARNING") as log_monitor:
             self.process_new_indexable_object(sample_event, logger)
         self.assertRegex(log_monitor.output[0],
-                         "WARNING:.*:In bundle .* the file \"text_data_file1.txt\" is marked for indexing"
-                         " yet has content type \"text/plain\" instead of the required"
-                         " content type \"application/json\". This file will not be indexed.")
+                         "WARNING:.*:In bundle .* the file 'text_data_file1.txt' is marked for indexing"
+                         " yet has content type 'text/plain' instead of the required"
+                         " content type 'application/json'. This file will not be indexed.")
         search_results = self.get_search_results(self.smartseq2_paired_ends_query, 1)
         self.assertEqual(1, len(search_results))
         self.verify_index_document_structure_and_content(search_results[0], bundle_key,
@@ -178,7 +178,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         with self.assertLogs(logger, level="WARNING") as log_monitor:
             self.process_new_indexable_object(sample_event, logger)
         self.assertRegex(log_monitor.output[0],
-                         "WARNING:.*:In bundle .* the file \"unparseable_json.json\" is marked for indexing"
+                         "WARNING:.*:In bundle .* the file 'unparseable_json.json' is marked for indexing"
                          " yet could not be parsed. This file will not be indexed. Exception:")
         search_results = self.get_search_results(self.smartseq2_paired_ends_query, 1)
         self.assertEqual(1, len(search_results))
@@ -193,7 +193,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         with self.assertLogs(logger, level="WARNING") as log_monitor:
             self.process_new_indexable_object(sample_event, logger)
         self.assertRegex(log_monitor.output[0],
-                         f"WARNING:.*:In bundle .* the file \"{inaccesssible_filename}\" is marked for indexing"
+                         f"WARNING:.*:In bundle .* the file '{inaccesssible_filename}' is marked for indexing"
                          " yet could not be accessed. This file will not be indexed. Exception: .*, File blob key:")
         search_results = self.get_search_results(self.smartseq2_paired_ends_query, 1)
         self.assertEqual(1, len(search_results))

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -23,7 +23,7 @@ import dss
 from dss.api.search import _es_search_page
 from copy import deepcopy
 from dss.config import IndexSuffix
-from dss.events.handlers.index import get_elasticsearch_index
+from dss.events.handlers.index import BundleDocument
 from dss.util.es import ElasticsearchServer, ElasticsearchClient
 from tests import get_version
 from tests.es import elasticsearch_delete_index
@@ -73,7 +73,9 @@ class TestSearchBase(DSSAssertMixin):
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
-        get_elasticsearch_index(self.dss_index_name, self.dss_alias_name, logger)
+        # TODO: (hannes) This will go away once get_elasticsearch_index is a top-level function again
+        document = BundleDocument.from_json(self.replica_name, 'uuid.version', {}, logger)
+        document.get_elasticsearch_index(self.dss_index_name)
 
     def test_es_search_page(self):
         """Confirm that elasaticsearch is returning _source info only when necessary."""

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -23,7 +23,7 @@ import dss
 from dss.api.search import _es_search_page
 from copy import deepcopy
 from dss.config import IndexSuffix
-from dss.events.handlers.index import BundleDocument
+from dss.events.handlers.index import create_elasticsearch_index
 from dss.util.es import ElasticsearchServer, ElasticsearchClient
 from tests import get_version
 from tests.es import elasticsearch_delete_index
@@ -73,9 +73,7 @@ class TestSearchBase(DSSAssertMixin):
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
-        # TODO: (hannes) This will go away once get_elasticsearch_index is a top-level function again
-        document = BundleDocument.from_json(self.replica_name, 'uuid.version', {}, logger)
-        document.get_elasticsearch_index(self.dss_index_name)
+        create_elasticsearch_index(self.dss_index_name, self.replica_name, logger)
 
     def test_es_search_page(self):
         """Confirm that elasaticsearch is returning _source info only when necessary."""

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -15,7 +15,7 @@ import google.auth
 import google.auth.transport.requests
 import requests
 
-from dss.events.handlers.index import BundleDocument
+from dss.events.handlers.index import BundleDocument, create_elasticsearch_index
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) # noqa
 sys.path.insert(0, pkg_root) # noqa
@@ -72,7 +72,7 @@ class TestSubscriptionsBase(DSSAssertMixin):
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
         index_shape_identifier = index_document.get_index_shape_identifier()
         self.index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, self.replica, index_shape_identifier)
-        index_document.get_elasticsearch_index(self.index_name)
+        create_elasticsearch_index(self.index_name, self.replica.name, logger)
 
         self.callback_url = "https://example.com"
         self.sample_percolate_query = smartseq2_paired_ends_v2_or_v3_query


### PR DESCRIPTION
I would like to introduce a little OO into index.py. The benefit of this refactoring is that it makes more obvious how data flows between methods when preparing a document for indexing. The method signatures are simplified because contextual arguments are converted to instance attributes, for example `logger` and `replica`.

This change increases the line count mostly because it adds another way of constructing a BundleDocument from a ES document JSON.

This is a pure refactoring with minimal functional changes.

Reviewers are encouraged to review the diff with a tool that highlights intra-line changes, e.g. PyCharm. The diff will become very small as I paid close attention to not move code around, to the extent that one function became a method of BundleDocument even though it should not be. I will move those methods, deal with the overly long lines and remove the other TODOs once we reach consensus on whether we want this type of refactoring.