### PR TITLE
Prevent test output from being delayed by `make`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,10 @@ install:
 - dpkg -x make*.deb make4
 - export PATH=$(pwd)/make4/usr/bin:$PATH
 script:
+- DSS_UNITTEST_OPTS="$DSS_UNITTEST_OPTS -v"
 - set -eo pipefail
-- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 -O test; fi
-- if [[ $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 -O integration_test; fi
+- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 test; fi
+- if [[ $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 integration_test; fi
 - if [[ $TRAVIS_BRANCH == staging ]]; then source environment.staging; fi
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -16,21 +16,21 @@ test: lint mypy $(test_srcs)
 	rm -f .coverage.*
 
 $(test_srcs): %.py :
-	DSS_TEST_MODE="standalone" coverage run -p --source=dss -m unittest $@
+	DSS_TEST_MODE="standalone" coverage run -p --source=dss -m unittest $(DSS_UNITTEST_OPTS) $@ 2>&1 | sed -e "s/^/$$$$ /"
 
 integration_test: lint mypy $(integration_test_srcs)
 	coverage combine
 	rm -f .coverage.*
 
 $(integration_test_srcs): integration__%.py :
-	DSS_TEST_MODE="integration" coverage run -p --source=dss -m unittest $*.py
+	DSS_TEST_MODE="integration" coverage run -p --source=dss -m unittest $(DSS_UNITTEST_OPTS) $*.py 2>&1 | sed -e "s/^/$$$$ /"
 
 all_test: lint mypy $(all_test_srcs)
 	coverage combine
 	rm -f .coverage.*
 
 $(all_test_srcs): all__%.py :
-	DSS_TEST_MODE="integration standalone" coverage run -p --source=dss -m unittest $*.py
+	DSS_TEST_MODE="integration standalone" coverage run -p --source=dss -m unittest $(DSS_UNITTEST_OPTS) $*.py 2>&1 | sed -e "s/^/$$$$ /"
 
 smoketest: all__tests/test_smoketest.py
 


### PR DESCRIPTION
When the `-O` make option is used in conjunction with `-j`, the output of an entire recipe is buffered and printed atomically when the recipe finishes. I have the suspicion that this 1) interferes with Travis' build output handler and 2) causes truncated build logs. This PR

* prefixes every line in the test output with the shell's PID which is going to be unique per line in the recipe. The test recipes only consist of one line, so each test module's output will be prefixed with a different number. A stable, lexical sort of the build output will produce a result resembling that of `-O`.

* passes `-v` to unittest for Travis builds, making the test output more lively. A nice side effect of `-v` is that it also prints which individual test methods were skipped.

* removes `-O` for test-related targets. I originally thought that `-O=line` would sync around every line of output but that's not the case. It syncs around the output produced by a line in the recipe.

* introduces the `DSS_UNITTEST_OPTS` variable which can be set to pass additional argument to Python's unittest module when running the tests (run `python -m unittest -h` to see which options are supported)

I propose trying this out for a few days (on master) and backing it out if it does give us any insights. I'm particularly interested in diagnosing the failed builds that seem to have their logs truncated.