### PR TITLE
Described testmode integration and standalone in ./tests/readme.md

### DIFF
--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,3 +1,6 @@
 # Test Convention
 
-All test are decorated with either `testmode.standalone` or `testmode.integration`. The environment `DSS_TEST_MODE` selects which type of tests to run. If the word "integration" is in the env var, then it runs the integration tests. If the word "standalone" is in the env var, then it runs the standalone tests. `DSS_TEST_MODE` can contain both words, in which case, both sets of tests are run. 
+All test are decorated with either `testmode.standalone` or `testmode.integration`. The environment `DSS_TEST_MODE` 
+selects which type of tests to run. If the word "integration" is in the env var, then it runs the integration tests. If 
+the word "standalone" is in the env var, then it runs the standalone tests. `DSS_TEST_MODE` can contain both words, in 
+which case, both sets of tests are run. 

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,0 +1,3 @@
+# Test Convention
+
+All test are decorated with either `testmode.standalone` or `testmode.integration`. The environment `DSS_TEST_MODE` selects which type of tests to run. If the word "integration" is in the env var, then it runs the integration tests. If the word "standalone" is in the env var, then it runs the standalone tests. `DSS_TEST_MODE` can contain both words, in which case, both sets of tests are run. 

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,9 +1,9 @@
 # Test Convention
 
 All tests are decorated with either `testmode.standalone` or `testmode.integration`. The environment variable 
-`DSS_TEST_MODE` selects which type of tests to run. If the word "integration" is in `DSS_TEST_MODE`, then 
-integration tests will run. If the word "standalone" is in `DSS_TEST_MODE`, then standalone tests are run. `DSS_TEST_MODE` 
-can contain both words, in which case, both sets of tests are run. 
+`DSS_TEST_MODE` selects which type of tests to run. If the word "integration" is in `DSS_TEST_MODE`, then `make test` 
+will run integration tests. If the word "standalone" is in `DSS_TEST_MODE`, then`make test` will run standalone tests. 
+`DSS_TEST_MODE` can contain both words, in which case `make test` will run both sets of tests. 
 
 Standalone tests may only use the fixture and storage buckets in each replica. They may not use any other cloud 
 resources such as Elasticsearch instances, API gateway or Lambda functions. 
@@ -12,7 +12,7 @@ Integration tests require cloud resource to run.
 
 # How to Run
 
-* `make test` will run "standalone" test cases.
+* `make test` will run tests based off the environment variable `DSS_TEST_MODE` value.
 
 * `make integration_test` will run "integration" test cases.
 

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,6 +1,21 @@
 # Test Convention
 
-All test are decorated with either `testmode.standalone` or `testmode.integration`. The environment `DSS_TEST_MODE` 
-selects which type of tests to run. If the word "integration" is in the env var, then it runs the integration tests. If 
-the word "standalone" is in the env var, then it runs the standalone tests. `DSS_TEST_MODE` can contain both words, in 
-which case, both sets of tests are run. 
+All tests are decorated with either `testmode.standalone` or `testmode.integration`. The environment variable 
+`DSS_TEST_MODE` selects which type of tests to run. If the word "integration" is in `DSS_TEST_MODE`, then 
+integration tests will run. If the word "standalone" is in `DSS_TEST_MODE`, then standalone tests are run. `DSS_TEST_MODE` 
+can contain both words, in which case, both sets of tests are run. 
+
+Standalone tests may only use the fixture and storage buckets in each replica. They may not use any other cloud 
+resources such as Elasticsearch instances, API gateway or Lambda functions. 
+
+Integration tests require cloud resource to run.
+
+# How to Run
+
+* `make test` will run "standalone" test cases.
+
+* `make integration_test` will run "integration" test cases.
+
+* `make all_tests` will run "standalone" and "integration" tests. 
+
+* `make smoketest` will run the test_smoketest.py test suite.


### PR DESCRIPTION
At this point all test cases have been tagged. Finishing up #751 by adding a readme to tests as a reminder to add the decorator to your test cases.
