### PR TITLE
2/2: Make test_indexer logs less noisy; improve @retry test coverage 

### DIFF
--- a/dss/events/handlers/index.py
+++ b/dss/events/handlers/index.py
@@ -42,7 +42,7 @@ class Indexer(metaclass=ABCMeta):
                          f"event: {json.dumps(event, indent=4)}", exc_info=True)
             raise
 
-    @elasticsearch_retry
+    @elasticsearch_retry(logger)
     def index_object(self, key):
         elasticsearch_retry.add_context(key=key, indexer=self)
         identifier = ObjectIdentifier.from_key(key)

--- a/dss/storage/index_document.py
+++ b/dss/storage/index_document.py
@@ -131,7 +131,7 @@ class BundleDocument(IndexDocument):
     def manifest(self):
         return self['manifest']
 
-    @elasticsearch_retry
+    @elasticsearch_retry(logger)
     def index(self, dryrun=False) -> (bool, str):
         elasticsearch_retry.add_context(bundle=self)
         tombstone = self._lookup_tombstone()
@@ -177,7 +177,7 @@ class BundleDocument(IndexDocument):
             self._write_to_index(index_name, version=old_version or 0)
         return True, index_name
 
-    @elasticsearch_retry
+    @elasticsearch_retry(logger)
     def entomb(self, tombstone: 'BundleTombstoneDocument', dryrun=False):
         """
         Ensure that there is exactly one up-to-date instance of a tombstone for this document in exactly one
@@ -525,7 +525,7 @@ class BundleTombstoneDocument(IndexDocument):
         docs = [BundleDocument.from_replica(self.replica, bundle_fqid) for bundle_fqid in bundle_fqids]
         return docs
 
-    @elasticsearch_retry
+    @elasticsearch_retry(logger)
     def index(self, dryrun=False) -> (bool, str):
         elasticsearch_retry.add_context(tombstone=self)
         dead_docs = self._list_dead_bundles()

--- a/dss/util/es.py
+++ b/dss/util/es.py
@@ -153,8 +153,13 @@ def _retry_delay(i, delay):
     return 10 if delay is None else delay * 1.5
 
 
-elasticsearch_retry = retry(timeout=60,  # seconds
-                            limit=10,  # retries
-                            inherit=True,  # nested retries should obey the outer-most retry's timeout
-                            retryable=_retryable_exception,
-                            delay=_retry_delay)
+# noinspection PyPep8Naming
+class elasticsearch_retry(retry):
+    # noinspection PyShadowingNames
+    def __init__(self, logger) -> None:
+        super().__init__(timeout=60,  # seconds
+                         limit=10,  # retries
+                         inherit=True,  # nested retries should obey the outer-most retry's timeout
+                         retryable=_retryable_exception,
+                         delay=_retry_delay,
+                         logger=logger)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -189,8 +189,11 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                 raise e
 
         with unittest.mock.patch.object(Elasticsearch, 'index', mock_index):
-            # call method under test with patch in place
-            self.process_new_indexable_object(sample_event)
+            with unittest.mock.patch.object(dss.events.handlers.index.logger, 'warning') as mock_warning:
+                # call method under test with patches in place
+                self.process_new_indexable_object(sample_event)
+        mock_warning.assert_called_with('An exception occurred in %r.',
+                                        unittest.mock.ANY, exc_info=True, stack_info=True)
 
     def _delete_tombstone(self, tombstone_id):
         blobstore = Config.get_blobstore_handle(self.replica)


### PR DESCRIPTION
The tests that involve retries log a bunch of expected but scary looking exceptions. This change traps them in a mock and asserts them instead.

Test @retry in `Elasticsearch.get` as well as in `.index`.

Change the logger used by Elasticsearch retries to the module logger of the retried function instead of the @retry module's logger.