### PR TITLE
Fix: Integration tests needlessly start local Elasticsearch instances

### DIFF
--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -84,6 +84,7 @@ def tearDownModule():
     HTTPInfo.server.shutdown()
 
 
+@testmode.standalone
 class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, metaclass=ABCMeta):
     bundle_key_by_replica = dict()  # type: typing.MutableMapping[str, str]
 
@@ -114,7 +115,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.smartseq2_paired_ends_query = smartseq2_paired_ends_v2_or_v3_query
         PostTestHandler.reset()
 
-    @testmode.standalone
     def test_create(self):
         sample_event = self.create_bundle_created_event(self.bundle_key)
         self.process_new_indexable_object(sample_event)
@@ -126,19 +126,15 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             files=smartseq2_paried_ends_indexed_file_list,
         )
 
-    @testmode.standalone
     def test_delete(self):
         self._test_delete(all_versions=False, zombie=False)
 
-    @testmode.standalone
     def test_delete_all_versions(self):
         self._test_delete(all_versions=True, zombie=False)
 
-    @testmode.standalone
     def test_delete_zombie(self):
         self._test_delete(all_versions=False, zombie=True)
 
-    @testmode.standalone
     def test_delete_all_versions_zombie(self):
         self._test_delete(all_versions=True, zombie=True)
 
@@ -222,7 +218,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             expected_search_result = dict(tombstone_data, uuid=tombstone_id.uuid)
             self.assertDictEqual(search_results[0], expected_search_result)
 
-    @testmode.standalone
     def test_reindexing_with_changed_content(self):
         bundle_key = self.load_test_data_bundle_for_path("fixtures/indexing/bundles/v3/smartseq2/paired_ends")
         sample_event = self.create_bundle_created_event(bundle_key)
@@ -262,7 +257,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             self.process_new_indexable_object(sample_event)
         self.assertTrue(any('is already up-to-date' in e for e in log.output))
 
-    @testmode.standalone
     def test_reindexing_with_changed_shape(self):
         bundle_key = self.load_test_data_bundle_for_path("fixtures/indexing/bundles/v3/smartseq2/paired_ends")
         sample_event = self.create_bundle_created_event(bundle_key)
@@ -286,7 +280,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         # There should only be one hit and it should be from a different index, the "right" one
         _assert_reindexing_results(expect_shape_descriptor=False)
 
-    @testmode.standalone
     def test_indexed_file_with_invalid_content_type(self):
         bundle = TestBundle(self.blobstore, "fixtures/indexing/bundles/v3/smartseq2/paired_ends",
                             self.test_fixture_bucket, self.replica)
@@ -307,7 +300,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.verify_index_document_structure_and_content(search_results[0], bundle_key,
                                                          files=smartseq2_paried_ends_indexed_file_list)
 
-    @testmode.standalone
     def test_key_is_not_indexed_when_processing_an_event_with_a_file_key(self):
         file_fqid = get_file_fqid()
         sample_event = self.create_bundle_created_event(file_fqid.to_key())
@@ -317,7 +309,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.assertIn(str(file_fqid), log_monitor.output[0])
         self.assertFalse(ElasticsearchClient.get().indices.exists_alias(name=self.dss_alias_name))
 
-    @testmode.standalone
     def test_error_message_logged_when_invalid_bucket_in_event(self):
         bundle_key = "bundles/{}.{}".format(str(uuid.uuid4()), get_version())
         sample_event = self.create_bundle_created_event(bundle_key)
@@ -326,7 +317,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                 self.process_new_indexable_object(sample_event)
         self.assertRegex(log_monitor.output[0], "ERROR:.*Exception occurred while processing .* event:.*")
 
-    @testmode.standalone
     def test_indexed_file_unparsable(self):
         bundle_key = self.load_test_data_bundle_for_path("fixtures/indexing/bundles/unparseable_indexed_file")
         sample_event = self.create_bundle_created_event(bundle_key)
