### PR TITLE
Tsmith v4 test data

### DIFF
--- a/tests/fixtures/datafiles/indexing/bundles/v4/smartseq2/paired_ends/assay.json
+++ b/tests/fixtures/datafiles/indexing/bundles/v4/smartseq2/paired_ends/assay.json
@@ -1,0 +1,42 @@
+{
+	"content": {
+		"single_cell": {
+			"cell_handling": "Fluidigm C1"
+		},
+		"core": {
+			"type": "assay",
+			"schema_url": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/assay.json",
+			"schema_version": "4.6.1"
+		},
+		"rna": {
+			"end_bias": "five_prime_end",
+			"strand": "both",
+			"library_construction": "smart-seq2"
+		},
+		"assay_id": "assay_1",
+		"seq": {
+			"instrument_platform": "Illumina",
+			"molecule": "polyA RNA",
+			"paired_ends": true,
+			"lanes": [{
+				"number": 1,
+				"r2": "R2.fastq.gz",
+				"r1": "R1.fastq.gz"
+			}],
+			"instrument_model": "HiSeq 2500"
+		}
+	},
+	"core": {
+		"type": "assay_bundle",
+		"schema_url": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/assay_bundle.json",
+		"schema_version": "4.6.1"
+	},
+	"has_output": ["5b2eac6a-f62e-4656-8336-cd235d9c6007", "ec058925-f240-4cb3-832a-db1ae68ada32"],
+	"hca_ingest": {
+		"accession": "",
+		"submissionDate": "2017-12-15T16:30:56.520Z",
+		"updateDate": "2017-12-15T16:31:38.016Z",
+		"document_id": "28f868fe-3ba3-4f97-8434-debeabf2d42f"
+	},
+	"has_input": "fdd17f7d-a967-4b5e-a3fa-b9afc8b8d07b"
+}

--- a/tests/fixtures/datafiles/indexing/bundles/v4/smartseq2/paired_ends/project.json
+++ b/tests/fixtures/datafiles/indexing/bundles/v4/smartseq2/paired_ends/project.json
@@ -1,0 +1,32 @@
+{
+	"content": {
+		"core": {
+			"type": "project",
+			"schema_url": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/project.json",
+			"schema_version": "4.6.1"
+		},
+		"description": "Q3_DEMO-We report transcriptomes from 430 single glioblastoma cells isolated from 5 individual tumors and 102 single cells from gliomasphere cells lines generated using SMART-seq. In addition, we report population RNA-seq from the five tumors as well as RNA-seq from cell lines derived from 3 tumors (MGH26, MGH28, MGH31) cultured under serum free (GSC) and differentiated (DGC) conditions. This dataset highlights intratumoral heterogeneity with regards to the expression of de novo derived transcriptional modules and established subtype classifiers. Overall design: Operative specimens from five glioblastoma patients (MGH26, MGH28, MGH29, MGH30, MGH31) were acutely dissociated, depleted for CD45+ inflammatory cells and then sorted as single cells (576 samples). Population controls for each tumor were isolated by sorting 2000-10000 cells and processed in parallel (5 population control samples). Single cells from two established cell lines, GBM6 and GBM8, were also sorted as single cells (192 samples). SMART-seq protocol was implemented to generate single cell full length transcriptomes (modified from Shalek, et al Nature 2013) and sequenced using 25 bp paired end reads. Single cell cDNA libraries for MGH30 were resequenced using 100 bp paired end reads to allow for isoform and splice junction reconstruction (96 samples, annotated MGH30L). Cells were also cultured in serum free conditions to generate gliomasphere cell lines for MGH26, MGH28, and MGH31 (GSC) which were then differentiated using 10% serum (DGC). Population RNA-seq was performed on these samples (3 GSC, 3 DGC, 6 total). The initial dataset included 875 RNA-seq libraries (576 single glioblastoma cells, 96 resequenced MGH30L, 192 single gliomasphere cells, 5 tumor population controls, 6 population libraries from GSC and DGC samples). Data was processed as described below using RSEM for quantification of gene expression. 5,948 genes with the highest composite expression either across all single cells combined (average log2(TPM)>4.5) or within a single tumor (average log2(TPM)>6 in at least one tumor) were included. Cells expressing less than 2,000 of these 5,948 genes were excluded. The final processed dataset then included 430 primary single cell glioblastoma transcriptomes, 102 single cell transcriptomes from cell lines(GBM6,GBM8), 5 population controls (1 for each tumor), and 6 population libraries from cell lines derived from the tumors (GSC and DGC for MGH26, MGH28 and MGH31). The final matrix (GBM_data_matrix.txt) therefore contains 5948 rows (genes) quantified in 543 samples (columns). Please note that the samples which are not included in the data processing are indicated in the sample description field.",
+		"contributors": [{
+			"name": "Q3_DEMO-MintTeam",
+			"email": "dummy@email.com"
+		}],
+		"submitters": [{
+			"name": "Q3_DEMO-MintTeam",
+			"email": "dummy@email.com"
+		}],
+		"publications": [],
+		"project_id": "Q3_DEMO-project_PRJNA248302",
+		"name": "Q3_DEMO-Single cell RNA-seq of primary human glioblastomas"
+	},
+	"core": {
+		"type": "project_bundle",
+		"schema_url": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/project_bundle.json",
+		"schema_version": "4.6.1"
+	},
+	"hca_ingest": {
+		"accession": "",
+		"submissionDate": "2017-12-15T16:30:56.425Z",
+		"updateDate": "2017-12-15T16:31:36.774Z",
+		"document_id": "69b88cc8-1e8f-4c43-aa19-ed4a73a83285"
+	}
+}

