### PR TITLE
Reindexing 1/3: Prepare indexer code for REPAIR and VERIFY, add retry

### DIFF
--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -9,7 +9,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss.events.handlers.index import AWSIndexHandler, GCPIndexHandler
+from dss.events.handlers.index import AWSIndexer, GCPIndexer
 
 app = domovoi.Domovoi()
 
@@ -24,7 +24,8 @@ def dispatch_s3_indexer_event(event, context) -> None:
     if event.get("Event") == "s3:TestEvent":
         app.log.info("DSS index daemon received S3 test event")
     else:
-        AWSIndexHandler.process_new_indexable_object(event, app.log)
+        indexer = AWSIndexer()
+        indexer.process_new_indexable_object(event, app.log)
 
 
 @app.sns_topic_subscriber("dss-gs-bucket-events-" + os.environ["DSS_GS_BUCKET"])
@@ -33,4 +34,5 @@ def dispatch_gs_indexer_event(event, context):
     This handler receives GS events via the Google Cloud Function deployed from daemons/dss-gs-event-relay.
     """
     gs_event = json.loads(event['Records'][0]['Sns']['Message'])
-    GCPIndexHandler.process_new_indexable_object(gs_event['data'], app.log)
+    indexer = GCPIndexer()
+    indexer.process_new_indexable_object(gs_event['data'], app.log)

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -14,7 +14,10 @@ class IndexHandler:
 
     @classmethod
     def _process_new_indexable_object(cls, replica: Replica, key: str, logger):
-        identifier = ObjectIdentifier.from_key(key)
+        try:
+            identifier = ObjectIdentifier.from_key(key)
+        except ValueError:
+            identifier = None
         if isinstance(identifier, BundleFQID):
             cls._handle_bundle(replica, identifier, logger)
         elif isinstance(identifier, TombstoneID):

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -27,40 +27,14 @@ class IndexHandler:
     def _index_and_notify(replica: Replica, bundle_fqid: BundleFQID, logger):
         logger.info(f"Indexing bundle {bundle_fqid} from replica '{replica.name}'.")
         doc = BundleDocument.from_replica(replica, bundle_fqid, logger)
-        index_name = doc.prepare_index()
-        versions = doc.get_indexed_versions()
-        old_version = versions.pop(index_name, None)
-        if versions:
-            logger.warning(f"Removing stale copies of the bundle document for {bundle_fqid} from the following "
-                           f"index(es): {json.dumps(versions)}.")
-            doc.remove_versions(versions)
-        if old_version:
-            old_doc = doc.from_index(replica, bundle_fqid, index_name, logger, version=old_version)
-            if doc == old_doc:
-                logger.info(f"Document for bundle {bundle_fqid} is already up-to-date in index {index_name} at "
-                            f"version {old_version}.")
-            else:
-                logger.warning(f"Updating an older copy of the document for bundle {bundle_fqid} in index "
-                               f"{index_name} at version {old_version}.")
-                doc.add_to_index(index_name)
-        else:
-            logger.info(f"Writing the document for bundle {bundle_fqid} in index "
-                        f"{index_name} for the first time.")
-            doc.add_to_index(index_name)
-        doc.notify_matching_subscribers(index_name)
+        doc.index_and_notify()
         logger.debug(f"Finished indexing bundle {bundle_fqid} from replica '{replica.name}'.")
 
     @staticmethod
     def _delete_from_index(replica: Replica, tombstone_id: TombstoneID, logger):
         logger.info(f"Received {replica.name} deletion event with tombstone identifier: {tombstone_id}")
         tombstone_document = BundleTombstoneDocument.from_replica(replica, tombstone_id, logger)
-        dead_documents = tombstone_document.list_dead_bundles()
-        for document in dead_documents:
-            index_name = document.prepare_index()
-            document.clear()
-            document.update(tombstone_document)
-            document.add_to_index(index_name)
-            logger.info(f"Deleted from {replica.name} bundle: {document.fqid}")
+        tombstone_document.index()
 
 
 class AWSIndexHandler(IndexHandler):

--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -31,8 +31,8 @@ class Indexer(metaclass=ABCMeta):
             key = self._parse_event(event)
             self.index_object(key, logger)
         except Exception:
-            logger.error("Exception occurred while processing %s event: %s",
-                         self.replica, json.dumps(event, indent=4), exc_info=True)
+            logger.error("%s", f"Exception occurred while processing {self.replica} "
+                               f"event: {json.dumps(event, indent=4)}", exc_info=True)
             raise
 
     @elasticsearch_retry
@@ -47,7 +47,7 @@ class Indexer(metaclass=ABCMeta):
         elif isinstance(identifier, TombstoneID):
             self._index_tombstone(self.replica, identifier, logger)
         else:
-            logger.debug(f"Not processing {self.replica.name} event for key: {key}")
+            logger.debug("%s", f"Not processing {self.replica.name} event for key: {key}")
 
     @property
     @abstractmethod
@@ -59,18 +59,18 @@ class Indexer(metaclass=ABCMeta):
         raise NotImplementedError()
 
     def _index_bundle(self, replica: Replica, bundle_fqid: BundleFQID, logger):
-        logger.info(f"Indexing bundle {bundle_fqid} from replica {replica.name}.")
+        logger.info("%s", f"Indexing bundle {bundle_fqid} from replica {replica.name}.")
         doc = BundleDocument.from_replica(replica, bundle_fqid, logger)
         modified, index_name = doc.index(dryrun=self.dryrun)
         if self.notify or modified and self.notify is None:
             doc.notify(index_name)
-        logger.debug(f"Finished indexing bundle {bundle_fqid} from replica {replica.name}.")
+        logger.debug("%s", f"Finished indexing bundle {bundle_fqid} from replica {replica.name}.")
 
     def _index_tombstone(self, replica: Replica, tombstone_id: TombstoneID, logger):
-        logger.info(f"Indexing tombstone {tombstone_id} from {replica.name}.")
+        logger.info("%s", f"Indexing tombstone {tombstone_id} from {replica.name}.")
         doc = BundleTombstoneDocument.from_replica(replica, tombstone_id, logger)
         doc.index(dryrun=self.dryrun)
-        logger.info(f"Finished indexing tombstone {tombstone_id} from {replica.name}.")
+        logger.info("%s", f"Finished indexing tombstone {tombstone_id} from {replica.name}.")
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(dryrun={self.dryrun}, notify={self.notify})"

--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -42,7 +42,7 @@ class ObjectIdentifier(namedtuple('ObjectIdentifier', 'uuid version')):
             else:
                 raise ValueError(f"Object name does not contain a valid bundle identifier: {key}")
         else:
-            raise ValueError(f"Object name does not contain a valid bundle identifier: {key}")
+            raise ValueError(f"Key does not represent a valid identifier: {key}")
 
     def is_fully_qualified(self):
         return self.uuid is not None and self.version is not None
@@ -53,7 +53,7 @@ class ObjectIdentifier(namedtuple('ObjectIdentifier', 'uuid version')):
     @property
     @abstractmethod
     def prefix(self):
-        return NotImplementedError("'prefix' not implemented!")
+        return NotImplementedError()
 
     def to_key_prefix(self):
         return f"{self.prefix}/{self.uuid}.{self.version or ''}"

--- a/dss/storage/index_document.py
+++ b/dss/storage/index_document.py
@@ -70,6 +70,7 @@ class IndexDocument(dict, metaclass=ABCMeta):
         return json.dumps(self)
 
     def __eq__(self, other: object) -> bool:
+        # noinspection PyUnresolvedReferences
         return self is other or (super().__eq__(other) and
                                  type(self) == type(other) and
                                  self.replica == other.replica and

--- a/dss/storage/index_document.py
+++ b/dss/storage/index_document.py
@@ -4,6 +4,8 @@ import logging
 import socket
 import typing
 import uuid
+from abc import abstractmethod, ABCMeta
+
 from collections import defaultdict
 from urllib.parse import urlparse
 
@@ -22,7 +24,22 @@ from dss.util import create_blob_key
 from dss.util.es import ElasticsearchClient
 
 
-class IndexDocument(dict):
+class IndexDocument(dict, metaclass=ABCMeta):
+    """
+    An instance of this class represents a document in an Elasticsearch index.
+    """
+
+    @abstractmethod
+    def index(self, dryrun=False) -> (bool, str):
+        """
+        Ensure that there is exactly one up-to-date instance of this document in exactly one ES index.
+
+        :param dryrun: if True, only read-only actions will be performed but no ES indices will be modified
+        :return: a tuple (modified, index_name) indicating whether an index needed to be updated and what the name of
+                 that index is. Note that `modified` may be True even if dryrun is False, indicating that a wet run
+                 would have updated the index.
+        """
+        raise NotImplementedError()
 
     def __init__(self, replica: Replica, fqid: typing.Union[BundleFQID, TombstoneID], logger: logging.Logger,
                  *args, **kwargs) -> None:
@@ -31,28 +48,11 @@ class IndexDocument(dict):
         self.replica = replica
         self.fqid = fqid
 
-    @classmethod
-    def from_index(cls, replica: Replica, bundle_fqid: BundleFQID, index_name, logger, version=None):
-        es_client = ElasticsearchClient.get(logger)
-        source = es_client.get(index_name, str(bundle_fqid), ESDocType.doc.name, version=version)['_source']
-        return cls(replica, bundle_fqid, logger, source)
-
-    def add_to_index(self, index_name: str):
+    def _write_to_index(self, index_name: str):
         es_client = ElasticsearchClient.get(self.logger)
-        try:
-            self.logger.debug("Adding index data to ElasticSearch index '%s': %s", index_name,
-                              json.dumps(self, indent=4))
-            initial_mappings = es_client.indices.get_mapping(index_name)[index_name]['mappings']
-            es_client.index(index=index_name,
-                            doc_type=ESDocType.doc.name,
-                            id=str(self.fqid),
-                            # FIXME: (hannes) Can this be json.dumps(self, indent=4) ?
-                            body=self.to_json())  # Don't use refresh here.
-        except Exception as ex:
-            self.logger.error("Document not indexed. Exception: %s, Index name: %s, Index data: %s",
-                              ex, index_name, json.dumps(self, indent=4))
-            raise
-        return initial_mappings
+        json = self.to_json()
+        self.logger.debug("Writing document to index '%s': %s", index_name, json)
+        es_client.index(index=index_name, doc_type=ESDocType.doc.name, id=str(self.fqid), body=json)
 
     def to_json(self):
         return json.dumps(self)
@@ -63,11 +63,31 @@ class IndexDocument(dict):
                                  self.replica == other.replica and
                                  self.fqid == other.fqid)
 
+    @staticmethod
+    def _msg(dryrun):
+        """
+        Returns a unary function that conditionally rewrites a given log message so it makes sense in the context of a
+        dry run.
+
+        The message should start with with a verb in -ing form, announcing an action to be taken.
+        """
+        def msg(s):
+            assert s
+            assert s[:1].isupper()
+            assert s.split(maxsplit=1)[0].endswith('ing')
+            return f"Skipped {s[:1].lower() + s[1:]}" if dryrun else s
+        return msg
+
 
 class BundleDocument(IndexDocument):
     """
