### PR TITLE
Mention checkout buckets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ Run `source environment`  now and whenever these environment files are modified.
    to the name of that bucket. Make sure the bucket region is consistent with `AWS_DEFAULT_REGION` in
    `environment.local`.
 
-3. If you wish to run the unit tests, you must create two more S3 buckets, one for test data and another for test
+3. Repeat the previous step for
+
+   * DSS_S3_CHECKOUT_BUCKET
+   * DSS_S3_CHECKOUT_BUCKET_TEST
+   * DSS_S3_CHECKOUT_BUCKET_TEST_FIXTURES
+
+4. If you wish to run the unit tests, you must create two more S3 buckets, one for test data and another for test
    fixtures, and set the environment variables `DSS_S3_BUCKET_TEST` and `DSS_S3_BUCKET_TEST_FIXTURES` to the names of
    those buckets.
 


### PR DESCRIPTION
The README should mention the checkout buckets. 

Without those buckets `make deploy` fails with

```
Traceback (most recent call last):
  File "/Users/hannes/workspace/hca/data-store/scripts/deploy_checkout_lifecycle.py", line 19, in <module>
    'ID': "dss_checkout_expiration",
  File "/Users/hannes/workspace/hca/data-store/.venv/lib/python3.6/site-packages/botocore/client.py", line 314, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/hannes/workspace/hca/data-store/.venv/lib/python3.6/site-packages/botocore/client.py", line 612, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the PutBucketLifecycleConfiguration operation: Access Denied
make[1]: *** [dss-checkout-sfn] Error 1
make: *** [deploy-daemons-parallel] Error 2
```