### PR TITLE
Include bundle UUID in index document to enable searching by bundle UUID

### DIFF
--- a/dss/storage/index_document.py
+++ b/dss/storage/index_document.py
@@ -111,6 +111,7 @@ class BundleDocument(IndexDocument):
         self['manifest'] = self._read_bundle_manifest(blobstore, bucket_name, bundle_fqid)
         self['files'] = self._read_file_infos(blobstore, bucket_name)
         self['state'] = 'new'
+        self['uuid'] = bundle_fqid.uuid
         return self
 
     @classmethod
@@ -476,7 +477,9 @@ class BundleTombstoneDocument(IndexDocument):
     def from_replica(cls, replica: Replica, tombstone_id: TombstoneID, logger):
         blobstore, _, bucket_name = Config.get_cloud_specific_handles(replica)
         tombstone_data = json.loads(blobstore.get(bucket_name, tombstone_id.to_key()))
-        return cls(replica, tombstone_id, logger, tombstone_data)
+        self = cls(replica, tombstone_id, logger, tombstone_data)
+        self['uuid'] = tombstone_id.uuid
+        return self
 
     def _list_dead_bundles(self) -> typing.Sequence[BundleDocument]:
         blobstore, _, bucket_name = Config.get_cloud_specific_handles(self.replica)

--- a/tests/sample_v3_index_doc.json
+++ b/tests/sample_v3_index_doc.json
@@ -1,5 +1,6 @@
 {
     "state": "new",
+    "uuid": "d5647e86-3ed7-409a-8f40-017fb1e0e672",
     "manifest": {
         "format": "0.0.1",
         "version": "2017-11-02T204944.954054Z",


### PR DESCRIPTION

The UUID is added to the index document for both regular bundles and bundle tombstones.

Connects to #801 

### Test plan
Test search by bundle UUID in deployed system.