-    An instance of this class represents the ElasticSearch document for a given bundle.
+    An instance of this class represents the Elasticsearch document for a given bundle.
     """
+
+    # Note to implementors, only public methods should have a `dryrun` keyword argument. If they do, the argument
+    # should have a default value of False. Protected and private methods may also have a dryrun argument but if they
+    # do it must be positional in order to ensure that the argument isn't accidentally dropped along the call chain.
+
     @classmethod
     def from_replica(cls, replica: Replica, bundle_fqid: BundleFQID, logger):
         self = cls(replica, bundle_fqid, logger)
@@ -77,6 +97,12 @@ class BundleDocument(IndexDocument):
         self['state'] = 'new'
         return self
 
+    @classmethod
+    def from_index(cls, replica: Replica, bundle_fqid: BundleFQID, index_name, logger, version=None):
+        es_client = ElasticsearchClient.get(logger)
+        source = es_client.get(index_name, str(bundle_fqid), ESDocType.doc.name, version=version)['_source']
+        return cls(replica, bundle_fqid, logger, source)
+
     @property
     def files(self):
         return self['files']
@@ -85,40 +111,62 @@ class BundleDocument(IndexDocument):
     def manifest(self):
         return self['manifest']
 
-    def index_and_notify(self):
-        index_name = self.prepare_index()
-        versions = self.get_indexed_versions()
+    def index(self, dryrun=False) -> (bool, str):
+        index_name = self._prepare_index(dryrun)
+        return self._index_into(index_name, dryrun)
+
+    def _index_into(self, index_name: str, dryrun: bool):
+        msg = self._msg(dryrun)
+        versions = self._get_indexed_versions()
         old_version = versions.pop(index_name, None)
         if versions:
-            self.logger.warning(f"Removing stale copies of the bundle document for {self.fqid} from the following "
-                                f"index(es): {json.dumps(versions)}.")
-            self.remove_versions(versions)
+            self.logger.warning(msg(f"Removing stale copies of the bundle document for {self.fqid} from the following "
+                                    f"index(es): {json.dumps(versions)}."))
+            if not dryrun:
+                self._remove_versions(versions)
         if old_version:
             old_doc = self.from_index(self.replica, self.fqid, index_name, self.logger, version=old_version)
             if self == old_doc:
                 self.logger.info(f"Document for bundle {self.fqid} is already up-to-date in index {index_name} at "
                                  f"version {old_version}.")
+                return False, index_name
             else:
-                self.logger.warning(f"Updating an older copy of the document for bundle {self.fqid} in index "
-                                    f"{index_name} at version {old_version}.")
-                self.add_to_index(index_name)
+                self.logger.warning(msg(f"Updating an older copy of the document for bundle {self.fqid} in index "
+                                        f"{index_name} at version {old_version}."))
         else:
-            self.logger.info(f"Writing the document for bundle {self.fqid} in index "
-                             f"{index_name} for the first time.")
-            self.add_to_index(index_name)
-        self.notify_matching_subscribers(index_name)
+            self.logger.info(msg(f"Writing the document for bundle {self.fqid} to index "
+                                 f"{index_name} for the first time."))
+        if not dryrun:
+            self._write_to_index(index_name)
+        return True, index_name
 
-    def add_to_index(self, index_name: str) -> None:
-        initial_mappings = super().add_to_index(index_name)
+    def entomb(self, tombstone: 'BundleTombstoneDocument', dryrun=False):
+        """
+        Ensure that there is exactly one up-to-date instance of a tombstone for this document in exactly one
+        ES index. The tombstone data overrides the document's data in the index.
+
+        :param tombstone: The document with which to replace this document in the index.
+        :param dryrun: see :py:meth:`~IndexDocument.index`
+        :return: see :py:meth:`~IndexDocument.index`
+        """
+        self.logger.info(f"Writing tombstone for {self.replica.name} bundle: {self.fqid}")
+        # Preare the index using the original data such that the tombstone can be placed in the correct index.
+        index_name = self._prepare_index(dryrun)
+        # Override document with tombstone JSON …
+        self.clear()
+        self.update(tombstone)
+        # … and place into proper index.
+        modified, index_name = self._index_into(index_name, dryrun)
+        self.logger.info(f"Finished writing tombstone for {self.replica.name} bundle: {self.fqid}")
+        return modified, index_name
+
+    def _write_to_index(self, index_name: str):
         es_client = ElasticsearchClient.get(self.logger)
-        try:
-            current_mappings = es_client.indices.get_mapping(index_name)[index_name]['mappings']
-            if initial_mappings != current_mappings:
-                self._refresh_percolate_queries(index_name)
-        except Exception as ex:
-            self.logger.error("Error refreshing subscription queries for index. Exception: %s, Index name: %s",
-                              ex, index_name)
-            raise
+        initial_mappings = es_client.indices.get_mapping(index_name)[index_name]['mappings']
+        super()._write_to_index(index_name)
+        current_mappings = es_client.indices.get_mapping(index_name)[index_name]['mappings']
+        if initial_mappings != current_mappings:
+            self._refresh_percolate_queries(index_name)
 
     def _read_bundle_manifest(self, handle: BlobStore, bucket_name: str, bundle_fqid: BundleFQID) -> dict:
         manifest_string = handle.get(bucket_name, bundle_fqid.to_key()).decode("utf-8")
@@ -170,11 +218,12 @@ class BundleDocument(IndexDocument):
         scrub_index_data(index_files, str(self.fqid), self.logger)
         return index_files
 
-    def prepare_index(self):
+    def _prepare_index(self, dryrun):
         shape_descriptor = self.get_shape_descriptor()
         index_name = Config.get_es_index_name(ESIndexType.docs, self.replica, shape_descriptor)
         es_client = ElasticsearchClient.get(self.logger)
-        IndexManager.create_index(es_client, self.replica, index_name)
+        if not dryrun:
+            IndexManager.create_index(es_client, self.replica, index_name)
         return index_name
 
     def get_shape_descriptor(self) -> typing.Optional[str]:
@@ -220,7 +269,7 @@ class BundleDocument(IndexDocument):
         else:
             return None  # No files with schema identifiers were found
 
-    def get_indexed_versions(self) -> typing.MutableMapping[str, str]:
+    def _get_indexed_versions(self) -> typing.MutableMapping[str, str]:
         """
         Returns a dictionary mapping the name of each index containing this document to the
         version of this document in that index. Note that `version` denotes document version, not
