### PR TITLE
Let visitation lambda write to storage bucket (resolves #913)

### DIFF
--- a/iam/policy-templates/dss-visitation-lambda.json
+++ b/iam/policy-templates/dss-visitation-lambda.json
@@ -16,7 +16,8 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetObject",
-        "s3:ListBucket"
+        "s3:ListBucket",
+        "s3:PutObject"
       ],
       "Resource": [
         "arn:aws:s3:::$DSS_S3_BUCKET",


### PR DESCRIPTION
This is necessary since the indexer caches schema URLs there.

