### PR TITLE
Fix stack overflow when debugging test_indexer.py with PyCharm (alternative 3/3)

### DIFF
--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -61,7 +61,7 @@ class ThreadedLocalServer(threading.Thread):
             **kwargs)
 
     @classmethod
-    def inject_api_requests_methods(cls):
+    def _inject_api_requests_methods(cls):
         """
         requests.api is a module consisting of all the HTTP request types, defined as methods.  If we're being called
         with one of these types, then execute the call against the running server.
@@ -77,4 +77,5 @@ class ThreadedLocalServer(threading.Thread):
             self._server.server.shutdown()
 
 
-ThreadedLocalServer.inject_api_requests_methods()
+# noinspection PyProtectedMember
+ThreadedLocalServer._inject_api_requests_methods()


### PR DESCRIPTION
… or any other IDE that uses pydevd.

This change use a more static approach for reexporting the `requests.api` methods on `ThreadedLocalServer`. With the original `__getattr__`-based approach I get

```
Fatal Python error: Cannot recover from stack overflow.
```

and the process crashes with SIGABRT.

The currently recommended workaround of enabling Genvent-compatible debugging avoids the SO but trashed stderr with hundreds of these:

```
Traceback (most recent call last):
  File "/Users/hannes/workspace/hca/data-store/.venv/lib/python3.6/site-packages/werkzeug/urls.py", line 425, in <genexpr>
    if not rest or any(c not in s('0123456789') for c in rest):
SystemError: error return without exception set
Exception ignored in: <generator object url_parse.<locals>.<genexpr> at 0x105169d58>
```

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
