### PR TITLE
1a/2: Serialize tests that use local ES instance; increase ES heap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,12 @@ install:
 - mkdir make4
 - dpkg -x make*.deb make4
 - export PATH=$(pwd)/make4/usr/bin:$PATH
+before_script:
+- export -n _JAVA_OPTIONS # https://github.com/travis-ci/travis-ci/issues/8408
 script:
 - export DSS_UNITTEST_OPTS="$DSS_UNITTEST_OPTS -v"
 - set -eo pipefail
-- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 test; fi
+- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 safe_test; fi
 - if [[ $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 integration_test; fi
 - if [[ $TRAVIS_BRANCH == staging ]]; then source environment.staging; fi
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -8,35 +8,59 @@ mypy:
 	mypy --ignore-missing-imports $(MODULES)
 
 test_srcs := $(wildcard tests/test_*.py)
-all_test_srcs := $(addprefix all__, $(test_srcs))
-integration_test_srcs := $(addprefix integration__, $(test_srcs))
 
-test: lint mypy $(test_srcs)
+define test_rules
+
+# Generate a set of rules for running test scripts, either all of them or
+# individually, for a given value of DSS_TEST_MODE. Depending on that value,
+# certain test cases or test methods within the test scripts will skipped.
+#
+# $1 is the prefix for the name of the phony target that runs all test scripts
+# (can be empty)
+# 
+# $2 is the prefix that's added to each test script name to create a phony
+# target for running that script individually (if empty, the actual script name
+# is used)
+# 
+# $3 is the value for DSS_TEST_MODE (if empty, no test cases or methods will be
+# skipped).
+
+$(2)test_srcs := $$(addprefix $(2), $$(test_srcs))
+
+$(1)test: lint mypy $$($(2)test_srcs)
 	coverage combine
 	rm -f .coverage.*
 
-$(test_srcs): %.py :
+$$($(2)test_srcs): $(2)%.py :
 	set -o pipefail \
-	&& DSS_TEST_MODE="standalone" coverage run -p --source=dss -m unittest $(DSS_UNITTEST_OPTS) $@  2>&1 \
-	| sed -e "s/^/$$$$ /"
+	&& DSS_TEST_MODE="$(3)" coverage run -p --source=dss -m unittest $$(DSS_UNITTEST_OPTS) $$*.py 2>&1 \
+	| sed -e "s/^/$$$$$$$$ /"
 
-integration_test: lint mypy $(integration_test_srcs)
-	coverage combine
-	rm -f .coverage.*
+.PHONY: $(1)test $$($(2)test_srcs)
 
-$(integration_test_srcs): integration__%.py :
-	set -o pipefail \
-	&& DSS_TEST_MODE="integration" coverage run -p --source=dss -m unittest $(DSS_UNITTEST_OPTS) $*.py 2>&1 \
-	| sed -e "s/^/$$$$ /"
+endef
 
-all_test: lint mypy $(all_test_srcs)
-	coverage combine
-	rm -f .coverage.*
+# Define three independent sets of rules for standalone, integration and all tests
+#
+$(eval $(call test_rules,safe_,safe__,standalone))
+$(eval $(call test_rules,integration_,integration__,integration))
+$(eval $(call test_rules,all_,all__,integration standalone))
 
-$(all_test_srcs): all__%.py :
-	set -o pipefail \
-	&& DSS_TEST_MODE="integration standalone" coverage run -p --source=dss -m unittest $(DSS_UNITTEST_OPTS) $*.py 2>&1 \
-	| sed -e "s/^/$$$$ /"
+# Serialize the standalone tests that use a local Elasticsearch instance. This
+# will prevent them from running at the same time, but running a test script
+# individually may trigger running another one before that. To avoid this we
+# also ...
+#
+safe__tests/test_search.py: safe__tests/test_indexer.py
+safe__tests/test_indexer.py: safe__tests/test_subscriptions.py
+
+# ... add a set of rules that doesn't serialize those tests. Be aware that when
+# you run `make -j test`, all standalone tests will be scheduled in parallel and
+# you will likely get three concurrent ES instances, each requiring 2GiB of RAM.
+# Note that this set of rules is also used when you run a test individually
+# e.g., via `make tests/test_indexer.py`.
+#
+$(eval $(call test_rules,,,standalone))
 
 smoketest: all__tests/test_smoketest.py
 
@@ -84,6 +108,5 @@ requirements.txt requirements-dev.txt : %.txt : %.txt.in
 
 requirements-dev.txt : requirements.txt.in
 
-.PHONY: lint mypy
-.PHONY: test all_test integration_test $(test_srcs) $(integration_test_srcs) $(standalone_test_srcs)
+.PHONY: lint mypy test
 .PHONY: deploy deploy-chalice deploy-daemons


### PR DESCRIPTION
This change does three things: 

1) It works around 

https://github.com/travis-ci/travis-ci/issues/8408

which is the saving grace that currently prevents builds from failing all the time on master. Without this Travis bug, ES would actually run with only 512MiB of heap (introduced in 3fdc29683764d079a4e7d65743957a4ed107accb) and fail most of the time.

2) It bumps up ES heap to 1.6GiB (initial and max, as recommended by ES docs)

3) Serializes the ES-based tests which makes them more stable.

This change is a variation of one that was backed out of #859 due to @ttung's concern that serializing the tests in the Makefile interferes with running them individually and @kislyuk's concern of being too complex syntactically. I've addressed the former by introducing a fourth set of test rules and the latter by adding comments. 

I consider this still a hacky patch until we find a better way of running the tests.

