### PR TITLE
Allow for getting bucket name without instantiating blob store objects

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    raise AssertionError
+    raise NotImplementedError

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ npm-debug.log
 
 # Python coverage
 .coverage
-.coverage*
+.coverage.*
 
 # Credential files
 /gcp-credentials.json

--- a/dss/util/bundles.py
+++ b/dss/util/bundles.py
@@ -72,7 +72,7 @@ def get_bundle_from_bucket(
         }
         if directurls:
             file_version['url'] = str(UrlBuilder().set(
-                scheme=Config.get_storage_schema(replica),
+                scheme=replica.storage_schema,
                 netloc=bucket,
                 path="blobs/{}.{}.{}.{}".format(
                     file[BundleFileMetadata.SHA256],

--- a/tests/infra/storage_mixin.py
+++ b/tests/infra/storage_mixin.py
@@ -32,7 +32,7 @@ class TestFile:
         self.name = os.path.basename(file_key)
         self.path = file_key
         self.uuid = str(uuid.uuid4())
-        self.url = Config.get_storage_schema(replica) + "://" + bundle.bucket + "/" + self.path
+        self.url = replica.storage_schema + "://" + bundle.bucket + "/" + self.path
         self.version = None
 
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -82,7 +82,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self._test_bundle_get_directaccess(Replica.gcp)
 
     def _test_bundle_get_directaccess(self, replica: Replica):
-        schema = Config.get_storage_schema(replica)
+        schema = replica.storage_schema
 
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
@@ -153,7 +153,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self._test_bundle_put(Replica.gcp, self.gs_test_fixtures_bucket)
 
     def _test_bundle_put(self, replica: Replica, fixtures_bucket: str):
-        schema = Config.get_storage_schema(replica)
+        schema = replica.storage_schema
 
         bundle_uuid = str(uuid.uuid4())
         file_uuid = str(uuid.uuid4())
@@ -249,7 +249,7 @@ class TestDSS(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self._test_bundle_delete(Replica.gcp, self.gs_test_fixtures_bucket, False)
 
     def _test_bundle_delete(self, replica: Replica, fixtures_bucket: str, authorized: bool):
-        schema = Config.get_storage_schema(replica)
+        schema = replica.storage_schema
 
         # prep existing bundle
         bundle_uuid = str(uuid.uuid4())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from dss.config import DeploymentStage, Config, BucketConfig
+from dss.config import DeploymentStage, Config, BucketConfig, Replica
 
 
 class TestConfig(unittest.TestCase):
@@ -63,6 +63,13 @@ class TestConfig(unittest.TestCase):
         for bucket_config in BucketConfig:
             Config.set_config(bucket_config)
             self.assertEquals(Config.get_notification_email(), os.environ["DSS_NOTIFICATION_SENDER"])
+
+    def test_replica(self):
+        # Assert that derived properties are distinct between enum instances
+        for prop in Replica.storage_schema, Replica.bucket:
+            prop_vals = set(prop.getter(r) for r in Replica)
+            self.assertFalse(None in prop_vals)
+            self.assertEqual(len(Replica), len(prop_vals))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -107,7 +107,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         Config.set_config(BucketConfig.TEST_FIXTURE)
         cls.blobstore, _, cls.test_fixture_bucket = Config.get_cloud_specific_handles(cls.replica)
         Config.set_config(BucketConfig.TEST)
-        _, _, cls.test_bucket = Config.get_cloud_specific_handles(cls.replica)
+        cls.test_bucket = cls.replica.bucket
         cls.dss_alias_name = dss.Config.get_es_alias_name(dss.ESIndexType.docs, cls.replica)
         cls.subscription_index_name = dss.Config.get_es_index_name(dss.ESIndexType.subscriptions, cls.replica)
 


### PR DESCRIPTION
I think get_cloud_specific_handles() is ill-conceived. If you look at its call sites, you'll see that often only a subset of its three return values are used.

This takes us one step closer to its elimination. The typesafe Enum pattern encourages converting code like

```
if foo == Foo.x:
   return ...
elif foo == Foo.y:
   return ...
```

into instance methods of the enum class.
