### PR TITLE
V5 meta support

### DIFF
--- a/dss/index/es/schemainfo.py
+++ b/dss/index/es/schemainfo.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 # https://somewhere.anything/1.2.3/anything/type123.json
 # "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.0/json_schema/project_bundle.json"
-schema_url_regex = re.compile(r'/(?P<major_version>[0-9]+)\.[0-9]+\.[0-9]+[\w\d/]*/(?P<type>[\w]+)(.json)?$')
+schema_url_regex = re.compile(r'/(?P<major_version>[0-9]+)\.[0-9]+\.[0-9]+[\w/]*/(?P<type>[\w]+)(\.json)?$')
 
 
 class SchemaInfo(namedtuple('SchemaInfo', ['url', 'version', 'type'])):

--- a/dss/index/es/schemainfo.py
+++ b/dss/index/es/schemainfo.py
@@ -1,0 +1,30 @@
+import re
+from collections import namedtuple
+from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+# https://somewhere.anything/1.2.3/anything/type123.json
+# "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/4.6.0/json_schema/project_bundle.json"
+schema_url_regex = re.compile(r'/(?P<major_version>[0-9]+)\.[0-9]+\.[0-9]+[\w\d/]*/(?P<type>[\w]+)(.json)?$')
+
+
+class SchemaInfo(namedtuple('SchemaInfo', ['url', 'version', 'type'])):
+    @classmethod
+    def from_json(cls, data: dict) -> Optional['SchemaInfo']:
+        if data.get('describedBy'):
+            url = data['describedBy']
+            version, doc_type = schema_url_regex.search(url).group('major_version', 'type')
+            info = cls(url, version, doc_type)
+        elif data.get('core'):
+            # TODO: Remove this if block once we stop supporting the `core` property (see issue #1015).
+            doc_type = data['core']['type']
+            version = data['core']['schema_version'].split(".")[0]
+            url = data['core']['schema_url']
+            info = cls(url, version, doc_type)
+        else:
+            # TODO: Remove 'core' from log message once we stop supporting the `core` property (see issue #1015).
+            logger.info("Need either 'describedBy' or 'core' property to determine JSON schema. Both are absent.")
+            info = None
+        return info

--- a/tests/infra/assert_mixin.py
+++ b/tests/infra/assert_mixin.py
@@ -109,3 +109,16 @@ class DSSAssertMixin:
             return super(DSSAssertMixin, self).__getattr__(item)  # type: ignore
         else:
             raise AttributeError(item)
+
+    def assertRegexIn(self, expected_pattern: str, iterable: typing.List[str], msg: typing.Optional[str]=None) -> None:
+        """Fails the test unless the expected_regex matches one of the strings in iterable"""
+        if isinstance(expected_pattern, (str, bytes)):
+            assert expected_pattern, "expected_regex must not be empty."
+            expected_regex = re.compile(expected_pattern)
+        for text in iterable:
+            if expected_regex.search(text):
+                return
+        standard_msg = "Regex didn't match: %r not found in %r" % (expected_pattern, iterable)
+        # _formatMessage ensures the longMessage option is respected
+        msg = self._formatMessage(msg, standard_msg)
+        raise self.failureException(msg)

--- a/tests/test_hcagenerator.py
+++ b/tests/test_hcagenerator.py
@@ -34,7 +34,6 @@ class TestHCAGenerator(unittest.TestCase):
             self.assertEqual(self.faker.schemas[name], {'$ref': url, 'id': url})
 
     def test_generation(self):
-        for i in range(100):
             for name in self.faker.schemas.keys():
                 with self.subTest(name):
                     fake_json = self.faker.generate(name)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -3,6 +3,7 @@
 
 from abc import ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
+import copy
 import datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import io
@@ -50,7 +51,6 @@ logger = logging.getLogger(__name__)
 # TODO (mbaumann) When the defects in moto have been fixed, remove True from the line below.
 USE_AWS_S3 = bool(os.environ.get("USE_AWS_S3", True))
 
-# TODO: (tsmith) test with multiple doc indexes once indexing by major version is compeleted
 
 #
 # Basic test for DSS indexer:
@@ -483,7 +483,8 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.verify_notification(subscription_id, subscription_query, bundle_fqid)
         self.delete_subscription(subscription_id)
 