--- a/tests/fixtures/datafiles/indexing/bundles/v4/smartseq2/paired_ends/sample.json
+++ b/tests/fixtures/datafiles/indexing/bundles/v4/smartseq2/paired_ends/sample.json
@@ -1,0 +1,72 @@
+{
+	"core": {
+		"type": "sample_bundle",
+		"schema_url": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/sample_bundle.json",
+		"schema_version": "4.6.1"
+	},
+	"samples": [{
+		"content": {
+			"core": {
+				"type": "sample",
+				"schema_url": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/sample.json",
+				"schema_version": "4.6.1"
+			},
+			"name": "Q3_DEMO-Single cell mRNA-seq_MGH30_A01",
+			"specimen_from_organism": {
+				"body_part": {
+					"text": "glioblastoma"
+				},
+				"organ": {
+					"text": "brain"
+				}
+			},
+			"ncbi_taxon_id": 9606,
+			"derived_from": "Q3_DEMO-donor_MGH30",
+			"sample_id": "Q3_DEMO-sample_SAMN02797092"
+		},
+		"derivation_protocols": [{
+			"pdf": "Q3_DEMO-protocol.pdf",
+			"protocol_id": "Q3_DEMO-protocol",
+			"type": {
+				"text": "single cell sequencing"
+			},
+			"core": {
+				"type": "protocol",
+				"schema_url": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/protocol.json",
+				"schema_version": "4.6.1"
+			}
+		}],
+		"hca_ingest": {
+			"accession": "",
+			"submissionDate": "2017-12-15T16:30:56.471Z",
+			"updateDate": "2017-12-15T16:31:37.937Z",
+			"document_id": "fdd17f7d-a967-4b5e-a3fa-b9afc8b8d07b"
+		},
+		"derived_from": "76983296-83fa-48e8-ae8f-f9b0e6742acd"
+	}, {
+		"content": {
+			"core": {
+				"type": "sample",
+				"schema_url": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.1/json_schema/sample.json",
+				"schema_version": "4.6.1"
+			},
+			"name": "Q3 DEMO donor MGH30",
+			"genus_species": {
+				"text": "Homo sapiens",
+				"ontology": "NCBITaxon:9606"
+			},
+			"ncbi_taxon_id": 9606,
+			"sample_id": "SAMN04303778",
+			"donor": {
+				"is_living": true
+			}
+		},
+		"derivation_protocols": [],
+		"hca_ingest": {
+			"accession": "",
+			"submissionDate": "2017-12-15T16:30:56.454Z",
+			"updateDate": "2017-12-15T16:31:38.757Z",
+			"document_id": "76983296-83fa-48e8-ae8f-f9b0e6742acd"
+		}
+	}]
+}

