### PR TITLE
1b/2: Serialize tests that use local ES instance; increase ES heap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,12 @@ install:
 - mkdir make4
 - dpkg -x make*.deb make4
 - export PATH=$(pwd)/make4/usr/bin:$PATH
+before_script:
+- export -n _JAVA_OPTIONS # https://github.com/travis-ci/travis-ci/issues/8408
 script:
 - export DSS_UNITTEST_OPTS="$DSS_UNITTEST_OPTS -v"
 - set -eo pipefail
-- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 test; fi
+- if [[ ! $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 safe_test; fi
 - if [[ $TRAVIS_DSS_INTEGRATION_MODE ]]; then make -j4 integration_test; fi
 - if [[ $TRAVIS_BRANCH == staging ]]; then source environment.staging; fi
 after_success:


### PR DESCRIPTION
A variant of https://github.com/HumanCellAtlas/data-store/pull/941, based on @kislyuk's [preference](https://github.com/HumanCellAtlas/data-store/pull/941#pullrequestreview-94536735) but with the following differences:

* retains @ttung's [requirement](https://github.com/HumanCellAtlas/data-store/pull/941#issuecomment-363554076) that, by default, tests are run in parallel
* keep standalone the default test mode, as currently on master
* serial tests are run in parallel to parallel test (but obviously not in parallel to each other)
