### PR TITLE
Make Validator More Robust

### DIFF
--- a/dss/storage/validator.py
+++ b/dss/storage/validator.py
@@ -65,8 +65,8 @@ def scrub_index_data(index_data: dict, bundle_id: str, logger: logging.Logger) -
                     #  Example error message: "Additional properties are not allowed ('extra_lst', 'extra_top' were
                     #  unexpected)" or "'extra', does not match any of the regexes: '^characteristics_.*$'"
                     fields_to_remove = (path,
-                                        [field for field in re.findall(r"(?<!regexes: )'([^']+)',?", error.message)]
-                                        )
+                                        [field for field in _utils.find_additional_properties(error.instance,
+                                                                                              error.schema)])
                     extra_fields.append(fields_to_remove)
         else:
             extra_documents.append(document)


### PR DESCRIPTION
Here is another way we could get the fields. It might cost a bit more since `jsonschema._utils.find_additional_properties` is called twice per `document`. The first call is by `_validators.additionalProperties`, the second time is by us.
 
### Release notes
Using `jsonschema._utils.find_additional_properties` to find extra fields over `re.findall`. This is less prone to breaking since extra fields are extracted by comparing the `json_data` with the `schema` and not the `error.message`.