@@ -246,7 +295,7 @@ class BundleDocument(IndexDocument):
         indices = {hit['_index']: hit['_version'] for hit in hits['hits']}
         return indices
 
-    def remove_versions(self, versions: typing.MutableMapping[str, str]):
+    def _remove_versions(self, versions: typing.MutableMapping[str, str]):
         """
         Remove this document from each given index provided that it contains the given version of this document.
         """
@@ -261,7 +310,7 @@ class BundleDocument(IndexDocument):
         for item in errors:
             self.logger.warning(f"Document deletion failed: {json.dumps(item)}")
 
-    def _refresh_percolate_queries(self, index_name: str) -> None:
+    def _refresh_percolate_queries(self, index_name: str):
         # When dynamic templates are used and queries for percolation have been added
         # to an index before the index contains mappings of fields referenced by those queries,
         # the queries must be reloaded when the mappings are present for the queries to match.
@@ -288,11 +337,11 @@ class BundleDocument(IndexDocument):
                 self.logger.error("Error occurred when adding subscription queries to index %s Errors: %s",
                                   index_name, ex.errors)
 
-    def notify_matching_subscribers(self, index_name):
-        subscriptions = self.find_matching_subscriptions(index_name)
-        self.notify_subscribers(subscriptions)
+    def notify(self, index_name):
+        subscription_ids = self._find_matching_subscriptions(index_name)
+        self._notify_subscribers(subscription_ids)
 
