### PR TITLE
Fix Makefile target mixup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ install:
 - export PATH=$(pwd)/make4/usr/bin:$PATH
 script:
 - set -eo pipefail
-- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 -O standalone_test; fi
-- if [[ $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 -O test; fi
+- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 -O test; fi
+- if [[ $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 -O integration_test; fi
 - if [[ $TRAVIS_BRANCH == staging ]]; then source environment.staging; fi
 - if [[ $TRAVIS_EVENT_TYPE == cron ]]; then make smoketest; fi
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -80,5 +80,5 @@ requirements.txt requirements-dev.txt : %.txt : %.txt.in
 requirements-dev.txt : requirements.txt.in
 
 .PHONY: lint mypy
-.PHONY: test all_test integration_test standalone_test $(test_srcs) $(integration_test_srcs) $(standalone_test_srcs)
+.PHONY: test all_test integration_test $(test_srcs) $(integration_test_srcs) $(standalone_test_srcs)
 .PHONY: deploy deploy-chalice deploy-daemons


### PR DESCRIPTION
The first commit fixes a bug in .travis.yml and removes a stale .PHONY declaration.

The bug causes non-IT builds tests to essentially skip tests and IT-builds to only run standalone tests. Any PR builds of branches based on b8290d240a4c7f20753122415a6df5a6666414c8 should be disregarded and the branches rebased once this is merged. 

The second commit makes the target naming in Makefile more intuitive.