### PR TITLE
Validator KeyError Fix (fixes #804)

### DIFF
--- a/dss/storage/validator.py
+++ b/dss/storage/validator.py
@@ -44,7 +44,6 @@ DSS_Draft4Validator = validators.create(
 )
 
 resolver = validators.RefResolver(referrer='', base_uri='')
-EXTRA_FIELD_ERROR_REGEX = re.compile(r"(?<!regexes: )'([^']+)',?")
 
 
 def scrub_index_data(index_data: dict, bundle_id: str, logger: logging.Logger) -> list:
@@ -65,7 +64,9 @@ def scrub_index_data(index_data: dict, bundle_id: str, logger: logging.Logger) -
                     path = [document, *error.path]
                     #  Example error message: "Additional properties are not allowed ('extra_lst', 'extra_top' were
                     #  unexpected)" or "'extra', does not match any of the regexes: '^characteristics_.*$'"
-                    fields_to_remove = (path, [field for field in EXTRA_FIELD_ERROR_REGEX.findall(error.message)])
+                    fields_to_remove = (path,
+                                        [field for field in re.findall(r"(?<!regexes: )'([^']+)',?", error.message)]
+                                        )
                     extra_fields.append(fields_to_remove)
         else:
             extra_documents.append(document)

--- a/dss/storage/validator.py
+++ b/dss/storage/validator.py
@@ -44,6 +44,7 @@ DSS_Draft4Validator = validators.create(
 )
 
 resolver = validators.RefResolver(referrer='', base_uri='')
+EXTRA_FIELD_ERROR_REGEX = re.compile(r"(?<!regexes: )'([^']+)',?")
 
 
 def scrub_index_data(index_data: dict, bundle_id: str, logger: logging.Logger) -> list:
@@ -63,8 +64,8 @@ def scrub_index_data(index_data: dict, bundle_id: str, logger: logging.Logger) -
                 if error.validator == 'additionalProperties':
                     path = [document, *error.path]
                     #  Example error message: "Additional properties are not allowed ('extra_lst', 'extra_top' were
-                    #  unexpected)"
-                    fields_to_remove = (path, [field for field in re.findall(r"'([^']*)'", error.message)])
+                    #  unexpected)" or "'extra', does not match any of the regexes: '^characteristics_.*$'"
+                    fields_to_remove = (path, [field for field in EXTRA_FIELD_ERROR_REGEX.findall(error.message)])
                     extra_fields.append(fields_to_remove)
         else:
             extra_documents.append(document)

--- a/tests/fixtures/datafiles/indexing/bundles/v3/smartseq2/paired_ends/project.json
+++ b/tests/fixtures/datafiles/indexing/bundles/v3/smartseq2/paired_ends/project.json
@@ -123,5 +123,6 @@
         "ftp://ftp-trace.ncbi.nlm.nih.gov/sra/sra-instant/reads/ByStudy/sra/SRP/SRP066/SRP066834"
     ], 
     "title": "Human cerebral organoids recapitulate gene expression programs of fetal neocortex development.", 
-    "update_date": "2017-06-02"
+    "update_date": "2017-06-02",
+    "characteristics_color": "green"
 }

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -607,9 +607,10 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
                                                       }
                                                      )
             index_data['files']['assay_json']['core']['extra_internal'] = 123
-            index_data['files']['sample_json']['extra'] = "tests patterned properties."
-            index_data['files']['project_json']['extra'] = "Another extra field in a different file."
+            index_data['files']['sample_json']['extra_0'] = "tests patterned properties."
+            index_data['files']['project_json']['extra_1'] = "Another extra field in a different file."
             index_data['files']['project_json']['extra_2'] = "Another extra field in a different file."
+            index_data['files']['project_json']['core']['characteristics_3'] = "patternProperties only apply to root."
             bundle_fqid = self.bundle_key.split('/')[1]
             with self.assertLogs(logger, level="INFO") as log_monitor:
                 scrub_index_data(index_data['files'], bundle_fqid, logger)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -604,8 +604,12 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
             index_data['files']['assay_json'].update({'extra_top': 123,
                                                       'extra_obj': {"something": "here", "another": 123},
                                                       'extra_lst': ["a", "b"]
-                                                      })
+                                                      }
+                                                     )
             index_data['files']['assay_json']['core']['extra_internal'] = 123
+            index_data['files']['sample_json']['extra'] = "tests patterned properties."
+            index_data['files']['project_json']['extra'] = "Another extra field in a different file."
+            index_data['files']['project_json']['extra_2'] = "Another extra field in a different file."
             bundle_fqid = self.bundle_key.split('/')[1]
             with self.assertLogs(logger, level="INFO") as log_monitor:
                 scrub_index_data(index_data['files'], bundle_fqid, logger)


### PR DESCRIPTION
Fixes #804 

Fix for Validator KeyError

### Test plan
- Added testing for json schemas with patternProperties.
- Added testing for extra fields in different json files.

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->
- Run populate on test fixtures.

### Release notes
- Added EXTRA_FIELD_ERROR_REGEX and adjust regular express to extract field names from both error messages found in jsonschema._validators.additionalProperties.
- Added characteristics field to ./tests/fixtures/datafiles/indexing/bundles/v3/smartseq2/paired_ends/project.json.
- Fixes #804
