### PR TITLE
Use gcloud command to deploy dss-gs-event-relay

### DIFF
--- a/scripts/deploy_gcf.py
+++ b/scripts/deploy_gcf.py
@@ -3,7 +3,7 @@
 This script manages the deployment of Google Cloud Functions.
 """
 
-import os, sys, time, io, zipfile, random, string, binascii, datetime, argparse, base64
+import os, sys, time, io, zipfile, random, string, binascii, datetime, argparse, base64, subprocess
 
 import boto3
 import google.cloud.storage
@@ -15,11 +15,6 @@ from urllib3.util.retry import Retry
 class GCPClient(ClientWithProject):
     SCOPE = ["https://www.googleapis.com/auth/cloud-platform",
              "https://www.googleapis.com/auth/cloudruntimeconfig"]
-
-class GoogleCloudFunctionsConnection(JSONConnection):
-    API_BASE_URL = "https://cloudfunctions.googleapis.com"
-    API_VERSION = "v1beta2"
-    API_URL_TEMPLATE = "{api_base_url}/{api_version}{path}"
 
 class GoogleRuntimeConfigConnection(JSONConnection):
     API_BASE_URL = "https://runtimeconfig.googleapis.com"
@@ -38,7 +33,6 @@ gs = google.cloud.storage.Client.from_service_account_json(gcp_key_file)
 gcp_client = GCPClient()
 gcp_client._http.adapters["https://"].max_retries = Retry(status_forcelist={503, 504})
 grtc_conn = GoogleRuntimeConfigConnection(client=gcp_client)
-gcf_conn = GoogleCloudFunctionsConnection(client=gcp_client)
 gcf_ns = f"projects/{gcp_client.project}/locations/{gcp_region}/functions"
 
 boto3_session = boto3.session.Session()
@@ -66,54 +60,11 @@ for k, v in config_vars.items():
     except google.cloud.exceptions.Conflict:
         grtc_conn.api_request("PUT", f"/{var_ns}/{k}", data=dict(name=f"{var_ns}/{k}", value=b64v))
 
-try:
-    now = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-    deploy_filename = "{}-deploy-{}-{}.zip".format(args.gcf_name, now, binascii.hexlify(os.urandom(4)).decode())
-    deploy_blob = gs.bucket(os.environ["DSS_GS_BUCKET_TEST_FIXTURES"]).blob(deploy_filename)
-    with io.BytesIO() as buf:
-        with zipfile.ZipFile(buf, 'w', compression=zipfile.ZIP_DEFLATED) as zbuf:
-            for root, dirs, files in os.walk(args.src_dir):
-                for f in files:
-                    archive_path = os.path.relpath(os.path.join(root, f), args.src_dir)
-                    if archive_path.startswith("node_modules"):
-                        continue
-                    print("Adding", archive_path)
-                    zbuf.write(os.path.join(root, f), archive_path)
-            zbuf.close()
-        deploy_blob.upload_from_string(buf.getvalue())
-        print("Uploaded", deploy_blob)
-
-    gcf_config = {
-        "name": f"{gcf_ns}/{args.gcf_name}",
-        "entryPoint": args.entry_point,
-        "timeout": "60s",
-        "availableMemoryMb": 256,
-        "sourceArchiveUrl": f"gs://{deploy_blob.bucket.name}/{deploy_blob.name}",
-        "eventTrigger": {
-            "eventType": "providers/cloud.storage/eventTypes/object.change",
-            "resource": "projects/_/buckets/" + os.environ['DSS_GS_BUCKET']
-        }
-    }
-
-    try:
-        print(gcf_conn.api_request("POST", f"/{gcf_ns}", data=gcf_config))
-    except google.cloud.exceptions.Conflict:
-        print(gcf_conn.api_request("PUT", f"/{gcf_ns}/{args.gcf_name}", data=gcf_config))
-
-    sys.stderr.write("Waiting for deployment...")
-    sys.stderr.flush()
-    for t in range(90):
-        if gcf_conn.api_request("GET", f"/{gcf_ns}/{args.gcf_name}")["status"] != "DEPLOYING":
-            break
-        sys.stderr.write(".")
-        sys.stderr.flush()
-        time.sleep(1)
-    else:
-        sys.exit("Timeout while waiting for GCF deployment to complete")
-    sys.stderr.write("done\n")
-
-    res = gcf_conn.api_request("GET", f"/{gcf_ns}/{args.gcf_name}")
-    print(res)
-    assert res["status"] == "READY"
-finally:
-    deploy_blob.delete()
+subprocess.run([
+    'gcloud', 'beta', 'functions', 'deploy', args.gcf_name,
+    '--timeout=%i' % 60,
+    '--memory=%i' % 256,
+    '--source=%s' % args.src_dir,
+    '--entry-point=%s' % args.entry_point,
+    '--trigger-bucket=%s' % os.environ["DSS_GS_BUCKET"],
+], timeout=240)


### PR DESCRIPTION
Deployment of `dss-gs-event-relay` currently relies on the existence of GCP test fixture buckets. This can be avoided with `gcloud beta functions deploy`.

Unfortunately the gcloud method is in beta.

Connects to #856 
FIxes #923 

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to staging and production. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->