### PR TITLE
[URGENT] Fix: test_json_faker fails stochastically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ before_install:
 install:
 - pip install -r requirements.txt
 - pip install -r requirements-dev.txt
-- npm install json-schema-faker --save
-- npm install -g json-schema-faker-cli
+- npm install
 - wget -q ${ES_DOWNLOAD_URL}
 - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
 - wget -q http://us-east-1.ec2.archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/make_4.1-6_amd64.deb

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ clean:
 	git clean -df {chalice,daemons/*}/{chalicelib,domovoilib,vendor}
 	git checkout $$(git status --porcelain {chalice,daemons/*}/.chalice/config.json | awk '{print $$2}')
 	-rm -rf .requirements-env
+	-rm -rf node_modules
 
 refresh_all_requirements:
 	@echo -n '' >| requirements.txt

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ this directory.
 
 The HCA DSS prototype requires Python 3.6+ to run. Run `pip install -r requirements.txt` in this directory.
 
+The tests require certain node.js packages. They must be installed using `npm`, the node.js package manager. Install 
+[npm](https://www.npmjs.com/get-npm) (on macOS `brew install npm`) and run `npm install` from the project root.
+
 #### Pull sample data bundles
 
 Tests also use data from the data-bundle-examples subrepository. Run: `git submodule update --init`

--- a/common.mk
+++ b/common.mk
@@ -19,3 +19,7 @@ endif
 ifeq ($(findstring Python 3.6, $(shell python --version 2>&1)),)
 $(error Please run make commands from a Python 3.6 virtualenv)
 endif
+
+ifeq ($(shell which npm),)
+$(error Please install npm using "brew install node" or as described at https://www.npmjs.com/get-npm)
+endif

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,88 @@
+{
+  "name": "data-store",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "chance": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.0.13.tgz",
+      "integrity": "sha512-9cpcgmAIQiXC0eMgQuMZgXuHR2Y+gKUyGQnalqSAg5LlUJyJFsZeKyuHVSGhj+bx18ppH+Jo3VOayNeXR/7p9Q=="
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "deref": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/deref/-/deref-0.6.4.tgz",
+      "integrity": "sha1-vVqW1F2+0wEbuBvfaN31S+jhvU4=",
+      "requires": {
+        "deep-extend": "0.4.2"
+      }
+    },
+    "discontinuous-range": {
+      "version": "github:fent/discontinuous-range#a4c2462c6ee92c6f995e89c6b020a2eeec4183e6"
+    },
+    "faker": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
+      "integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8="
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "optional": true
+    },
+    "json-schema-faker": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.3.7.tgz",
+      "integrity": "sha1-jzrApodbmNLBO1lQZJ2QP+y5jkE=",
+      "requires": {
+        "chance": "1.0.13",
+        "deref": "0.6.4",
+        "faker": "3.1.0",
+        "randexp": "0.4.6"
+      }
+    },
+    "json-schema-faker-cli": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-faker-cli/-/json-schema-faker-cli-2.0.0.tgz",
+      "integrity": "sha1-bqHIDIf3Mj6nwyB3M/LHvcUQgVQ=",
+      "requires": {
+        "json-schema-faker": "0.3.7",
+        "jsonfile": "2.4.0",
+        "lodash": "4.17.5"
+      }
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "requires": {
+        "discontinuous-range": "github:fent/discontinuous-range#a4c2462c6ee92c6f995e89c6b020a2eeec4183e6",
+        "ret": "0.1.15"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "data-store",
+  "version": "1.0.0",
+  "dependencies": {
+    "json-schema-faker-cli": "2.0.0",
+    "//": [
+      "json-schema-faker@0.3.7 (depended on by json-schema-faker-cli) does not work with randexp@0.4.7 so we'll pin",
+      "it to 0.4.6.  After upgrading json-schema-faker-cli here you should consider removing this pin."
+    ],
+    "randexp": "0.4.6"
+  }
+}

--- a/tests/scalability/json_faker.py
+++ b/tests/scalability/json_faker.py
@@ -1,8 +1,12 @@
+import os
 import random
+import sys
 import tempfile
 from jsonschema import RefResolver
 import json
 import subprocess
+
+import dss
 from dss.util.s3urlcache import S3UrlCache
 
 
@@ -78,7 +82,9 @@ class JsonFaker(object):
             with open(schema_file_name, 'w') as temp_jsf:
                 json.dump(schema, temp_jsf)
             data_file_name = f"{src_dir}/temp.json"
-            subprocess.call(["generate-json", schema_file_name, data_file_name])
+            project_root = os.path.dirname(os.path.dirname(sys.modules[dss.__name__].__file__))
+            generate_json = os.path.join(project_root, "node_modules", ".bin", "generate-json")
+            subprocess.call([generate_json, schema_file_name, data_file_name])
             with open(data_file_name, 'r') as temp_json:
                 return json.load(temp_json)
 


### PR DESCRIPTION
Only every 16th build succeeds. The exact error message is

```
Error: Cannot create property '_randexp' on string '.{8}-.{4}-.{4}-.{4}-.{12}' in /properties/hca_ingest/properties/document_id
```

This is caused by a recent release of randexp, a transitive dependency, upgrading it from `0.4.6` to `0.4.7`. The fix is to pin that dependency. In order to pin the dependency, we need to switch to using `package-lock.json` in conjuction with `npm install` which is the prescribed way of installing node.js dependencies reproducibly. Another fix would be to bump `json-schema-faker` to `0.4.7` but unfortunately that's not as easy because `json-schema-faker-cli` depends on it with a `^0.3.6` (essentially `0.3.x`) spec. Bumping to `0.4.7` would conflict with that spec, causing `json-schema-faker-cli` to get its own `node_modules` directory, rendering the bump ineffective.

This is the PR build that shows the test as passing, prior to the PR landing:

https://travis-ci.org/HumanCellAtlas/data-store/builds/338217003

This is the build on master after the PR landed:

https://travis-ci.org/HumanCellAtlas/data-store/builds/340713380