### PR TITLE
callbacks for `Future.add_done_callback` expect a single argument.

### DIFF
--- a/dss/stepfunctions/s3copyclient/implementation.py
+++ b/dss/stepfunctions/s3copyclient/implementation.py
@@ -114,7 +114,7 @@ def copy_worker(event, lambda_context, branch_id):
             state_lock = threading.Lock()
 
             def make_on_complete_callback(part_id: int):
-                def callback():
+                def callback(_):
                     with state_lock:
                         if part_id >= state[_Key.NEXT_PART]:
                             state[_Key.NEXT_PART] = part_id + 1


### PR DESCRIPTION
In this case, we don't use it, so just throw it away.

Fixes #961
