### PR TITLE
refactor the `test_file_put_large` test to more easily accommodate additional replicas

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -76,8 +76,8 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
     @testmode.integration
     def test_file_put_large(self):
 
-        def upload_callable_creator(uploader_class: type):
-            def upload_callable(bucket: str, key: str):
+        def upload_callable_creator(uploader_class: type) -> typing.Callable[[str, str], None]:
+            def upload_callable(bucket: str, key: str) -> None:
                 tempdir = tempfile.gettempdir()
                 uploader = uploader_class(tempdir, bucket)
 


### PR DESCRIPTION
Isolate the upload portion, which is the most cloud-specific aspect of the whole operation.