@@ -340,7 +330,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.verify_index_document_structure_and_content(search_results[0], bundle_key,
                                                          files=smartseq2_paried_ends_indexed_file_list)
 
-    @testmode.standalone
     def test_indexed_file_access_error(self):
         inaccesssible_filename = "inaccessible_file.json"
         bundle_key = self.load_test_data_bundle_with_inaccessible_file(
@@ -362,7 +351,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                                                          files=files,
                                                          excluded_files=[inaccesssible_filename.replace(".", "_")])
 
-    @testmode.standalone
     def test_notify(self):
         def _notify(subscription, bundle_id=get_bundle_fqid()):
             document = BundleDocument(self.replica, bundle_id)
@@ -387,7 +375,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             headers=get_auth_header()
         )
 
-    @testmode.standalone
     def test_subscription_notification_successful(self):
         sample_event = self.create_bundle_created_event(self.bundle_key)
         self.process_new_indexable_object(sample_event)
@@ -405,7 +392,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             self.delete_subscription(subscription_id)
             PostTestHandler.reset()
 
-    @testmode.standalone
     def test_subscription_notification_unsuccessful(self):
         PostTestHandler.verify_payloads = True
         sample_event = self.create_bundle_created_event(self.bundle_key)
@@ -427,7 +413,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                          f"WARNING:.*:Failed notification for subscription {subscription_id}"
                          f" for bundle {bundle_fqid} with transaction id .+ Code: {error_response_code}")
 
-    @testmode.standalone
     def test_subscription_registration_before_indexing(self):
         subscription_id = self.subscribe_for_notification(self.smartseq2_paired_ends_query,
                                                           f"http://{HTTPInfo.address}:{HTTPInfo.port}")
@@ -438,7 +423,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.verify_notification(subscription_id, self.smartseq2_paired_ends_query, bundle_fqid)
         self.delete_subscription(subscription_id)
 
-    @testmode.standalone
     def test_subscription_query_with_multiple_data_types_indexing_and_notification(self):
         # Verify that a subscription query using numeric, date and string types
         # that is registered before indexing (via the ES setting
@@ -491,7 +475,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.verify_notification(subscription_id, subscription_query, bundle_fqid)
         self.delete_subscription(subscription_id)
 
