### PR TITLE
Add location to the checkout readiness check

### DIFF
--- a/daemons/dss-checkout-sfn/app.py
+++ b/daemons/dss-checkout-sfn/app.py
@@ -32,6 +32,7 @@ def schedule_copy(event, context):
     version = event["version"]
     dss_bucket = event["dss_bucket"]
     dst_bucket = get_dst_bucket(event)
+    replica = Replica[event["replica"]]
 
     scheduled = 0
     for src_key, dst_key in get_manifest_files(bundle_fqid, version, replica):
@@ -48,6 +49,7 @@ def schedule_copy(event, context):
 def get_job_status(event, context):
     bundle_fqid = event["bundle"]
     version = event["version"]
+    replica = Replica[event["replica"]]
 
     check_count = 0
     if "status" in event:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -825,8 +825,6 @@ paths:
               destination:
                 description: User-owned destination storage bucket.
                 type: string
-            required:
-              - email
       responses:
         200:
           description: Returned when the bundle UUID with optionally specified version exists and checkout has been initiated.
@@ -876,6 +874,9 @@ paths:
                 description: Status of the checkout request.
                 type: string
                 enum: [RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED]
+              location:
+                description: Destination location of the bundle
+                type: string
             required:
               - status
         default:

--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -11,7 +11,6 @@ STATE_MACHINE_NAME_TEMPLATE = "dss-checkout-sfn-{stage}"
 
 @dss_handler
 def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
-    email = json_request_body['email']
     dss_bucket = Config.get_s3_bucket()
 
     assert replica is not None
@@ -28,7 +27,6 @@ def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
     execution_id = get_execution_id()
     stepfunctions.step_functions_invoke(STATE_MACHINE_NAME_TEMPLATE, execution_id, sfn_input)
     return jsonify(dict(checkout_job_id=execution_id)), requests.codes.ok
-
 
 @dss_handler
 def get(checkout_job_id: str):

--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 from flask import jsonify
 
@@ -16,9 +18,12 @@ def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
 
     bundle = get_bundle(uuid, Replica[replica], version)
     sfn_input = {"dss_bucket": dss_bucket, "bundle": uuid, "version": bundle["bundle"]["version"],
-                 "email": email, "replica": replica}
+                 "replica": replica}
     if "destination" in json_request_body:
         sfn_input["bucket"] = json_request_body["destination"]
+
+    if "email" in json_request_body:
+        sfn_input["email"] = json_request_body["email"]
 
     execution_id = get_execution_id()
     stepfunctions.step_functions_invoke(STATE_MACHINE_NAME_TEMPLATE, execution_id, sfn_input)
@@ -28,4 +33,13 @@ def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
 @dss_handler
 def get(checkout_job_id: str):
     response = stepfunctions.step_functions_describe_execution(STATE_MACHINE_NAME_TEMPLATE, checkout_job_id)
-    return jsonify(dict(status=response.get('status'))), requests.codes.ok
+    status = response.get('status')
+    result = dict(status=status)
+    if status == 'SUCCEEDED':
+        execution_output = json.loads(response['output'])
+        dst_bucket = execution_output['schedule']['dst_bucket']
+        dst_location = execution_output['schedule']['dst_location']
+
+        result['location'] = f"s3://{dst_bucket}/{dst_location}"
+
+    return jsonify(result), requests.codes.ok

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -64,7 +64,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
         for replica in Replica:
