### PR TITLE
Fix smoketest imports

### DIFF
--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -6,12 +6,12 @@ A basic integration test of the DSS. This can also be invoked via `make smoketes
 import os, sys, argparse, time, uuid, json, shutil, tempfile, unittest
 from subprocess import check_call, check_output, CalledProcessError
 
-from tests.infra import testmode
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from dss.api.files import ASYNC_COPY_THRESHOLD
+from tests.infra import testmode
+
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("--no-clean", dest="clean", action="store_false",


### PR DESCRIPTION
importing tests.* should happen after the path hack.

@amork noticed that `make smoketest` fails.