### PR TITLE
Fix type error in retry logic for Elasticsearch (fixes #928)

### DIFF
--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -137,9 +137,10 @@ class ElasticsearchClient:
 
 
 def _retryable_exception(e):
-    return isinstance(e, elasticsearch.TransportError) and (
-        e.status_code == 409 or  # version conflicts
-        500 <= e.status_code <= 599)  # server errors
+    return (isinstance(e, elasticsearch.TransportError) and
+            isinstance(e.status_code, int) and (  # have spotted 'N/A' in the wild
+                e.status_code == 409 or  # version conflicts
+                500 <= e.status_code <= 599))  # server errors
 
 
 def _retry_delay(i, delay):


### PR DESCRIPTION
Status code is typically a number but can be 'N/A'.

