### PR TITLE
More indexer refactorings

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -198,14 +198,18 @@ class Config:
         return Config._ALLOWED_EMAILS
 
     @staticmethod
-    def get_es_index_name(index_type: ESIndexType, replica: Replica,
-                          version: typing.Optional[str] = None
+    def get_es_index_name(index_type: ESIndexType,
+                          replica: Replica,
+                          shape_descriptor: typing.Optional[str] = None
                           ) -> str:
-        """Returns the index name"""
+        """
+        Returns the fully qualified name of an Elasticsearch index of documents for a given
+        replica of a given type and shape.
+        """
         deployment_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
         index = f"dss-{deployment_stage}-{replica.name}-{index_type.name}"
-        if version:
-            index = f"{index}-{version}"
+        if shape_descriptor:
+            index = f"{index}-{shape_descriptor}"
         if Config._CURRENT_CONFIG == BucketConfig.TEST:
             index = f"{index}.{IndexSuffix.name}"
         return index

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -51,7 +51,7 @@ def process_new_indexable_object(bucket_name: str, key: str, replica: Replica, l
         logger.info(f"Received {replica} creation event for bundle which will be indexed: {key}")
         document = BundleDocument.from_bucket(replica, bucket_name, key, logger)
         index_name = document.prepare_index()
-        document.add_data_to_elasticsearch(index_name)
+        document.add_to_index(index_name)
         document.notify_subscriptions(index_name)
         logger.debug(f"Finished index processing of {replica} creation event for bundle: {key}")
     else:
@@ -207,11 +207,11 @@ class BundleDocument(dict):
             return bundle_key[len(bundle_prefix):]
         raise Exception(f"This is not a key for a bundle: {bundle_key}")
 
-    def add_data_to_elasticsearch(self, index_name: str) -> None:
+    def add_to_index(self, index_name: str) -> None:
         es_client = ElasticsearchClient.get(self.logger)
         try:
             self.logger.debug("Adding index data to Elasticsearch index '%s': %s", index_name,
-                              json.dumps(self, indent=4))  # noqa
+                              json.dumps(self, indent=4))
             initial_mappings = es_client.indices.get_mapping(index_name)[index_name]['mappings']
             es_client.index(index=index_name,
                             doc_type=ESDocType.doc.name,

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -151,31 +151,34 @@ class BundleDocument(dict):
         return index_files
 
     def prepare_index(self):
-        index_shape_identifier = self.get_index_shape_identifier()
-        index_name = Config.get_es_index_name(ESIndexType.docs, self.replica, index_shape_identifier)
+        shape_descriptor = self.get_shape_descriptor()
+        index_name = Config.get_es_index_name(ESIndexType.docs, self.replica, shape_descriptor)
         create_elasticsearch_index(index_name, self.replica, self.logger)
         return index_name
 
-    def get_index_shape_identifier(self) -> typing.Optional[str]:
-        """ Return string identifying the shape/structure/format of the data in the index document,
-        so that it may be indexed appropriately.
+    def get_shape_descriptor(self) -> typing.Optional[str]:
+        """
+        Return a string identifying the shape/structure/format of the data in this bundle
+        document, so that it may be indexed appropriately.
 
-        Currently, this returns a string identifying the metadata schema release major number:
+        Currently, this returns a string identifying the metadata schema release major number.
         For example:
+
             v3 - Bundle contains metadata in the version 3 format
             v4 - Bundle contains metadata in the version 4 format
             ...
 
         This includes verification that schema major number is the same for all index metadata
-        files in the bundle, consistent with the current HCA ingest service behavior.
-        If no metadata version information is contained in the bundle, the empty string is returned.
+        files in the bundle, consistent with the current HCA ingest service behavior. If no
+        metadata version information is contained in the bundle, the empty string is returned.
         Currently this occurs in the case of the empty bundle used for deployment testing.
 
         If/when bundle schemas are available, this function should be updated to reflect the
         bundle schema type and major version number.
 
         Other projects (non-HCA) may manage their metadata schemas (if any) and schema versions.
-        This should be an extension point that is customizable by other projects according to their metadata.
+        This should be an extension point that is customizable by other projects according to
+        their metadata.
         """
 
         schema_version_map = defaultdict(set)  # type: typing.MutableMapping[str, typing.MutableSet[str]]

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -80,7 +80,7 @@ class BundleDocument(dict):
 
     @classmethod
     def from_bucket(cls, replica: Replica, bucket_name: str, key: str, logger):  # TODO: return type hint
-        self = cls(replica, cls.get_bundle_id_from_key(key), logger)
+        self = cls(replica, cls._get_bundle_id_from_key(key), logger)
         handle = Config.get_cloud_specific_handles(replica.name)[0]
         self['manifest'] = self._read_bundle_manifest(handle, bucket_name, key)
         self['files'] = self._read_file_infos(handle, bucket_name)
@@ -201,7 +201,7 @@ class BundleDocument(dict):
             return None  # No files with schema identifiers were found
 
     @staticmethod
-    def get_bundle_id_from_key(bundle_key: str) -> str:
+    def _get_bundle_id_from_key(bundle_key: str) -> str:
         bundle_prefix = "bundles/"
         if bundle_key.startswith(bundle_prefix):
             return bundle_key[len(bundle_prefix):]
@@ -226,13 +226,13 @@ class BundleDocument(dict):
         try:
             current_mappings = es_client.indices.get_mapping(index_name)[index_name]['mappings']
             if initial_mappings != current_mappings:
-                self.refresh_percolate_queries(index_name)
+                self._refresh_percolate_queries(index_name)
         except Exception as ex:
             self.logger.error("Error refreshing subscription queries for index. Exception: %s, Index name: %s",
                               ex, index_name)
             raise
 
-    def refresh_percolate_queries(self, index_name: str) -> None:
+    def _refresh_percolate_queries(self, index_name: str) -> None:
         # When dynamic templates are used and queries for percolation have been added
         # to an index before the index contains mappings of fields referenced by those queries,
         # the queries must be reloaded when the mappings are present for the queries to match.

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -206,7 +206,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
     def test_notify(self):
         def _notify(subscription, bundle_id="i.v"):
             document = BundleDocument.from_json(Replica[self.replica], bundle_id, {}, logger)
-            document.notify(subscription_id=subscription["id"], subscription=subscription)
+            document.notify_subscriber(subscription=subscription)
         with self.assertRaisesRegex(requests.exceptions.InvalidURL, "Invalid URL 'http://': No host supplied"):
             _notify(subscription=dict(id="", es_query={}, callback_url="http://"))
         with self.assertRaisesRegex(AssertionError, "Unexpected scheme for callback URL"):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -330,7 +330,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         self.verify_notification(subscription_id, subscription_query, bundle_id)
         self.delete_subscription(subscription_id)
 
-    def test_get_index_shape_identifier(self):
+    def test_get_shape_descriptor(self):
         index_document = BundleDocument.from_json(self.replica, 'uuid.version', {
             'files': {
                 'assay_json': {
@@ -350,29 +350,29 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
             }
         }, logger)
         with self.subTest("Same major version."):
-            self.assertEqual(index_document.get_index_shape_identifier(), "v3")
+            self.assertEqual(index_document.get_shape_descriptor(), "v3")
 
         index_document['files']['assay_json']['core']['schema_version'] = "4.0.0"
         with self.subTest("Mixed/inconsistent metadata schema release versions in the same bundle"):
             with self.assertRaisesRegex(AssertionError,
                                         "The bundle contains mixed schema major version numbers: \['3', '4'\]"):
-                index_document.get_index_shape_identifier()
+                index_document.get_shape_descriptor()
 
         index_document['files']['sample_json']['core']['schema_version'] = "4.0.0"
         with self.subTest("Consistent versions, with a different version value"):
-            self.assertEqual(index_document.get_index_shape_identifier(), "v4")
+            self.assertEqual(index_document.get_shape_descriptor(), "v4")
 
         index_document['files']['assay_json'].pop('core')
         with self.subTest("An version file and unversioned file"):
             with self.assertLogs(logger, level="INFO") as log_monitor:
-                index_document.get_index_shape_identifier()
+                index_document.get_shape_descriptor()
             self.assertRegex(log_monitor.output[0], ("INFO:.*File assay_json does not contain a 'core' section "
                                                      "to identify the schema and schema version."))
-            self.assertEqual(index_document.get_index_shape_identifier(), "v4")
+            self.assertEqual(index_document.get_shape_descriptor(), "v4")
 
         index_document['files']['sample_json'].pop('core')
         with self.subTest("no versioned file"):
-            self.assertEqual(index_document.get_index_shape_identifier(), None)
+            self.assertEqual(index_document.get_shape_descriptor(), None)
 
     def test_alias_and_versioned_index_exists(self):
         sample_event = self.create_sample_bundle_created_event(self.bundle_key)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -24,7 +24,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss import Config, BucketConfig, DeploymentStage
-from dss.config import IndexSuffix
+from dss.config import IndexSuffix, Replica
 from dss.events.handlers.index import process_new_s3_indexable_object, process_new_gs_indexable_object, BundleDocument
 from dss.hcablobstore import BundleMetadata, BundleFileMetadata, FileMetadata
 from dss.util import create_blob_key, networking, UrlBuilder
@@ -205,7 +205,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
 
     def test_notify(self):
         def _notify(subscription, bundle_id="i.v"):
-            document = BundleDocument.from_json(self.replica, bundle_id, {}, logger)
+            document = BundleDocument.from_json(Replica[self.replica], bundle_id, {}, logger)
             document.notify(subscription_id=subscription["id"], subscription=subscription)
         with self.assertRaisesRegex(requests.exceptions.InvalidURL, "Invalid URL 'http://': No host supplied"):
             _notify(subscription=dict(id="", es_query={}, callback_url="http://"))

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -70,9 +70,7 @@ class TestSubscriptionsBase(DSSAssertMixin):
         logger.debug("Setting up Elasticsearch")
         es_client = ElasticsearchClient.get(logger)
         elasticsearch_delete_index(f"*{IndexSuffix.name}")
-        index_shape_identifier = index_document.get_index_shape_identifier()
-        self.index_name = dss.Config.get_es_index_name(dss.ESIndexType.docs, self.replica, index_shape_identifier)
-        create_elasticsearch_index(self.index_name, self.replica.name, logger)
+        self.index_name = index_document.prepare_index()
 
         self.callback_url = "https://example.com"
         self.sample_percolate_query = smartseq2_paired_ends_v2_or_v3_query

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -65,7 +65,7 @@ class TestSubscriptionsBase(DSSAssertMixin):
         dss.Config.set_config(dss.BucketConfig.TEST)
 
         with open(os.path.join(os.path.dirname(__file__), "sample_v3_index_doc.json"), "r") as fh:
-            index_document = BundleDocument.from_json(self.replica.name, 'uuid.version', json.load(fh), logger)
+            index_document = BundleDocument.from_json(self.replica, 'uuid.version', json.load(fh), logger)
 
         logger.debug("Setting up Elasticsearch")
         es_client = ElasticsearchClient.get(logger)


### PR DESCRIPTION
Starting to reap the benefits of the `BundleDocument` refactoring.

The reasoning for renaming `index shape identifier` to `shape descriptor` is that the former might be misinterpreted as the shape of an index, whereas the latter more accurately describes the shape of a document.

Reviewers should look at each commit separately.