-    def test_get_shape_descriptor(self):
+    # TODO: Remove this test once we stop supporting the `core` property (see issue #1015).
+    def test_get_shape_descriptor_core(self):
         index_document = BundleDocument(self.replica, get_bundle_fqid())
         index_document.update({
             'files': {
@@ -518,13 +519,55 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
 
         index_document['files']['assay_json'].pop('core')
         with self.subTest("An versioned file and an unversioned file"):
-            with self.assertLogs(dss.logger, level="INFO") as log_monitor:
+            with self.assertLogs(dss.logger, level="WARNING") as log_monitor:
                 index_document.get_shape_descriptor()
-            self.assertRegex(log_monitor.output[0], "^INFO:.*File assay_json does not contain the 'core' section "
-                                                    "necessary to identify the schema and its version.", )
+            self.assertRegexIn(r"WARNING:.*Unable to obtain JSON schema info from file 'assay_json'. The file will be "
+                               r"indexed as is, without sanitization. This may prevent subsequent, valid files from "
+                               r"being indexed correctly.", log_monitor.output)
             self.assertEqual(index_document.get_shape_descriptor(), "v4")
 
         index_document['files']['sample_json'].pop('core')
+        with self.subTest("no versioned file"):
+            self.assertEqual(index_document.get_shape_descriptor(), None)
+
+    def test_get_shape_descriptor_describedBy(self):
+        index_document = BundleDocument(self.replica, get_bundle_fqid())
+        index_document.update({
+            'files': {
+                'assay_json': {
+                    "describedBy": "http://schema.humancellatlas.org/module/5.0.0/assay.json"
+
+                },
+                'sample_json': {
+                    "describedBy": "http://schema.humancellatlas.org/module/5.0.0/sample.json"
+                }
+            }
+        })
+        with self.subTest("Same major version."):
+            self.assertEqual(index_document.get_shape_descriptor(), "v5")
+
+        v4_assay_url = "http://schema.humancellatlas.org/module/4.0.0/assay.json"
+        index_document['files']['assay_json']['describedBy'] = v4_assay_url
+        with self.subTest("Mixed/inconsistent metadata schema release versions in the same bundle"):
+            with self.assertRaisesRegex(AssertionError,
+                                        "The bundle contains mixed schema major version numbers: \['4', '5'\]"):
+                index_document.get_shape_descriptor()
+
+        v4_sample_url = "http://schema.humancellatlas.org/module/4.0.0/sample.json"
+        index_document['files']['sample_json']['describedBy'] = v4_sample_url
+        with self.subTest("Consistent versions, with a different version value"):
+            self.assertEqual(index_document.get_shape_descriptor(), "v4")
+
+        index_document['files']['assay_json'].pop('describedBy')
+        with self.subTest("A versioned file and an unversioned file"):
+            with self.assertLogs(dss.logger, level="WARNING") as log_monitor:
+                index_document.get_shape_descriptor()
+            self.assertRegexIn(r"WARNING:.*Unable to obtain JSON schema info from file 'assay_json'. The file will be "
+                               r"indexed as is, without sanitization. This may prevent subsequent, valid files from "
+                               r"being indexed correctly.", log_monitor.output)
+            self.assertEqual(index_document.get_shape_descriptor(), "v4")
+
+        index_document['files']['sample_json'].pop('describedBy')
         with self.subTest("no versioned file"):
             self.assertEqual(index_document.get_shape_descriptor(), None)
 
@@ -630,7 +673,8 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
 
         self.delete_subscription(subscription_id)
 
-    def test_scrub_index_data(self):
+    # TODO: Remove this test once we stop supporting the `core` property (see issue #1015).
+    def test_scrub_index_data_with_core(self):
         manifest = read_bundle_manifest(self.blobstore, self.test_bucket, self.bundle_key)
         doc = 'assay_json'
         with self.subTest("removes extra fields when fields not specified in schema."):
@@ -647,9 +691,8 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
 
             with self.assertLogs(dss.logger, level="INFO") as log_monitor:
                 scrub_index_data(index_data['files'], bundle_fqid)
-            self.assertRegex(log_monitor.output[0], r"INFO:[^:]+:In [\w\-\.]+, unexpected additional fields "
-                                                    r"have been removed from the data to be indexed. "
-                                                    r"Removed \[[^\]]*].")
+            self.assertRegexIn(r"INFO:[^:]+:In [\w\-\.]+, unexpected additional fields have been removed from the "
+                               r"data to be indexed. Removed \[[^\]]*].", log_monitor.output)
             self.verify_index_document_structure_and_content(
                 index_data,
                 self.bundle_key,
@@ -662,9 +705,9 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             index_data['files'][doc]['core']['schema_url'] = invalid_url
             with self.assertLogs(dss.logger, level="WARNING") as log_monitor:
                 scrub_index_data(index_data['files'], bundle_fqid)
-            self.assertRegex(log_monitor.output[0], f"WARNING:[^:]+:Unable to retrieve schema from {doc} in "
-                                                    f"{bundle_fqid} because retrieving {invalid_url} caused exception: "
-                                                    f".*")
+            self.assertRegexIn(f"WARNING:[^:]+:Unable to retrieve JSON schema information from {doc} in bundle "
+                               f"{bundle_fqid}.*",
+                               log_monitor.output)
             self.verify_index_document_structure_and_content(
                 index_data,
                 self.bundle_key,
@@ -672,19 +715,11 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                 excluded_files=[doc]
             )
 
-        with self.subTest("document is removed from meta data when document is missing core.schema_url field."):
+        with self.subTest("exception is raised when document is missing core.schema_url field."):
             index_data = create_index_data(self.blobstore, self.test_bucket, self.bundle_key, manifest)
             index_data['files'][doc]['core'].pop('schema_url')
-            with self.assertLogs(dss.logger, level="WARNING") as log_monitor:
+            with self.assertRaises(KeyError):
                 scrub_index_data(index_data['files'], bundle_fqid)
-            self.assertRegex(log_monitor.output[0], f"WARNING:[^:]+:Unable to retrieve schema_url from {doc} in "
-                                                    f"{bundle_fqid} because core.schema_url does not exist.*")
-            self.verify_index_document_structure_and_content(
-                index_data,
-                self.bundle_key,
-                files=smartseq2_paried_ends_indexed_file_list,
-                excluded_files=[doc]
-            )
 
         with self.subTest("document is removed from meta data when document is missing core field."):
             'Only the manifest should exist.'
@@ -710,6 +745,138 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                                                                       f"{json.dumps(expected_index_data, indent=4)}"
                                                                       f"Actual index document: "
                                                                       f"{json.dumps(index_data, indent=4)}")
+
+    def test_scrub_index_data_with_describedBy(self):
+        index_data_master = {
+            "files": {
+                "biomaterial_bundle_json": {
+                    "describedBy": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/"
+                                   "5.0.0/json_schema/bundle/biomaterial.json",
+                    "schema_version": "5.0.0",
+                    "schema_type": "biomaterial_bundle",
+                    "biomaterials": [
+                        {
+                            "hca_ingest": {
+                                "describedBy": "https://schema.humancellatlas.org/bundle/5.0.0/ingest_audit",
+                                "document_id": "a37dbd93-b93a-4838-a7bb-cd0796b3d9d0",
+                                "submissionDate": "2017-10-13T09:18:49.422Z",
+                                "updateDate": "2017-10-13T09:19:40.069Z",
+                                "accession": "SAM0888697"
+                            },
+                            "content": {
+                                "describedBy": "https://schema.humancellatlas.org/type/biomaterial/"
+                                               "5.0.0/donor_organism",
+                                "schema_version": "5.0.0",
+                                "schema_type": "biomaterial",
+                                "biomaterial_core": {
+                                    "describedBy": "https://schema.humancellatlas.org/core/biomaterial/"
+                                                   "5.0.0/biomaterial_core",
+                                    "biomaterial_id": "d1",
+                                    "biomaterial_name": "donor1",
+                                    "ncbi_taxon_id": [
+                                        9606
+                                    ]
+                                },
+                                "is_living": True,
+                                "biological_sex": "male",
+                                "development_stage": {
+                                    "describedBy":
+                                        "https://schema.humancellatlas.org/module/ontology/"
+                                        "5.0.0/development_stage_ontology",
+                                    "text": "adult",
+                                    "ontology": "EFO_0001272"
+                                },
+                                "genus_species": [
+                                    {
+                                        "describedBy": "https://schema.humancellatlas.org/module/ontology/"
+                                                       "5.0.0/species_ontology",
+                                        "text": "Homo sapiens",
+                                        "ontology": "NCBITAXON_9606"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "hca_ingest": {
+                                "describedBy": "https://schema.humancellatlas.org/bundle/5.0.0/ingest_audit",
+                                "document_id": "a37dbd93-b93a-4838-a7bb-cd0796b3d9d1",
+                                "submissionDate": "2017-10-13T09:18:49.422Z",
+                                "updateDate": "2017-10-13T09:19:40.069Z",
+                                "accession": "SAM0999697"
+                            },
+                            "content": {
+                                "describedBy": "https://schema.humancellatlas.org/type/biomaterial/"
+                                               "5.0.0/specimen_from_organism",
+                                "schema_version": "5.0.0",
+                                "schema_type": "biomaterial",
+                                "biomaterial_core": {
+                                    "describedBy": "https://schema.humancellatlas.org/core/biomaterial/"
+                                                   "5.0.0/biomaterial_core",
+                                    "biomaterial_id": "s1",
+                                    "biomaterial_name": "PBMCs",
+                                    "biomaterial_description": "peripheral blood mononuclear cells (PBMCs)",
+                                    "ncbi_taxon_id": [
+                                        9606
+                                    ],
+                                    "has_input_biomaterial": "d1"
+                                },
+                                "organ": {
+                                    "describedBy": "https://schema.humancellatlas.org/module/ontology/"
+                                                   "5.0.0/organ_ontology",
+                                    "text": "blood",
+                                    "ontology": "UBERON_0000178"
+                                },
+                                "organ_part": {
+                                    "describedBy": "https://schema.humancellatlas.org/module/ontology/"
+                                                   "5.0.0/organ_part_ontology",
+                                    "text": "peripheral blood mononuclear cells (PBMCs)"
+                                }
+                            },
+                            "derived_from": ["a37dbd93-b93a-4838-a7bb-cd0796b3d9d1"],
+                            "derivation_processes": []
+                        }
+                    ]
+                },
+                "ingest_audit_json": {
+                    "describedBy": "https://raw.githubusercontent.com/HumanCellAtlas/metadata-schema/"
+                                   "5.0.0/json_schema/bundle/ingest_audit.json",
+                    "document_id": ".{8}-.{4}-.{4}-.{4}-.{12}",
+                    "submissionDate": "08-08-2018"
+                }
+            }
+        }
+        doc = 'biomaterial_bundle_json'
+        bundle_fqid = self.bundle_key.split('/')[1]
+        index_data_expected = copy.deepcopy(index_data_master)
+        index_data_expected['files'].pop(doc)
+        with self.subTest("Exception is raised when an invalid url is in describedBy."):
+            invalid_url = "://invalid_url"
+            index_data = copy.deepcopy(index_data_master)
+            index_data['files'][doc]['describedBy'] = invalid_url
+            with self.assertRaises(AttributeError):
+                scrub_index_data(index_data['files'], bundle_fqid)
+
+        with self.subTest("document is removed from meta data when document is missing describedBy field."):
+            index_data = copy.deepcopy(index_data_master)
+            index_data['files'][doc].pop('describedBy')
+            with self.assertLogs(dss.logger, level="WARNING") as log_monitor:
+                scrub_index_data(index_data['files'], bundle_fqid)
+            self.assertRegexIn(f"WARNING:[^:]+:Unable to retrieve JSON schema information from {doc} in bundle "
+                               f"{bundle_fqid}.*", log_monitor.output)
+            self.assertDictEqual(index_data_expected, index_data)
+
+        with self.subTest("removes extra fields when fields not specified in schema."):
+            index_data = copy.deepcopy(index_data_master)
+            index_data['files']['biomaterial_bundle_json'].update({'extra_top': 123,
+                                                                   'extra_obj': {"something": "here", "another": 123},
+                                                                   'extra_lst': ["a", "b"]})
+            index_data['files']['ingest_audit_json']['extra_1'] = "Another extra field in a different file."
+
+        with self.assertLogs(dss.logger, level="INFO") as log_monitor:
+            scrub_index_data(index_data['files'], bundle_fqid)
+        self.assertDictEqual(index_data_master, index_data)
+        self.assertRegexIn(r"INFO:[^:]+:In [\w\-\.]+, unexpected additional fields have been removed from the "
+                           r"data to be indexed. Removed \[[^\]]*].", log_monitor.output)
 
     def verify_notification(self, subscription_id, es_query, bundle_fqid):
         posted_payload_string = self.get_notification_payload()


### PR DESCRIPTION
### Test plan
- adding test cases for `shape_descriptor` and `scrub_index_data`

### Release notes
v5 of the meta data uses `describedBy` to specify versions and type. Extra fields will be removed from v5 metadata bundle  and v5 bundle will be index by major version using `describedBy`. The `core` field in previous version of the metadate will continue to be supported.