-    def find_matching_subscriptions(self, index_name: str) -> set:
+    def _find_matching_subscriptions(self, index_name: str) -> typing.MutableSet[str]:
         percolate_document = {
             'query': {
                 'percolate': {
@@ -310,12 +359,12 @@ class BundleDocument(IndexDocument):
         self.logger.debug("Found matching subscription count: %i", len(subscription_ids))
         return subscription_ids
 
-    def notify_subscribers(self, subscription_ids: set) -> None:
+    def _notify_subscribers(self, subscription_ids: typing.MutableSet[str]):
         for subscription_id in subscription_ids:
             try:
                 # TODO Batch this request
                 subscription = self._get_subscription(subscription_id)
-                self.notify_subscriber(subscription)
+                self._notify_subscriber(subscription)
             except Exception:
                 self.logger.error("Error occurred while processing subscription %s for bundle %s.",
                                   subscription_id, self.fqid, exc_info=True)
@@ -341,7 +390,7 @@ class BundleDocument(IndexDocument):
         subscription['id'] = subscription_id
         return subscription
 
-    def notify_subscriber(self, subscription: dict):
+    def _notify_subscriber(self, subscription: dict):
         subscription_id = subscription['id']
         transaction_id = str(uuid.uuid4())
         payload = {
@@ -394,7 +443,7 @@ class BundleTombstoneDocument(IndexDocument):
         tombstone_data = json.loads(blobstore.get(bucket_name, tombstone_id.to_key()))
         return cls(replica, tombstone_id, logger, tombstone_data)
 
-    def _list_dead_bundles(self):
+    def _list_dead_bundles(self) -> typing.Sequence[BundleDocument]:
         blobstore, _, bucket_name = Config.get_cloud_specific_handles(self.replica)
 
         if self.fqid.is_fully_qualified():
@@ -407,14 +456,9 @@ class BundleTombstoneDocument(IndexDocument):
             bundle_fqids = filter(lambda fqid: type(fqid) == BundleFQID, fqids)
 
         docs = [BundleDocument.from_replica(self.replica, bundle_fqid, self.logger) for bundle_fqid in bundle_fqids]
-
         return docs
 
-    def index(self):
+    def index(self, dryrun=False) -> (bool, str):
         dead_docs = self._list_dead_bundles()
         for doc in dead_docs:
-            index_name = doc.prepare_index()
-            doc.clear()
-            doc.update(self)
-            doc.add_to_index(index_name)
-            self.logger.info(f"Deleted from {doc.replica.name} bundle: {doc.fqid}")
+            doc.entomb(self, dryrun=dryrun)

--- a/dss/storage/index_document.py
+++ b/dss/storage/index_document.py
@@ -394,7 +394,7 @@ class BundleTombstoneDocument(IndexDocument):
         tombstone_data = json.loads(blobstore.get(bucket_name, tombstone_id.to_key()))
         return cls(replica, tombstone_id, logger, tombstone_data)
 
-    def list_dead_bundles(self):
+    def _list_dead_bundles(self):
         blobstore, _, bucket_name = Config.get_cloud_specific_handles(self.replica)
 
         if self.fqid.is_fully_qualified():
@@ -411,11 +411,10 @@ class BundleTombstoneDocument(IndexDocument):
         return docs
 
     def index(self):
-        dead_documents = self.list_dead_bundles()
-        for document in dead_documents:
-            index_name = document.prepare_index()
-            document.clear()
-            document.update(self)
-            document.add_to_index(index_name)
-            self.logger.info(f"Deleted from {document.replica.name} bundle: {document.fqid}")
-
+        dead_docs = self._list_dead_bundles()
+        for doc in dead_docs:
+            index_name = doc.prepare_index()
+            doc.clear()
+            doc.update(self)
+            doc.add_to_index(index_name)
+            self.logger.info(f"Deleted from {doc.replica.name} bundle: {doc.fqid}")

--- a/dss/util/retry.py
+++ b/dss/util/retry.py
@@ -1,0 +1,277 @@
+import logging
+import threading
+
+import itertools
+
+import time
+from functools import wraps
+from typing import Any, Optional, Callable, Union
+
+default_logger = logging.getLogger(__name__)
+
+
+# noinspection PyPep8Naming
+class retry:
+    """
+    A function decorator that retries invocations of the decorated function on every unhandled exception. Each
+    invocation attempt (the first attempt and each retry) represents a transaction. Contextual information that
+    accumulates (via the static :py:meth:`retry.add_context`) over the course of the transaction is logged when an
+    exception occurs, the context is reset and the transaction retried.
+
+    @retry without arguments retries the decorated function forever (!), on any exception, without delay.
+
+    >>> default_logger.setLevel(logging.ERROR) # avoid polluting test output with expected warnings
+
+    >>> @retry
+    ... def f1(x):
+    ...     retry.add_context(x=x)
+    ...     import os
+    ...     y = ord(os.urandom(1)) % 16
+    ...     retry.add_context(y=y)
+    ...     if y == x % 16:
+    ...         return x
+    ...     else:
+    ...         raise Exception
+    >>> f1(3)
+    3
+
+    Note that the `retry.add_context` method can be used anywhere, directly in the decorated function or any function
+    it calls.
+
+    In most cases you will want to specify either a maximum number of retries …
+
+    >>> @retry(limit=1)
+    ... def f2(x):
+    ...     retry.add_context(x=x)
+    ...     raise Exception(x)
+    >>> f2(42)
+    Traceback (most recent call last):
+      ...
+    Exception: 42
+
+    … or a timeout in seconds. A delay in seconds between retries can also be specified:
+
+    >>> @retry(timeout=0.5, delay=0.1)
+    ... def f3(x):
+    ...     retry.add_context(x=x)
+    ...     raise Exception(x)
+    >>> f3(42)
+    Traceback (most recent call last):
+      ...
+    Exception: 42
+
+    A predicate can be used to retry a function only when specific types of exceptions occur:
+
+    >>> i = 0
+    >>> @retry(retryable=lambda e: isinstance(e, RuntimeError), limit=2)
+    ... def f4(x):
+    ...     global i
+    ...     i += 1
+    ...     raise ValueError(x)
+    >>> f4(42)
+    Traceback (most recent call last):
+      ...
+    ValueError: 42
+    >>> i
+    1
+
+    By default the name of the decorated function is logged when an exception occurs. Both name and logger can be
+    configured:
+
+    >>> from unittest.mock import MagicMock
+    >>> logger = MagicMock()
+
+    >>> @retry(name='foo', logger=logger, limit=0)
+    ... def f5():
+    ...     raise Exception
+    >>> f5()
+    Traceback (most recent call last):
+      ...
+    Exception
+    >>> logger.method_calls[0]
+    call.warning("An exception occurred in '%s' of %r", 'foo', {}, exc_info=True)
+
+    If one decorated function calls another decorated function, the inner function will be retried independently and
+    each inner TX will commence with an empty context and its own timeout and logger. While this seems desirable it
+    could violate a timeout constraint specified for the outer function. Use `inherit=True` to have the inner TX
+    inherit the outer TX's context, logger and timeout. Note that while an inner TX inherits the context of the outer
+    TX, changes made to that context are only reflected for the duration of the inner TX. Every inner TX starts with
+    a fresh copy of the outer TX's original context.
+
+    >>> from unittest.mock import MagicMock
+    >>> logger = MagicMock()
+
+    >>> @retry(timeout=0, logger=logger)
+    ... def f6(x):
+    ...     retry.add_context(x=x)
+    ...     return f7(x+x)
+
+    >>> @retry(inherit=True)
+    ... def f7(y):
+    ...     retry.add_context(y=y)
+    ...     raise Exception
+
+    Without `inherit=True`, f7 would be retried forever, the logged context would lack 'x' and logs would go to the
+    default logger. With it, the retry of f7 honours the timeout on f6, which is 0 in this case, disabling a retry.
+    The log messages emitted for `f7` include `x` from `f6` but those emitted for f6 don't include `y` from f6.
+
+    >>> f6(42)
+    Traceback (most recent call last):
+      ...
+    Exception
+
+    >>> logger.method_calls
+    [call.warning("An exception occurred in '%s' of %r", 'f7', {'x': 42, 'y': 84}, exc_info=True),
+     call.debug("Timed out retrying '%s' of %r", 'f7', {'x': 42, 'y': 84}),
+     call.warning("An exception occurred in '%s' of %r", 'f6', {'x': 42}, exc_info=True),
+     call.debug("Timed out retrying '%s' of %r", 'f6', {'x': 42})]
+
+    Note that any retry `limit` constraints are applied independently, regardless of `inherit`. Barring timeouts,
+    the lowest upper bound on the number of times an inner function is retried is the product of the inner and outer
+    `limit`.
+
+    The delay before each retry can be computed dynamically based on the previous delay and the index of the retry.
+    The index of the first retry is 0 and its previous delay is None. The following example implements exponential
+    back-off:
+
+    >>> i, t = 0, time.time()
+    >>> @retry(delay=lambda _, delay: 0.1 if delay is None else delay * 2, limit=4)
+    ... def f8():
+    ...     global i; i += 1; raise Exception
+    >>> f8()
+    Traceback (most recent call last):
+      ...
+    Exception
+    >>> i
+    5
+    >>> time.time() - t >= 1.5
+    True
+
+    To use a fixed list of delays:
+
+    >>> i, t = 0, time.time()
+    >>> delays = [0.1, 0.2, 0.4, 0.8]
+    >>> @retry(delay=lambda j, _: delays[j], limit=len(delays))
+    ... def f9():
+    ...     global i; i += 1; raise Exception
+    >>> f9()
+    Traceback (most recent call last):
+      ...
+    Exception
+    >>> i
+    5
+    >>> time.time() - t >= 1.5
+    True
+
+    """
+
+    thread_local = threading.local()
+
+    def __init__(self,
+                 inherit: bool = False,
+                 name: Optional[str] = None,
+                 limit: Optional[int] = None,
+                 timeout: Optional[float] = None,
+                 retryable: Callable[[BaseException], bool] = lambda e: True,
+                 delay: Union[float, Callable[[int, float], float]] = 0,
+                 logger=None) -> None:
+        super().__init__()
+        self.inherit = inherit
+        self.name = name
+        self.limit = limit
+        self.timeout = timeout
+        self.retryable = retryable
+        self.delay = delay if callable(delay) else lambda *_: delay
+        self.logger = logger or default_logger
+
+    def __call__(self, f):
+        name = self.name or f.__name__
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            outer_tx = self._get_tx()
+            if not self.inherit or outer_tx is None:
+                inner_tx = self._new_tx()
+            else:
+                inner_tx = outer_tx.copy()
+            delay = None
+            attempts = itertools.count() if self.limit is None else iter(range(self.limit))
+            while True:
+                tx = inner_tx.copy()
+                self._set_tx(tx)
+                try:
+                    return f(*args, **kwargs)
+                except BaseException as e:
+                    tx.logger.warning("An exception occurred in '%s' of %r", name, tx, exc_info=True)
+                    if self.retryable(e):
+                        attempt = next(attempts, None)
+                        if attempt is None:
+                            tx.logger.debug("Exceeded retry limit for '%s' of %r", name, tx)
+                            raise
+                        delay = self.delay(attempt, delay)
+                        if tx.would_expire_after(delay):
+                            tx.logger.debug("Timed out retrying '%s' of %r", name, tx)
+                            raise
+                        else:
+                            time.sleep(delay)
+                    else:
+                        raise
+                finally:
+                    self._set_tx(outer_tx)
+
+        return wrapper
+
+    def _new_tx(self):
+        timeout = self.timeout
+        expiration = None if timeout is None else time.time() + timeout
+        return self.TX(expiration=expiration, logger=self.logger)
+
+    @classmethod
+    def _get_tx(cls) -> Optional['TX']:
+        return getattr(cls.thread_local, 'tx', None)
+
+    @classmethod
+    def _set_tx(cls, tx: 'TX'):
+        cls.thread_local.tx = tx
+
+    @classmethod
+    def get_tx(cls) -> 'TX':
+        tx = cls._get_tx()
+        if tx is None:
+            raise LookupError('No retry transaction active in current thread')
+        else:
+            return tx
+
+    @classmethod
+    def add_context(cls, **kwargs) -> None:
+        cls.get_tx().update(kwargs)
+
+    @classmethod
+    def set_logger(cls, logger: logging.Logger) -> None:
+        cls.get_tx().logger = logger
+
+    class TX(dict):
+
+        def __init__(self, expiration: float, logger: logging.Logger) -> None:
+            super().__init__()
+            self.logger = logger
+            self.expiration = expiration
+
+        def would_expire_after(self, delay: float):
+            return self.expiration is not None and self.expiration < time.time() + delay
+
+        def copy(self):
+            other = type(self)(self.expiration, self.logger)
+            other.update(self)
+            return other
+
+    # Overide __new__ to make @retry equivalent to @retry()
+
+    def __new__(cls, *args, **kwargs) -> Any:
+        if args and callable(args[0]):
+            assert len(args) == 1, 'Decorators should only be invoked with a single, callable argument'
+            self = super().__new__(cls)
+            self.__init__()
+            return self(args[0])
+        else:
+            return super().__new__(cls)

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+"""
+Run selected doctests as a regular unit test.
+"""
+
+import os
+import sys
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+import doctest
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite('dss.util.retry'))
+    return tests

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -321,7 +321,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         self.assertRegex(
             log_monitor.output[0],
             f"WARNING:.*:In bundle .* the file '{inaccesssible_filename}' is marked for indexing"
-            " yet could not be accessed. This file will not be indexed. Exception: .*, File blob key:",
+            " yet could not be accessed. This file will not be indexed. Exception: .*, file blob key:",
         )
 
         search_results = self.get_search_results(self.smartseq2_paired_ends_query, 1)
@@ -501,8 +501,9 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         with self.subTest("An version file and unversioned file"):
             with self.assertLogs(logger, level="INFO") as log_monitor:
                 index_document.get_shape_descriptor()
-            self.assertRegex(log_monitor.output[0], ("INFO:.*File assay_json does not contain a 'core' section "
-                                                     "to identify the schema and schema version."))
+            self.assertIn("INFO:", log_monitor.output[0])
+            self.assertIn("File assay_json does not contain the 'core' section necessary to "
+                          "identify the schema and its version.", log_monitor.output[0])
             self.assertEqual(index_document.get_shape_descriptor(), "v4")
 
         index_document['files']['sample_json'].pop('core')

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -35,8 +35,9 @@ from tests import get_version, get_auth_header
 from tests.es import elasticsearch_delete_index, clear_indexes
 from tests.infra import DSSAssertMixin, DSSUploadMixin, DSSStorageMixin, TestBundle, start_verbose_logging, testmode
 from tests.infra.server import ThreadedLocalServer
-from tests.sample_search_queries import (smartseq2_paired_ends_v2_query, smartseq2_paired_ends_v3_query,
-                                         smartseq2_paired_ends_v2_or_v3_query, smartseq2_paired_ends_v4_query,
+from tests.sample_search_queries import (smartseq2_paired_ends_v3_query,
+                                         smartseq2_paired_ends_v2_or_v3_query,
+                                         smartseq2_paired_ends_v4_query,
                                          smartseq2_paired_ends_v3_or_v4_query)
 
 from tests import eventually, get_bundle_fqid, get_file_fqid
@@ -622,9 +623,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
             index_data = create_index_data(self.blobstore, self.test_bucket, manifest)
             index_data['files']['assay_json'].update({'extra_top': 123,
                                                       'extra_obj': {"something": "here", "another": 123},
-                                                      'extra_lst': ["a", "b"]
-                                                      }
-                                                     )
+                                                      'extra_lst': ["a", "b"]})
             index_data['files']['assay_json']['core']['extra_internal'] = 123
             index_data['files']['sample_json']['extra_0'] = "tests patterned properties."
             index_data['files']['project_json']['extra_1'] = "Another extra field in a different file."
@@ -953,7 +952,9 @@ def create_s3_bucket(bucket_name) -> None:
             logger.error(f"An unexpected error occured when creating test bucket: {bucket_name}")
 
 
-def generate_expected_index_document(blobstore, bucket_name, bundle_key, excluded_files=[]):
+def generate_expected_index_document(blobstore, bucket_name, bundle_key, excluded_files=None):
+    if excluded_files is None:
+        excluded_files = []
     manifest = read_bundle_manifest(blobstore, bucket_name, bundle_key)
     index_data = create_index_data(blobstore, bucket_name, manifest, excluded_files)
     return index_data
@@ -965,7 +966,9 @@ def read_bundle_manifest(blobstore, bucket_name, bundle_key):
     return manifest
 
 
-def create_index_data(blobstore, bucket_name, manifest, excluded_files=[]):
+def create_index_data(blobstore, bucket_name, manifest, excluded_files=None) -> typing.MutableMapping[str, typing.Any]:
+    if excluded_files is None:
+        excluded_files = []
     index = dict(state="new", manifest=manifest)
     files_info = manifest['files']
     excluded_file = [file.replace('_', '.') for file in excluded_files]

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -25,7 +25,7 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss import Config, BucketConfig, DeploymentStage
 from dss.config import IndexSuffix, ESDocType, Replica
-from dss.events.handlers.index import AWSIndexHandler, GCPIndexHandler, BundleDocument
+from dss.events.handlers.index import AWSIndexer, GCPIndexer, BundleDocument
 from dss.hcablobstore import BundleMetadata, BundleFileMetadata, FileMetadata
 from dss.util import create_blob_key, networking, UrlBuilder
 from dss.storage.bundles import ObjectIdentifier, BundleFQID, TombstoneID
@@ -238,7 +238,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
             self.assertEqual(1, len(hits))
             self.assertEqual(expect_shape_descriptor, shape_descriptor in hits[0]['_index'])
 
-        # Index documenty into the "wrong" index by patching the shape descriptor
+        # Index document into the "wrong" index by patching the shape descriptor
         with unittest.mock.patch.object(BundleDocument, 'get_shape_descriptor', return_value=shape_descriptor):
             self.process_new_indexable_object(sample_event, logger)
         # There should only be one hit and it should be from the "wrong" index
@@ -335,7 +335,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
     def test_notify(self):
         def _notify(subscription, bundle_id=get_bundle_fqid()):
             document = BundleDocument(self.replica, bundle_id, logger)
-            document.notify_subscriber(subscription=subscription)
+            document._notify_subscriber(subscription=subscription)
 
         with self.assertRaisesRegex(requests.exceptions.InvalidURL, "Invalid URL 'http://': No host supplied"):
             _notify(subscription=dict(id="", es_query={}, callback_url="http://"))
@@ -805,7 +805,7 @@ class TestIndexerBase(DSSAssertMixin, DSSStorageMixin, DSSUploadMixin):
         raise NotImplemented()
 
 
-class TestAWSIndexer(AWSIndexHandler, TestIndexerBase, unittest.TestCase):
+class TestAWSIndexer(AWSIndexer, TestIndexerBase, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -825,7 +825,7 @@ class TestAWSIndexer(AWSIndexHandler, TestIndexerBase, unittest.TestCase):
         return sample_event
 
 
-class TestGCPIndexer(GCPIndexHandler, TestIndexerBase, unittest.TestCase):
+class TestGCPIndexer(GCPIndexer, TestIndexerBase, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This refactors the indexer considerably in order to get it ready for the REPAIR and VERIFY modes of reindexing. It adds a general @retry decorator and uses that decorator to retry indexing on 409 versioning conflicts and 5xx server errors.