### PR TITLE
ES test server improvements

### DIFF
--- a/dss/index/es/__init__.py
+++ b/dss/index/es/__init__.py
@@ -16,6 +16,7 @@ from botocore.vendored import requests
 from elasticsearch import RequestsHttpConnection, Elasticsearch
 from requests_aws4auth import AWS4Auth
 
+from dss import Config
 from dss.util.retry import retry
 from dss.util import networking
 
@@ -67,7 +68,7 @@ class ElasticsearchServer:
                 "-E", f"http.port={port}",
                 "-E", f"transport.tcp.port={transport_port}",
                 "-E", f"path.data={tempdir.name}",
-                "-E", "logger.org.elasticsearch=warn"]
+                "-E", "logger.org.elasticsearch=" + ("info" if Config.debug_level() > 0 else "warn")]
         logger.debug("Running %r with environment %r", args, env)
         proc = subprocess.Popen(args, env=env)
 

--- a/dss/logging.py
+++ b/dss/logging.py
@@ -31,6 +31,7 @@ The values in this map are tuples of log levels. The first (second or third) tup
 
 test_log_levels: log_level_t = {
     dss.logger: (WARNING, DEBUG),
+    'test.es': (INFO, DEBUG)
 }
 """
 The log levels for running tests. The entries in this map override or extend the entries in the main map.

--- a/tests/es/__init__.py
+++ b/tests/es/__init__.py
@@ -1,8 +1,15 @@
 import logging
+import socket
+import subprocess
+import time
 from typing import List
-from dss.config import Config, BucketConfig
-from dss.index.es import ElasticsearchClient
 
+import os
+import tempfile
+
+from dss.config import BucketConfig, Config
+from dss.index.es import ElasticsearchClient
+from dss.util import networking
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +34,10 @@ def close_elasticsearch_connections(es_client):
 
 
 def clear_indexes(index_names: List[str], doctypes: List[str]):
-    '''erases all of the documents in indexes with any of the doctypes provided. This can only be used in TEST
-    configuration with IndexSuffix.name set. Only indexes with the same IndexSuffix.name can be erased.'''
-
+    """
+    Erases all of the documents in indexes with any of the doctypes provided. This can only be used in TEST
+    configuration with IndexSuffix.name set. Only indexes with the same IndexSuffix.name can be erased.
+    """
     # ensure the indexes are test index.
     assert Config._CURRENT_CONFIG == BucketConfig.TEST
     assert Config.test_index_suffix.value
@@ -43,3 +51,62 @@ def clear_indexes(index_names: List[str], doctypes: List[str]):
                                   doc_type=doctypes,
                                   refresh=True,
                                   conflicts='proceed')
+
+
+class ElasticsearchServer:
+    def __init__(self, timeout: float=60, delay: float=10) -> None:
+        elasticsearch_binary = os.getenv("DSS_TEST_ES_PATH", "elasticsearch")
+        tempdir = tempfile.TemporaryDirectory()
+
+        # Set Elasticsearch's initial and max heap to 1.6 GiB, 40% of what's available on Travis, according to
+        # guidance from https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+        env = dict(os.environ, ES_JAVA_OPTIONS="-Xms1638m -Xmx1638m")
+
+        # Work around https://github.com/travis-ci/travis-ci/issues/8408
+        if '_JAVA_OPTIONS' in env:  # no coverage
+            logger.warning("_JAVA_OPTIONS is set. This may override the options just set via ES_JAVA_OPTIONS.")
+
+        port = networking.unused_tcp_port()
+        transport_port = networking.unused_tcp_port()
+
+        args = [elasticsearch_binary,
+                "-E", f"http.port={port}",
+                "-E", f"transport.tcp.port={transport_port}",
+                "-E", f"path.data={tempdir.name}",
+                "-E", "logger.org.elasticsearch=" + ("info" if Config.debug_level() > 0 else "warn")]
+        logger.debug("Running %r with environment %r", args, env)
+        proc = subprocess.Popen(args, env=env)
+
+        def check():
+            status = proc.poll()
+            if status is not None:
+                tempdir.cleanup()
+                raise ChildProcessError('ES process died with status {status}')
+
+        deadline = time.time() + timeout
+        while True:
+            check()
+            time.sleep(delay)
+            check()
+            logger.info('Attempting to connect to ES instance at 127.0.0.1:%i', port)
+            try:
+                sock = socket.create_connection(("127.0.0.1", port), 1)
+            except (ConnectionRefusedError, socket.timeout):
+                if time.time() + delay > deadline:
+                    proc.kill()
+                    tempdir.cleanup()
+                    raise
+            else:
+                sock.close()
+                check()
+                self.port = port
+                self.proc = proc
+                self.tempdir = tempdir
+                break
+
+    def shutdown(self) -> None:
+        self.proc.kill()
+        self.proc.wait()
+        self.tempdir.cleanup()
+
+

--- a/tests/es/__init__.py
+++ b/tests/es/__init__.py
@@ -74,7 +74,7 @@ class ElasticsearchServer:
                 "-E", f"transport.tcp.port={transport_port}",
                 "-E", f"path.data={tempdir.name}",
                 "-E", "logger.org.elasticsearch=" + ("info" if Config.debug_level() > 0 else "warn")]
-        logger.debug("Running %r with environment %r", args, env)
+        logger.info("Running %r with environment %r", args, env)
         proc = subprocess.Popen(args, env=env)
 
         def check():
@@ -92,6 +92,7 @@ class ElasticsearchServer:
             try:
                 sock = socket.create_connection(("127.0.0.1", port), 1)
             except (ConnectionRefusedError, socket.timeout):
+                logger.debug('Failed connecting to ES instance at 127.0.0.1:%i', port, exc_info=True)
                 if time.time() + delay > deadline:
                     proc.kill()
                     tempdir.cleanup()
@@ -108,5 +109,3 @@ class ElasticsearchServer:
         self.proc.kill()
         self.proc.wait()
         self.tempdir.cleanup()
-
-

--- a/tests/infra/elasticsearch_test_case.py
+++ b/tests/infra/elasticsearch_test_case.py
@@ -3,8 +3,7 @@ import unittest
 import os
 
 from dss.config import Config
-from dss.index.es import ElasticsearchServer
-from tests.es import elasticsearch_delete_index
+from tests.es import elasticsearch_delete_index, ElasticsearchServer
 
 
 class ElasticsearchTestCase(unittest.TestCase):


### PR DESCRIPTION
I still suspect some test hangs are caused by the code that spawns an Elasticsearch instance on demand during test setup. There was this outer loop that would essentially retry starting a new instance forever if it couldn't connect to recently started one. There were no log statements made during that loop so it would have been hard to detect in the build output. I took it out. The new approach will raise an exception if the situation occurs that the outer loop tried to mitigate. I think we would want to see this happen in the wild before we attempt to fix it.

The way the free ports are determined is still potentially racy. For example, there are two invocations of that function, one right after the other. There is no guarantee that the second one won't return the same port as the first one.

I've increased the logging verbosity of this setup such that we can see more easily if weird ports are being chosen.