-    @testmode.standalone
     def test_get_shape_descriptor(self):
         index_document = BundleDocument(self.replica, get_bundle_fqid())
         index_document.update({
@@ -537,7 +520,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         with self.subTest("no versioned file"):
             self.assertEqual(index_document.get_shape_descriptor(), None)
 
-    @testmode.standalone
     def test_alias_and_versioned_index_exists(self):
         sample_event = self.create_bundle_created_event(self.bundle_key)
         self.process_new_indexable_object(sample_event)
@@ -548,7 +530,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.assertIn(doc_index_name, alias)
         self.assertTrue(es_client.indices.exists(index=doc_index_name))
 
-    @testmode.standalone
     def test_alias_and_multiple_schema_version_index_exists(self):
         # Load and test an unversioned bundle
         bundle_key = self.load_test_data_bundle_for_path(
@@ -572,7 +553,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.assertIn(doc_index_name, alias)
         self.assertTrue(es_client.indices.exists(index=doc_index_name))
 
-    @testmode.standalone
     def test_multiple_schema_version_indexing_and_search(self):
         # Load a schema version 4 bundle
         bundle_key = self.load_test_data_bundle_for_path(
@@ -605,7 +585,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         search_results = self.get_search_results(smartseq2_paired_ends_v3_or_v4_query, 2)
         self.assertEqual(2, len(search_results))
 
-    @testmode.standalone
     def test_multiple_schema_version_subscription_indexing_and_notification(self):
         PostTestHandler.verify_payloads = False
 
@@ -643,7 +622,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
 
         self.delete_subscription(subscription_id)
 
-    @testmode.standalone
     def test_scrub_index_data(self):
         manifest = read_bundle_manifest(self.blobstore, self.test_bucket, self.bundle_key)
         doc = 'assay_json'
@@ -739,7 +717,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.assertEqual(bundle_uuid, posted_json['match']['bundle_uuid'])
         self.assertEqual(bundle_version, posted_json['match']['bundle_version'])
 
-    @testmode.standalone
     def test_indexer_lookup(self):
         for replica, indexer in Indexer.for_replica.items():
             self.assertIs(replica, indexer.replica)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -39,6 +39,7 @@ def setUpModule():
     configure_test_logging()
 
 
+@testmode.standalone
 class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
 
     @classmethod
@@ -61,7 +62,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         es_client = ElasticsearchClient.get()
         IndexManager.create_index(es_client, self.replica, self.dss_index_name)
 
-    @testmode.standalone
     def test_es_search_page(self):
         """
         Confirm that Elasticsearch is returning _source info only when necessary.
@@ -73,7 +73,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         page = _es_search_page(smartseq2_paired_ends_v3_query, self.replica, 10, None, 'something')
         self.assertFalse('_source' in page['hits']['hits'][0])
 
-    @testmode.standalone
     def test_search_post(self):
         bundles = self.populate_search_index(self.index_document, 1)
         self.check_count(smartseq2_paired_ends_v3_query, 1)
@@ -87,7 +86,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         self.verify_search_result(search_obj.json, smartseq2_paired_ends_v3_query, 1, 1)
         self.verify_bundles(search_obj.json['results'], bundles)
 
-    @testmode.standalone
     def test_search_returns_no_results_when_no_documents_indexed(self):
         url = self.build_url()
         search_obj = self.assertPostResponse(
@@ -98,7 +96,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         self.assertIsNone(next_url)
         self.verify_search_result(search_obj.json, smartseq2_paired_ends_v3_query, 0)
 
-    @testmode.standalone
     def test_search_returns_no_result_when_query_does_not_match_indexed_documents(self):
         query = {
             "query": {
@@ -117,7 +114,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         self.assertIsNone(next_url)
         self.verify_search_result(search_obj.json, query, 0)
 
-    @testmode.standalone
     def test_next_url_is_empty_when_all_results_returned(self):
         self.populate_search_index(self.index_document, 1)
         self.check_count(smartseq2_paired_ends_v3_query, 1)
@@ -129,7 +125,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         next_url = self.get_next_url(search_obj.response.headers)
         self.assertIsNone(next_url)
 
-    @testmode.standalone
     def test_search_returns_error_when_invalid_query_used(self):
         invalid_query_data = [
             (
@@ -166,7 +161,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
                                                        status=error)
                 )
 
-    @testmode.standalone
     def test_search_returns_N_results_when_N_documents_match_query(self):
         """Create N identical documents. A search query is executed to match the document. All documents created must be
         present in the query results. N is varied across a variety of values.
@@ -190,7 +184,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
                 self.verify_search_result(search_obj.json, smartseq2_paired_ends_v3_query, docs, expected_results)
                 self.verify_bundles(found_bundles, bundles)
 
-    @testmode.standalone
     def test_next_page_is_delivered_when_next_is_in_query(self):
         bundles = self.populate_search_index(self.index_document, 150)
         self.check_count(smartseq2_paired_ends_v3_query, 150)
@@ -211,7 +204,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         self.verify_search_result(search_obj.json, smartseq2_paired_ends_v3_query, len(bundles), 50)
         self.verify_bundles(found_bundles, bundles)
 
-    @testmode.standalone
     def test_page_has_N_results_when_per_page_is_N(self):
         # per_page, expected
         per_page_tests = [(10, 10),
@@ -231,7 +223,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
                 next_url = self.get_next_url(search_obj.response.headers)
                 self.verify_next_url(next_url, per_page)
 
-    @testmode.standalone
     def test_output_format_is_raw(self):
         bundles = self.populate_search_index(self.index_document, 1)
         self.check_count(smartseq2_paired_ends_v3_query, 1)
@@ -246,7 +237,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         self.verify_bundles(search_obj.json['results'], bundles)
         self.assertEqual(search_obj.json['results'][0]['metadata'], self.index_document)
 
-    @testmode.standalone
     def test_error_returned_when_per_page_is_out_of_range(self):
         expected_error = ExpectedErrorFields(code="illegal_arguments",
                                              status=requests.codes.bad_request,
@@ -263,7 +253,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
                     json_request_body=dict(es_query=smartseq2_paired_ends_v3_query),
                     **expected)
 
-    @testmode.standalone
     def test_search_session_expired_when_session_deleted(self):
         self.populate_search_index(self.index_document, 20)
         self.check_count(smartseq2_paired_ends_v3_query, 20)
@@ -284,7 +273,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
             expected_error=ExpectedErrorFields(code="elasticsearch_context_not_found",
                                                status=requests.codes.not_found))
 
-    @testmode.standalone
     def test_verify_dynamic_mapping(self):
         doc1 = {
             "manifest": {"data": "hello world!"},

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -36,6 +36,7 @@ def setUpModule():
     configure_test_logging()
 
 
+@testmode.standalone
 class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
     @classmethod
     def setUpClass(cls):
@@ -69,7 +70,6 @@ class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
         self.callback_url = "https://example.com"
         self.sample_percolate_query = smartseq2_paired_ends_v2_or_v3_query
 
-    @testmode.standalone
     def test_auth_errors(self):
         url = str(UrlBuilder()
                   .set(path="/v1/subscriptions/" + str(uuid.uuid4()))
@@ -87,7 +87,6 @@ class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
         # No auth header
         self.assertGetResponse(url, requests.codes.unauthorized)
 
-    @testmode.standalone
     def test_put(self):
         uuid_ = self._put_subscription()
 
@@ -98,7 +97,6 @@ class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
         registered_query = response['_source']
         self.assertEqual(self.sample_percolate_query, registered_query)
 
-    @testmode.standalone
     def test_subscription_registration_succeeds_when_query_does_not_match_mappings(self):
         # It is now possible to register a subscription query before the mapping
         # of the field exists in the mappings (and may never exist in the mapppings)
@@ -127,7 +125,6 @@ class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
         )
         self.assertIn('uuid', resp_obj.json)
 
-    @testmode.standalone
     def test_get(self):
         find_uuid = self._put_subscription()
 
@@ -159,7 +156,6 @@ class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
             requests.codes.not_found,
             headers=get_auth_header())
 
-    @testmode.standalone
     def test_find(self):
         num_additions = 25
         for _ in range(num_additions):
@@ -176,7 +172,6 @@ class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
         self.assertEqual(self.callback_url, json_response['subscriptions'][0]['callback_url'])
         self.assertEqual(num_additions, len(json_response['subscriptions']))
 
-    @testmode.standalone
     def test_delete(self):
         find_uuid = self._put_subscription()
         url = str(UrlBuilder()

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -214,11 +214,11 @@ class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
             connexion.apis.abstract.Operation.testing_403 = orig_testing_403
 
 
-class TestGCPSubscription(TestSubscriptionsBase, unittest.TestCase):
+class TestGCPSubscription(TestSubscriptionsBase):
     replica = dss.Replica.gcp
 
 
-class TestAWSSubscription(TestSubscriptionsBase, unittest.TestCase):
+class TestAWSSubscription(TestSubscriptionsBase):
     replica = dss.Replica.aws
 
 # Prevent unittest's discovery from attempting to discover the base test class. The alterative, not inheriting


### PR DESCRIPTION
Moving the testmode decorators to the class level prevents the class setup/teardown that results in the needless start/stop of that instance.