### PR TITLE
Refactor usages of get_cloud_specific_handles_DEPRECATED

### DIFF
--- a/daemons/dss-sync/app.py
+++ b/daemons/dss-sync/app.py
@@ -55,7 +55,7 @@ def compose_upload(event, context):
     """
     gs_max_compose_parts = 32
     msg = json.loads(event["Records"][0]["Sns"]["Message"])
-    gs = dss.Config.get_cloud_specific_handles_DEPRECATED(Replica.gcp)[0].gcp_client
+    gs = dss.Config.get_cloud_specific_handles(Replica.gcp).native_cloud_handle
     gs_bucket = gs.get_bucket(msg["dest_bucket"])
     while True:
         try:
@@ -106,10 +106,11 @@ platform_to_replica = dict(s3=Replica.aws, gs=Replica.gcp)
 def copy_parts(event, context):
     topic_arn = event["Records"][0]["Sns"]["TopicArn"]
     msg = json.loads(event["Records"][0]["Sns"]["Message"])
-    blobstore_handle = dss.Config.get_cloud_specific_handles_DEPRECATED(platform_to_replica[msg["source_platform"]])[0]
+    blobstore_handle = dss.Config.get_cloud_specific_handles(
+        platform_to_replica[msg["source_platform"]]).blobstore_handle
     source_url = blobstore_handle.generate_presigned_GET_url(bucket=msg["source_bucket"], key=msg["source_key"])
     futures = []
-    gs = dss.Config.get_cloud_specific_handles_DEPRECATED(Replica.gcp)[0].gcp_client
+    gs = dss.Config.get_cloud_specific_handles(Replica.gcp).native_cloud_handle
     with ThreadPoolExecutor(max_workers=4) as executor:
         for part in msg["parts"]:
             context.log(log_msg.format(part=part, **msg))

--- a/dss/events/handlers/sync.py
+++ b/dss/events/handlers/sync.py
@@ -146,7 +146,7 @@ def dispatch_multipart_sync(source, dest, logger, context):
 
 
 def sync_blob(source_platform, source_key, dest_platform, logger, context):
-    gs = Config.get_cloud_specific_handles_DEPRECATED(Replica.gcp)[0].gcp_client
+    gs = Config.get_cloud_specific_handles(Replica.gcp).native_cloud_handle
     logger.info(f"Begin transfer of {source_key} from {source_platform} to {dest_platform}")
     gs_bucket, s3_bucket = gs.bucket(Config.get_gs_bucket()), resources.s3.Bucket(Config.get_s3_bucket())
     if source_platform == "s3" and dest_platform == "gs":
@@ -200,7 +200,7 @@ def compose_gs_blobs(gs_bucket, blob_names, dest_blob_name, logger):
 
 
 def copy_part(upload_url, source_url, dest_platform, part, context):
-    gs = Config.get_cloud_specific_handles_DEPRECATED(Replica.gcp)[0].gcp_client
+    gs = Config.get_cloud_specific_handles(Replica.gcp).native_cloud_handle
     boto3_session = boto3.session.Session()
     with closing(range_request(source_url, part["start"], part["end"])) as fh:
         if dest_platform == "s3":

--- a/dss/stepfunctions/visitation/integration_test.py
+++ b/dss/stepfunctions/visitation/integration_test.py
@@ -38,8 +38,8 @@ class IntegrationTest(Visitation):  # no coverage (this code *is* run by tests, 
 
     def job_finalize(self):
         super().job_finalize()
-        handle, _, _ = Config.get_cloud_specific_handles_DEPRECATED(Replica[self.replica])
-        listed_keys = handle.list(self.bucket, prefix=self.prefix)
+        cloud_handles = Config.get_cloud_specific_handles(Replica[self.replica])
+        listed_keys = cloud_handles.blobstore_handle.list(self.bucket, prefix=self.prefix)
         k_listed = sum(1 for _ in listed_keys)
         assert self.work_result == k_listed, f'Integration test failed: {self.work_result} != {k_listed}'
         self.logger.info(f"Integration test passed for {self.replica} with {k_listed} key(s) listed")
@@ -52,9 +52,9 @@ class IntegrationTest(Visitation):  # no coverage (this code *is* run by tests, 
 
         start_time = time()
 
-        handle = Config.get_cloud_specific_handles_DEPRECATED(Replica[self.replica])[0]
+        cloud_handles = Config.get_cloud_specific_handles(Replica[self.replica])
 
-        blobs = handle.list_v2(
+        blobs = cloud_handles.blobstore_handle.list_v2(
             self.bucket,
             prefix=self.work_id,
             start_after_key=self.marker,  # type: ignore  # Cannot determine type of 'marker'

--- a/dss/stepfunctions/visitation/reindex.py
+++ b/dss/stepfunctions/visitation/reindex.py
@@ -61,12 +61,12 @@ class Reindex(Visitation):
 
         self.indexer = indexer_class(dryrun=self.dryrun, notify=self.notify)
 
-        handle, _, default_bucket = Config.get_cloud_specific_handles_DEPRECATED(Replica[self.replica])
+        cloud_handles = Config.get_cloud_specific_handles(Replica[self.replica])
 
-        if self.bucket != default_bucket:
-            self.logger.warning(f'Indexing bucket {self.bucket} instead of default {default_bucket}.')
+        if self.bucket != cloud_handles.bucket_name:
+            self.logger.warning(f'Indexing bucket {self.bucket} instead of default {cloud_handles.bucket_name}.')
 
-        blobs = handle.list_v2(
+        blobs = cloud_handles.blobstore_handle.list_v2(
             self.bucket,
             prefix=f'bundles/{self.work_id}',
             start_after_key=self.marker,  # type: ignore  # Cannot determine type of 'marker'

--- a/dss/util/checkout.py
+++ b/dss/util/checkout.py
@@ -119,7 +119,7 @@ def touch_test_file(dst_bucket: str, replica: Replica) -> bool:
     :return: True if able to write, if not also returns error message as a cause
     """
     test_object = "touch.txt"
