### PR TITLE
Add permissions to sfn checkout to execute sfn-based copy

### DIFF
--- a/iam/policy-templates/dss-checkout-sfn-lambda.json
+++ b/iam/policy-templates/dss-checkout-sfn-lambda.json
@@ -65,14 +65,14 @@
     {
       "Effect": "Allow",
       "Action": [
-		"states:ListExecutions",
-		"states:StartExecution",
-		"states:DescribeExecution"
-	  ],
+        "states:ListExecutions",
+        "states:StartExecution",
+        "states:DescribeExecution"
+      ],
       "Resource": [
         "arn:aws:states:*:$account_id:stateMachine:dss-s3-copy-sfn*",
         "arn:aws:states:*:$account_id:execution:dss-s3-copy-sfn*"
-	  ]
+      ]
     }
   ]
 }

--- a/iam/policy-templates/dss-checkout-sfn-lambda.json
+++ b/iam/policy-templates/dss-checkout-sfn-lambda.json
@@ -61,7 +61,18 @@
       "Resource": [
         "arn:aws:ses:*:*:*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+		"states:ListExecutions",
+		"states:StartExecution",
+		"states:DescribeExecution"
+	  ],
+      "Resource": [
+        "arn:aws:states:*:$account_id:stateMachine:dss-s3-copy-sfn*",
+        "arn:aws:states:*:$account_id:execution:dss-s3-copy-sfn*"
+	  ]
     }
-
   ]
 }


### PR DESCRIPTION
The change is required due to switching to the step function-based implementation of the parllel copy. dss-checkout-sfn-* lambda needs to be able to start and describe executions of the dss-s3-copy-sfn