### PR TITLE
Relax bundle UUID pattern to allow any version (fixes #962)

### DIFF
--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -6,7 +6,7 @@ BUNDLE_PREFIX = "bundles"
 FILE_PREFIX = "files"
 TOMBSTONE_SUFFIX = "dead"
 
-UUID_PATTERN = "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+UUID_PATTERN = "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
 UUID_REGEX = re.compile(UUID_PATTERN)
 
 VERSION_PATTERN = "\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}[.]\d{6}Z"


### PR DESCRIPTION
While UUID versions 1, 2, and 3 are now obsolete, we should at least allow for versions 4 and 5. However, BlueBox is not the place to apply such restrictions, PurpleBox is. BlueBox should accept UUIDs of any version.

