### PR TITLE
Bump cloud-blobstore dependency to 1.0.0

### DIFF
--- a/daemons/dss-sync/app.py
+++ b/daemons/dss-sync/app.py
@@ -105,7 +105,7 @@ def copy_parts(event, context):
     topic_arn = event["Records"][0]["Sns"]["TopicArn"]
     msg = json.loads(event["Records"][0]["Sns"]["Message"])
     blobstore_handle = dss.Config.get_cloud_specific_handles(platform_to_replica[msg["source_platform"]])[0]
-    source_url = blobstore_handle.generate_presigned_GET_url(bucket=msg["source_bucket"], object_name=msg["source_key"])
+    source_url = blobstore_handle.generate_presigned_GET_url(bucket=msg["source_bucket"], key=msg["source_key"])
     futures = []
     gs = dss.Config.get_cloud_specific_handles("gcp")[0].gcp_client
     with ThreadPoolExecutor(max_workers=4) as executor:

--- a/dss/hcablobstore/__init__.py
+++ b/dss/hcablobstore/__init__.py
@@ -26,13 +26,13 @@ class HCABlobStore:
             downcase=True),
     )
 
-    def verify_blob_checksum(self, bucket: str, object_name: str, metadata: typing.Dict[str, str]) -> bool:
+    def verify_blob_checksum(self, bucket: str, key: str, metadata: typing.Dict[str, str]) -> bool:
         """
         Given a blob, verify that the checksum on the cloud store matches the checksum in the metadata dictionary.  The
         keys to the metadata dictionary will be the items in ``MANDATORY_METADATA``.  Each cloud-specific implementation
         of ``HCABlobStore`` should extract the correct field and check it against the cloud-provided checksum.
         :param bucket:
-        :param object_name:
+        :param key:
         :param metadata:
         :return: True iff the checksum is correct.
         """

--- a/dss/hcablobstore/gs.py
+++ b/dss/hcablobstore/gs.py
@@ -9,16 +9,16 @@ class GSHCABlobStore(HCABlobStore):
     def __init__(self, handle: BlobStore) -> None:
         self.handle = handle
 
-    def verify_blob_checksum(self, bucket: str, object_name: str, metadata: typing.Dict[str, str]) -> bool:
+    def verify_blob_checksum(self, bucket: str, key: str, metadata: typing.Dict[str, str]) -> bool:
         """
         Given a blob, verify that the checksum on the cloud store matches the checksum in the metadata dictionary.  The
         keys to the metadata dictionary will be the items in ``MANDATORY_METADATA``.  Each cloud-specific implementation
         of ``HCABlobStore`` should extract the correct field and check it against the cloud-provided checksum.
         :param bucket:
-        :param object_name:
+        :param key:
         :param metadata:
         :return: True iff the checksum is correct.
         """
-        checksum = self.handle.get_cloud_checksum(bucket, object_name)
+        checksum = self.handle.get_cloud_checksum(bucket, key)
         metadata_checksum_key = typing.cast(str, HCABlobStore.MANDATORY_METADATA['CRC32C']['keyname'])
         return checksum.lower() == metadata[metadata_checksum_key].lower()

--- a/dss/hcablobstore/s3.py
+++ b/dss/hcablobstore/s3.py
@@ -9,16 +9,16 @@ class S3HCABlobStore(HCABlobStore):
     def __init__(self, handle: BlobStore) -> None:
         self.handle = handle
 
-    def verify_blob_checksum(self, bucket: str, object_name: str, metadata: typing.Dict[str, str]) -> bool:
+    def verify_blob_checksum(self, bucket: str, key: str, metadata: typing.Dict[str, str]) -> bool:
         """
         Given a blob, verify that the checksum on the cloud store matches the checksum in the metadata dictionary.  The
         keys to the metadata dictionary will be the items in ``MANDATORY_METADATA``.  Each cloud-specific implementation
         of ``HCABlobStore`` should extract the correct field and check it against the cloud-provided checksum.
         :param bucket:
-        :param object_name:
+        :param key:
         :param metadata:
         :return: True iff the checksum is correct.
         """
-        checksum = self.handle.get_cloud_checksum(bucket, object_name)
+        checksum = self.handle.get_cloud_checksum(bucket, key)
         metadata_checksum_key = typing.cast(str, HCABlobStore.MANDATORY_METADATA['S3_ETAG']['keyname'])
         return checksum.lower() == metadata[metadata_checksum_key].lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ chained-aws-lambda==0.0.8
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==0.0.7
+cloud-blobstore==1.0.0
 connexion==1.1.15
 cryptography==2.1.3
 docutils==0.14

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -2,7 +2,7 @@
 azure-storage >= 0.36.0
 boto3 >= 1.4.7
 chained-aws-lambda >= 0.0.7
-cloud-blobstore >= 0.0.7
+cloud-blobstore >= 1.0.0
 connexion == 1.1.15 # pinned by akislyuk due to upstream breaking changes in auth middleware in connexion 1.2
 elasticsearch >= 5.4.0
 elasticsearch-dsl >= 5.3.0


### PR DESCRIPTION
This release renames any `object_name` arguments to `key`

