### PR TITLE
Fix validation error: Forbidden -> forbidden

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -143,7 +143,7 @@ def delete(uuid: str, replica: str, json_request_body: dict, version: str=None):
     if email not in ADMIN_USER_EMAILS:
         raise DSSException(
             requests.codes.forbidden,
-            "Forbidden",
+            "forbidden",
             f"You can't delete bundles with these credentials!",
         )
 


### PR DESCRIPTION
When user email is unauthorized in bundles/delete, "Forbidden" fails
response validation and a 500 error is returned. Lower case "forbidden"
passes response validation, returning the correct 403 response.

Incorrect 500 error:
{'detail': "'Forbidden' is not one of ['forbidden']\n"
           '\n'
           "Failed validating 'enum' in "
           "schema['allOf'][1]['properties']['code']:\n"
           "    {'description': 'Machine-readable error code.  The types of "
           "return '\n"
           "                    'values should not be changed lightly.',\n"
           "     'enum': ['forbidden'],\n"
           "     'type': 'string'}\n"
           '\n'
           "On instance['code']:\n"
           "    'Forbidden'",
 'status': 500,
 'title': 'Response body does not conform to specification',
 'type': 'about:blank'}

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