-            request_body = {"destination": replica.checkout_bucket, "email": "rkisin@chanzuckerberg.com"}
+            request_body = {"destination": replica.checkout_bucket}
 
             url = str(UrlBuilder()
                       .set(path="/v1/bundles/" + bundle_uuid + "/checkout")
@@ -81,7 +81,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
     def launch_checkout(self, dst_bucket: str, replica: Replica) -> str:
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
-        request_body = {"destination": dst_bucket, "email": "rkisin@chanzuckerberg.com"}
+        request_body = {"destination": dst_bucket}
 
         url = str(UrlBuilder()
                   .set(path="/v1/bundles/" + bundle_uuid + "/checkout")

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -8,7 +8,7 @@ from subprocess import check_call, check_output, CalledProcessError
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from dss import Config
+from dss import Config, Replica, BucketConfig
 from dss.api.files import ASYNC_COPY_THRESHOLD
 from tests.infra import testmode
 from dss.storage.checkout import get_dst_bundle_prefix
@@ -114,7 +114,10 @@ class Smoketest(unittest.TestCase):
             run(f"{venv_bin}hca dss post-search --es-query='{{}}' --replica {replica} > /dev/null")
 
         search_route = "https://${API_DOMAIN_NAME}/v1/search"
-        for replica in "aws", "gcp":
+        
+        Config.set_config(BucketConfig.TEST)
+
+        for  replica in Replica:
             run(f"jq -n '.es_query.query.match[env.k]=env.v' | http --check {search_route} replica==aws > res.json",
                 env=dict(os.environ, k="files.sample_json.id", v=sample_id))
             with open("res.json") as fh2:
@@ -125,33 +128,35 @@ class Smoketest(unittest.TestCase):
             res = run(f"{venv_bin}hca dss put-subscription "
                       "--callback-url https://example.com/ "
                       "--es-query '{}' "
-                      f"--replica {replica}",
+                      f"--replica {replica.name}",
                       runner=check_output)
             sub_id = json.loads(res.decode())["uuid"]
-            run(f"{venv_bin}hca dss get-subscriptions --replica {replica}")
-            run(f"{venv_bin}hca dss delete-subscription --replica {replica} --uuid {sub_id}")
+            run(f"{venv_bin}hca dss get-subscriptions --replica {replica.name}")
+            run(f"{venv_bin}hca dss delete-subscription --replica {replica.name} --uuid {sub_id}")
 
-        checkout_bucket = os.environ["DSS_S3_CHECKOUT_BUCKET"]
-        bundle_id = get_upload_val(".bundle_uuid")
-        version = get_upload_val(".version")
+            checkout_bucket = replica.checkout_bucket
+            bundle_id = get_upload_val(".bundle_uuid")
+            version = get_upload_val(".version")
 
-        for i in range(10):
-            run(f"{venv_bin}hca dss get-bundles-checkout "
-                f"--checkout-job-id {res_checkout['checkout_job_id']} > res.json")
-            with open("res.json") as fh:
-                res = json.load(fh)
-            status = res['status']
-            self.assertGreater(len(status), 0)
-            if status == 'RUNNING':
-                time.sleep(6)
-            else:
-                self.assertEqual(status, 'SUCCEEDED')
-                blob_handle = S3BlobStore.from_environment()
-                object_key = get_dst_bundle_prefix(bundle_id, version)
-                print(f"Checking bucket {checkout_bucket} object key: {object_key}")
-                files = list(blob_handle.list(checkout_bucket, object_key))
-                self.assertEqual(len(files), file_count)
-                break
+            for i in range(10):
+                run(f"{venv_bin}hca dss get-bundles-checkout "
+                    f"--checkout-job-id {res_checkout['checkout_job_id']} > res.json")
+                with open("res.json") as fh:
+                    res = json.load(fh)
+                status = res['status']
+                self.assertGreater(len(status), 0)
+                if status == 'RUNNING':
+                    time.sleep(6)
+                else:
+                    self.assertEqual(status, 'SUCCEEDED')
+                    location = res["location"]
+                    self.assertEqual(location, f"{replica.storage_schema}//{checkout_bucket}/{object_key}")
+                    blob_handle = S3BlobStore.from_environment()
+                    object_key = get_dst_bundle_prefix(bundle_id, version)
+                    print(f"Checking bucket {checkout_bucket} object key: {object_key}")
+                    files = list(blob_handle.list(checkout_bucket, object_key))
+                    self.assertEqual(len(files), file_count)
+                    break
         else:
             self.fail("Timed out waiting for checkout job to succeed")
 

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -114,10 +114,9 @@ class Smoketest(unittest.TestCase):
             run(f"{venv_bin}hca dss post-search --es-query='{{}}' --replica {replica} > /dev/null")
 
         search_route = "https://${API_DOMAIN_NAME}/v1/search"
-        
         Config.set_config(BucketConfig.TEST)
 
-        for  replica in Replica:
+        for replica in Replica:
             run(f"jq -n '.es_query.query.match[env.k]=env.v' | http --check {search_route} replica==aws > res.json",
                 env=dict(os.environ, k="files.sample_json.id", v=sample_id))
             with open("res.json") as fh2:
@@ -150,10 +149,9 @@ class Smoketest(unittest.TestCase):
                 else:
                     self.assertEqual(status, 'SUCCEEDED')
                     location = res["location"]
+                    object_key = get_dst_bundle_prefix(bundle_id, version)
                     self.assertEqual(location, f"{replica.storage_schema}//{checkout_bucket}/{object_key}")
                     blob_handle = S3BlobStore.from_environment()
-                    object_key = get_dst_bundle_prefix(bundle_id, version)
-                    print(f"Checking bucket {checkout_bucket} object key: {object_key}")
                     files = list(blob_handle.list(checkout_bucket, object_key))
                     self.assertEqual(len(files), file_count)
                     break


### PR DESCRIPTION
Add checkout location to the checkout readiness check API call. Make email address optional.

### Test plan
[] Use curl and HCA CLI to initiate checkout (with and without email address parameter)
[] Confirm that get checkout readiness returns correct S3 location by using AWS S3 CLI commands
[] Modify unit tests
