### PR TITLE
Avoid large state in visitation Parallel, bugfixes

### DIFF
--- a/dss/stepfunctions/visitation/implementation.py
+++ b/dss/stepfunctions/visitation/implementation.py
@@ -39,7 +39,7 @@ def job_initialize(event, context):
 
 
 def job_finalize(event, context):
-    obj = vis_obj(event[0])
+    obj = vis_obj(event)
     obj.job_finalize()
     return obj.get_state()
 
@@ -116,7 +116,8 @@ def _catch_to_state(next_state):
         "ErrorEquals": [
             "States.ALL"
         ],
-        "Next": next_state
+        "Next": next_state,
+        "ResultPath": None
     }]
 
 
@@ -221,6 +222,7 @@ sfn = {
             "Type": "Parallel",
             "Branches": [walker_sfn(i) for i in range(THREADPOOL_PARALLEL_FACTOR)],
             "Retry": _retry,
+            "ResultPath": None,
             "Next": "Finalize",
         },
         "Finalize": {

--- a/tests/test_visitation.py
+++ b/tests/test_visitation.py
@@ -79,8 +79,7 @@ class TestVisitationWalker(unittest.TestCase):
 
     @testmode.standalone
     def test_implementation_job_finalize(self):
-        states = [copy.deepcopy(self.walker_state) for _ in range(3)]
-        implementation.job_finalize(states, None)
+        implementation.job_finalize(self.job_state, None)
 
     @testmode.standalone
     def test_implementation_job_failed(self):


### PR DESCRIPTION
Pass parallel input directly to output.
Bugfix avoiding state loss when catching exceptions.

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
