### PR TITLE
Daemon to kick off integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ install:
 - export PATH=$(pwd)/make4/usr/bin:$PATH
 script:
 - set -eo pipefail
-- make -j4 -O test
+- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 -O standalone_test; fi
+- if [[ $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 -O test; fi
 - if [[ $TRAVIS_BRANCH == staging ]]; then source environment.staging; fi
 - if [[ $TRAVIS_EVENT_TYPE == cron ]]; then make smoketest; fi
 after_success:
@@ -42,6 +43,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
+      condition: ! $TRAVIS_DSS_INTEGRATION_MODE
   - provider: script
     script: make -j4 -O deploy
     skip_cleanup: true

--- a/daemons/integration-test/.chalice/config.json
+++ b/daemons/integration-test/.chalice/config.json
@@ -1,0 +1,11 @@
+{
+  "app_name": "integration-test",
+  "environment_variables": {
+    "TRAVIS_TOKEN": REPLACE_WITH_YOUR_TRAVIS_TOKEN
+  },
+  "stages": {
+  },
+  "version": "2.0",
+  "lambda_timeout": 300,
+  "lambda_memory_size": 1536
+}

--- a/daemons/integration-test/app.py
+++ b/daemons/integration-test/app.py
@@ -1,0 +1,34 @@
+import os
+
+import domovoi
+import requests
+
+
+app = domovoi.Domovoi()
+
+
+@app.scheduled_function("rate(60 minutes)")
+def integration_test(*args, **kwargs):
+    travis_token = os.environ["TRAVIS_TOKEN"]
+    body = {
+        'request': {
+            'branch': "master",
+            'message': "INTEGRATION TESTS",
+            'config': {
+                'merge_mode': "deep_merge",
+                'env': {
+                    'matrix': ["TRAVIS_DSS_INTEGRATION_MODE=1"]
+                },
+            },
+        }}
+    headers = {
+        'Accept': "application/json",
+        'Travis-API-Version': "3",
+        'Authorization': f"token {travis_token}",
+    }
+
+    return requests.post(
+        "https://api.travis-ci.org/repo/HumanCellAtlas%2Fdata-store/requests",
+        headers=headers,
+        json=body,
+    )

--- a/daemons/integration-test/requirements.txt
+++ b/daemons/integration-test/requirements.txt
@@ -1,0 +1,2 @@
+domovoi
+requests


### PR DESCRIPTION
1. Added configuration in .travis.yml to run standalone tests normally.
2. Added configuration in .travis.yml to run integration tests when TRAVIS_DSS_INTEGRATION_MODE is non-empty.
3. Added a daemon that kicks off integration tests every hour.
