### PR TITLE
Remove the ES bogus endpoint test

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -193,27 +193,6 @@ class TestSearchBase(DSSAssertMixin):
                 self.verify_search_result(search_obj.json, smartseq2_paired_ends_v3_query, docs, expected_results)
                 self.verify_bundles(found_bundles, bundles)
 
-    def test_elasticsearch_bogus_endpoint_exception(self):
-        # Test Elasticsearch exception handling by setting an invalid endpoint
-        es_logger = logging.getLogger("elasticsearch")
-        original_es_level = es_logger.getEffectiveLevel()
-        original_es_endpoint = os.getenv("DSS_ES_ENDPOINT", "127.0.0.1")
-
-        es_logger.setLevel("ERROR")
-        try:
-            os.environ['DSS_ES_ENDPOINT'] = "this-is-really-unlikely-to-exist"
-            url = self.build_url()
-            self.assertPostResponse(
-                path=url,
-                json_request_body=dict(es_query=smartseq2_paired_ends_v3_query),
-                expected_code=requests.codes.service_unavailable,
-                expected_error=ExpectedErrorFields(code="service_unavailable",
-                                                   status=requests.codes.service_unavailable,
-                                                   expect_stacktrace=True))
-        finally:
-            os.environ['DSS_ES_ENDPOINT'] = original_es_endpoint
-            es_logger.setLevel(original_es_level)
-
     def test_next_page_is_delivered_when_next_is_in_query(self):
         bundles = self.populate_search_index(self.index_document, 150)
         self.check_count(smartseq2_paired_ends_v3_query, 150)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,16 +13,14 @@ from requests.utils import parse_header_links
 
 import requests
 
-from dss import ESDocType
-from dss.util import UrlBuilder
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
+from dss import ESDocType
+from dss.util import UrlBuilder
 from dss.api.search import _es_search_page
-from copy import deepcopy
-from dss.config import IndexSuffix, Replica
+from dss.config import IndexSuffix
 from dss.events.handlers.index import create_elasticsearch_index
 from dss.util.es import ElasticsearchServer, ElasticsearchClient
 from tests import get_version


### PR DESCRIPTION
<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->
The `test_elasticsearch_bogus_endpoint_exception` test will fail if the resolver used to run the test does not return that the hostname does not exist.

This pull request skips this test if the resolver matches the bogus hostname.

<!--
### Test plan
Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
