### PR TITLE
Fix s3-copy-sfn

### DIFF
--- a/dss/stepfunctions/s3copyclient/implementation.py
+++ b/dss/stepfunctions/s3copyclient/implementation.py
@@ -171,11 +171,12 @@ def join(event, lambda_context):
     # which parts are present?
     s3_resource = boto3.resource("s3")
 
-    if isinstance(event, list):
-        # only the 0th worker propagates the full state.
-        state = event[0]
-    else:
-        state = event
+    if not isinstance(event, list):
+        # this is a single-part copy.
+        return event
+
+    # only the 0th worker propagates the full state.
+    state = event[0]
 
     mpu = s3_resource.MultipartUpload(
         state[Key.DESTINATION_BUCKET], state[Key.DESTINATION_KEY], state[_Key.UPLOAD_ID])


### PR DESCRIPTION
If it's a non-multipart copy, we want to exit the join operation.  Otherwise, we will attempt to join a non-existent multipart copy.

### Test plan
Ran tests/test_s3parallelcopy.py and checked that the sfns completed without errors.