### PR TITLE
Fault tolerance for checkout service

### DIFF
--- a/daemons/build_deploy_config.sh
+++ b/daemons/build_deploy_config.sh
@@ -50,5 +50,6 @@ if [[ ${CI:-} == true ]]; then
     cat "$config_json" | jq .manage_iam_role=false | jq .iam_role_arn=env.iam_role_arn | sponge "$config_json"
 fi
 
-cat "$iam_policy_template" | envsubst '$DSS_S3_BUCKET $DSS_S3_BUCKET_TEST $DSS_S3_CHECKOUT_BUCKET $dss_es_domain $account_id $stage' > "$policy_json"
+cat "$iam_policy_template" | envsubst '$DSS_S3_BUCKET $DSS_S3_BUCKET_TEST $DSS_S3_CHECKOUT_BUCKET $DSS_S3_CHECKOUT_BUCKET_TEST $dss_es_domain $account_id $stage' > "$policy_json"
+
 cp "$policy_json" "$stage_policy_json"

--- a/daemons/dss-checkout-sfn/.chalice/config.json
+++ b/daemons/dss-checkout-sfn/.chalice/config.json
@@ -7,5 +7,7 @@
       "environment_variables": {
       }
     }
-  }
+  },
+  "lambda_timeout": 300,
+  "lambda_memory_size": 1536
 }

--- a/daemons/dss-checkout-sfn/app.py
+++ b/daemons/dss-checkout-sfn/app.py
@@ -12,7 +12,7 @@ from chainedawslambda import aws
 from dss import chained_lambda_clients
 from dss.config import Replica
 
-from dss.util.state_machine.checkout_states import state_machine_def
+from dss.stepfunctions.checkout.checkout_states import state_machine_def
 from dss.util.email import send_checkout_success_email, send_checkout_failure_email
 from dss.util.checkout import (parallel_copy, get_dst_bundle_prefix, get_manifest_files,
                                validate_file_dst, pre_exec_validate)

--- a/dss/stepfunctions/checkout/checkout_states.py
+++ b/dss/stepfunctions/checkout/checkout_states.py
@@ -1,13 +1,48 @@
+retry_config = [
+    {
+        "ErrorEquals": ["States.TaskFailed"],
+        "IntervalSeconds": 5,
+        "MaxAttempts": 5,
+        "BackoffRate": 1.5
+    },
+    {
+        "ErrorEquals": ["States.Timeout"],
+        "IntervalSeconds": 30,
+        "MaxAttempts": 3,
+        "BackoffRate": 1.5
+    },
+    {
+        "ErrorEquals": ["States.Permissions"],
+        "MaxAttempts": 0
+    },
+    {
+        "ErrorEquals": ["States.ALL"],
+        "IntervalSeconds": 5,
+        "MaxAttempts": 5,
+        "BackoffRate": 2.0
+    }
+]
+
+catch_config = [
+    {
+        "ErrorEquals": ["States.ALL"],
+        "Next": "NotifyFailure"
+    }
+]
+
 state_machine_def = {
     "Comment": "DSS Checkout service state machine that submits a Job to chained copy client"
                " and monitors the Job until it completes.",
     "StartAt": "PreExecutionCheck",
+    "TimeoutSeconds": 3600,             # 60 minutes, in seconds.
     "States": {
         "PreExecutionCheck": {
             "Type": "Task",
             "Resource": None,
             "ResultPath": "$.validation",
-            "Next": "PreExecutionCheckPassed"
+            "Next": "PreExecutionCheckPassed",
+            "Retry": retry_config,
+            "Catch": catch_config
         },
         "PreExecutionCheckPassed": {
             "Type": "Choice",
@@ -24,7 +59,9 @@ state_machine_def = {
             "Type": "Task",
             "Resource": None,
             "ResultPath": "$.schedule",
-            "Next": "Wait"
+            "Next": "Wait",
+            "Retry": retry_config,
+            "Catch": catch_config
         },
         "Wait": {
             "Type": "Wait",
@@ -35,7 +72,9 @@ state_machine_def = {
             "Type": "Task",
             "Resource": None,
             "ResultPath": "$.status",
-            "Next": "JobDone"
+            "Next": "JobDone",
+            "Retry": retry_config,
+            "Catch": catch_config
         },
         "JobDone": {
             "Type": "Choice",

--- a/iam/policy-templates/dss-checkout-sfn-lambda.json
+++ b/iam/policy-templates/dss-checkout-sfn-lambda.json
@@ -35,7 +35,9 @@
       ],
       "Resource": [
         "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET/*"
+        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET/*",
+        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST",
+        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST/*"
       ]
     },
     {


### PR DESCRIPTION
Implement 60 minutes timeout for the overall bundle checkout
Implement retries for individual steps in the workflow including

TaskFailed
Timeout
Other
Configure intervals, max attempts and back-off rates

Test plan

Manually injected delays and failures in the lambda using alternative stage configuration. Confirmed complex retry behavior by analyzing execution log in AWS Step Function console

connect to #614