-    handle, *_ = Config.get_cloud_specific_handles_DEPRECATED(replica)
+    handle = Config.get_cloud_specific_handles(replica).blobstore_handle
 
     try:
         handle.upload_file_handle(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,7 @@ class TestApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin, DSSStorageMixin
     def setUp(self):
         self.replica = Replica.aws
         dss.Config.set_config(dss.BucketConfig.TEST)
-        self.blobstore, _, self.bucket = dss.Config.get_cloud_specific_handles_DEPRECATED(self.replica)
+        self.cloud_handles = dss.Config.get_cloud_specific_handles(self.replica)
 
     BUNDLE_FIXTURE = 'fixtures/test_api/bundle'
 
@@ -46,7 +46,8 @@ class TestApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin, DSSStorageMixin
           - GET /files/<uuid>
         and checks that data corresponds where appropriate.
         """
-        bundle = TestBundle(self.blobstore, self.BUNDLE_FIXTURE, self.bucket, self.replica)
+        bundle = TestBundle(
+            self.cloud_handles.blobstore_handle, self.BUNDLE_FIXTURE, self.cloud_handles.bucket_name, self.replica)
         self.upload_files_and_create_bundle(bundle, self.replica)
         self.get_bundle_and_check_files(bundle, self.replica)
 

--- a/tests/test_gscopyclient.py
+++ b/tests/test_gscopyclient.py
@@ -27,13 +27,13 @@ class TestGSCopy(unittest.TestCase):
         Config.set_config(BucketConfig.TEST)
 
         self.test_bucket = infra.get_env("DSS_GS_BUCKET_TEST")
-        self.gs_blobstore = typing.cast(GSBlobStore, Config.get_cloud_specific_handles_DEPRECATED(Replica.gcp)[0])
+        self.cloud_handles = Config.get_cloud_specific_handles(Replica.gcp)
         test_src_keys = [infra.generate_test_key() for _ in range(rounds)]
         final_key = infra.generate_test_key()
 
-        bucket_obj = self.gs_blobstore.gcp_client.bucket(self.test_bucket)
+        bucket_obj = self.cloud_handles.native_cloud_handle.bucket(self.test_bucket)
 
-        self.gs_blobstore.upload_file_handle(
+        self.cloud_handles.blobstore_handle.upload_file_handle(
             self.test_bucket,
             test_src_keys[0],
             io.BytesIO(os.urandom(1024 * 1024))

--- a/tests/test_s3urlcache.py
+++ b/tests/test_s3urlcache.py
@@ -64,7 +64,7 @@ class TestS3UrlCache(unittest.TestCase):
     def setUpClass(cls):
         replica = Replica.aws
         Config.set_config(BucketConfig.TEST_FIXTURE)
-        cls.blobstore, _, cls.test_fixture_bucket = Config.get_cloud_specific_handles_DEPRECATED(replica)
+        cls.cloud_handles = Config.get_cloud_specific_handles(replica)
         Config.set_config(BucketConfig.TEST)
         cls.test_bucket = replica.bucket
 
@@ -147,7 +147,7 @@ class TestS3UrlCache(unittest.TestCase):
             self.assertEqual(cached_url, url)
 
         with self.subTest("check content_type"):
-            contentType = self.blobstore.get_content_type(self.test_bucket, url_key)
+            contentType = self.cloud_handles.blobstore_handle.get_content_type(self.test_bucket, url_key)
             self.assertEqual(contentType, "application/octet-stream")
 
     def test_evict(self):


### PR DESCRIPTION
Use the new API, which is more specific about what is being requested.

I'd like to request a lot of eyes on this, since it touches a ton of places.

Depends on #872 