### PR TITLE
Allow integers in sfn defs with "int({t})"

### DIFF
--- a/dss/stepfunctions/generator/parser.py
+++ b/dss/stepfunctions/generator/parser.py
@@ -84,6 +84,9 @@ class StateMachineAnnotationProcessor:
 
     def _process_str(self, string: str):
         for template_string, index in self.template_map:
-            string = string.replace(template_string, str(index))
+            if f'int({template_string})' == string:
+                return index
+            else:
+                string = string.replace(template_string, str(index))
 
         return string


### PR DESCRIPTION
Allow integers in stepfunctions generator/parser to allow comparisons like:
"NumericLessThanEquals": "int({t})"

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->