--- a/tests/fixtures/populate_lib.py
+++ b/tests/fixtures/populate_lib.py
@@ -115,6 +115,13 @@ def upload(uploader: Uploader):
             "application/json",
         )
 
+    for fname in ["assay.json", "project.json", "sample.json"]:
+        uploader.checksum_and_upload_file(
+            f"indexing/bundles/v4/smartseq2/paired_ends/{fname}",
+            f"fixtures/indexing/bundles/v4/smartseq2/paired_ends/{fname}",
+            "application/json",
+        )
+
     # Create sample stored bundles with tombstones to test the filtering of deleted bundles
     source_path = "tombstones"
     for fname in [
@@ -139,7 +146,7 @@ def upload(uploader: Uploader):
                                                             "datafiles", "indexing", "bundles"))
 
     def load_example_smartseq2_paired_ends(target_path):
-        for fname in ["assay.json", "cell.json", "manifest.json", "project.json", "sample.json"]:
+        for fname in ["assay.json", "project.json", "sample.json"]:
             source_path = os.path.join(data_bundle_examples_dir, "v3", "smartseq2", "paired_ends")
             uploader.checksum_and_upload_file(
                 f"{source_path}/{fname}",
@@ -171,6 +178,18 @@ def upload(uploader: Uploader):
             f"indexing/{fname}",
             f"{target_path}/{fname}",
             "text/plain",
+        )
+
+    # Create a bundle based on data-bundle-examples/smartseq2/paired_ends.
+    # Then add some indexed files that are removed before indexing.
+    target_path = "fixtures/indexing/bundles/v3/smartseq2/paired_ends_extras"
+    load_example_smartseq2_paired_ends(target_path)
+    for fname in ["manifest.json", "cell.json"]:
+        source_path = os.path.join(data_bundle_examples_dir, "smartseq2", "paired_ends")
+        uploader.checksum_and_upload_file(
+            f"{source_path}/{fname}",
+            f"{target_path}/{fname}",
+            "application/json",
         )
 
     # TODO (mbaumann) this block was moved to the new path "fixtures/indexing/bundles/unparseable_indexed_file"

--- a/tests/sample_search_queries.py
+++ b/tests/sample_search_queries.py
@@ -70,3 +70,61 @@ smartseq2_paired_ends_v2_or_v3_query = \
             }
         }
     }
+
+smartseq2_paired_ends_v3_or_v4_query = \
+    {
+        'query': {
+            'bool': {
+                'must': [
+                    {
+                        'bool': {
+                            'should': [
+                                {'match': {'files.sample_json.ncbi_biosample': "SAMN04303778"}},
+                                {'match': {'files.sample_json.samples.content.sample_id': "SAMN04303778"}}],
+                            'minimum_should_match': 1
+                        }
+                    },
+                    {
+                        'bool': {
+                            'should': [
+                                {'match': {'files.assay_json.content.single_cell.cell_handling': "Fluidigm C1"}},
+                                {'match': {'files.assay_json.single_cell.cell_handling': "Fluidigm C1"}}
+                            ],
+                            'minimum_should_match': 1
+                        }
+                    },
+                    {
+                        'bool': {
+                            'should': [
+                                {'match': {'files.sample_json.donor.species.text': "Homo sapiens"}},
+                                {'match': {'files.sample_json.samples.content.genus_species.text': "Homo sapiens"}}
+                            ],
+                            'minimum_should_match': 1
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+
+smartseq2_paired_ends_v4_query = \
+    {
+        'query': {
+            'bool': {
+                'must': [{
+                    'match': {
+                        "files.sample_json.samples.content.genus_species.text": "Homo sapiens"
+                    }
+                }, {
+                    'match': {
+                        "files.assay_json.content.single_cell.cell_handling": "Fluidigm C1"
+                    }
+                }, {
+                    'match': {
+                        "files.sample_json.samples.content.sample_id": "SAMN04303778"
+                    }
+                }]
+            }
+        }
+    }


### PR DESCRIPTION
### Test plan
Updated test_indexer to use new test data.

### Deployment instructions & migrations
Must run populate before running tests.

### Release notes
Added version 4 testdata to the test fixtures buckets.


