### PR TITLE
GCP support in checkout service

### DIFF
--- a/daemons/dss-checkout-sfn/.chalice/config.json
+++ b/daemons/dss-checkout-sfn/.chalice/config.json
@@ -1,11 +1,13 @@
 {
   "version": "2.0",
   "app_name": "dss-checkout-sfn",
+  "environment_variables": {
+    "GOOGLE_APPLICATION_CREDENTIALS": "/var/task/domovoilib/gcp-credentials.json"
+  },
   "stages": {
     "dev": {
       "api_gateway_stage": "dev",
-      "environment_variables": {
-      }
+      "environment_variables": {}
     }
   },
   "lambda_timeout": 300,

--- a/dss/config.py
+++ b/dss/config.py
@@ -297,7 +297,7 @@ class Replica(Enum):
             checkout_bucket_getter: typing.Callable[[], str],
             storage_schema: str,
             blobstore_class: typing.Type[BlobStore],
-            hcablobstore_class: typing.Type[HCABlobStore]
+            hcablobstore_class: typing.Type[HCABlobStore],
     ) -> None:
         self._bucket_getter = bucket_getter
         self._checkout_bucket_getter = checkout_bucket_getter

--- a/dss/config.py
+++ b/dss/config.py
@@ -91,6 +91,7 @@ class Config:
     _S3_BUCKET = None  # type: typing.Optional[str]
     _GS_BUCKET = None  # type: typing.Optional[str]
     _S3_CHECKOUT_BUCKET = None  # type: typing.Optional[str]
+    _GS_CHECKOUT_BUCKET = None  # type: typing.Optional[str]
 
     _ALLOWED_EMAILS = None  # type: typing.Optional[str]
     _CURRENT_CONFIG = BucketConfig.ILLEGAL  # type: BucketConfig
@@ -182,6 +183,25 @@ class Config:
         return Config._GS_BUCKET
 
     @staticmethod
+    def get_gs_checkout_bucket() -> str:
+        if Config._GS_CHECKOUT_BUCKET is None:
+            if Config._CURRENT_CONFIG == BucketConfig.NORMAL:
+                envvar = "DSS_GS_CHECKOUT_BUCKET"
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST:
+                envvar = "DSS_GS_CHECKOUT_BUCKET_TEST"
+            elif Config._CURRENT_CONFIG == BucketConfig.TEST_FIXTURE:
+                envvar = "DSS_GS_CHECKOUT_BUCKET_TEST_FIXTURES"
+            elif Config._CURRENT_CONFIG == BucketConfig.ILLEGAL:
+                raise Exception("bucket config not set")
+
+            if envvar not in os.environ:
+                raise Exception(
+                    "Please set the {} environment variable".format(envvar))
+            Config._GS_CHECKOUT_BUCKET = os.environ[envvar]
+
+        return Config._GS_CHECKOUT_BUCKET
+
+    @staticmethod
     def get_allowed_email_domains() -> str:
         if Config._ALLOWED_EMAILS is None:
             if Config._CURRENT_CONFIG == BucketConfig.NORMAL:
@@ -268,17 +288,19 @@ class Config:
 
 
 class Replica(Enum):
-    aws = (Config.get_s3_bucket, "s3", S3BlobStore, S3HCABlobStore)
-    gcp = (Config.get_gs_bucket, "gs", GSBlobStore, GSHCABlobStore)
+    aws = (Config.get_s3_bucket, Config.get_s3_checkout_bucket, "s3", S3BlobStore, S3HCABlobStore)
+    gcp = (Config.get_gs_bucket, Config.get_gs_checkout_bucket, "gs", GSBlobStore, GSHCABlobStore)
 
     def __init__(
             self,
             bucket_getter: typing.Callable[[], str],
+            checkout_bucket_getter: typing.Callable[[], str],
             storage_schema: str,
             blobstore_class: typing.Type[BlobStore],
-            hcablobstore_class: typing.Type[HCABlobStore],
+            hcablobstore_class: typing.Type[HCABlobStore]
     ) -> None:
         self._bucket_getter = bucket_getter
+        self._checkout_bucket_getter = checkout_bucket_getter
         self._storage_schema = storage_schema
         self._blobstore_class = blobstore_class
         self._hcablobstore_class = hcablobstore_class
@@ -299,6 +321,9 @@ class Replica(Enum):
     def hcablobstore_class(self) -> typing.Type[HCABlobStore]:
         return self._hcablobstore_class
 
+    @property
+    def checkout_bucket(self) -> str:
+        return self._checkout_bucket_getter()
 
 @contextmanager
 def override_bucket_config(temp_config: BucketConfig):

--- a/dss/storage/checkout.py
+++ b/dss/storage/checkout.py
@@ -1,20 +1,15 @@
 import io
 import logging
 import uuid
-
-from cloud_blobstore import BlobNotFoundError, BlobStoreUnknownError
-from cloud_blobstore.s3 import S3BlobStore
 from enum import Enum, auto
 
-from dss.storage.bundles import get_bundle, get_bundle_from_bucket
+from cloud_blobstore import BlobNotFoundError, BlobStoreUnknownError
 from dss import DSSException, stepfunctions
 from dss.config import Config, Replica
-from dss.stepfunctions import s3copyclient
-
+from dss.stepfunctions import s3copyclient, gscopyclient
+from dss.storage.bundles import get_bundle, get_bundle_from_bucket
 
 log = logging.getLogger(__name__)
-blobstore = S3BlobStore.from_environment()
-
 
 class BundleFileMeta:
     NAME = "name"
@@ -35,16 +30,27 @@ class ValidationEnum(Enum):
     WRONG_BUNDLE_KEY = auto(),
     PASSED = auto()
 
-
-def parallel_copy(source_bucket: str, source_key: str, destination_bucket: str, destination_key: str):
+def parallel_copy(source_bucket: str, source_key: str, destination_bucket: str, destination_key: str, replica: Replica):
     log.debug(f"Copy file from bucket {source_bucket} with key {source_key} to "
               f"bucket {destination_bucket} destination file: {destination_key}")
-    state = s3copyclient.copy_sfn_event(
-        source_bucket, source_key,
-        destination_bucket, destination_key,
-    )
+
+    if replica == Replica.aws:
+        state = s3copyclient.copy_sfn_event(
+            source_bucket, source_key,
+            destination_bucket, destination_key,
+        )
+        state_machine_name_template = "dss-s3-copy-sfn-{stage}"
+    elif replica == Replica.gcp:
+        state = gscopyclient.copy_sfn_event(
+            source_bucket, source_key,
+            destination_bucket, destination_key
+        )
+        state_machine_name_template = "dss-gs-copy-sfn-{stage}"
+    else:
+        raise ValueError("Unsupported replica")
+
     execution_name = get_execution_id()
-    stepfunctions.step_functions_invoke("dss-s3-copy-sfn-{stage}", execution_name, state)
+    stepfunctions.step_functions_invoke(state_machine_name_template, execution_name, state)
 
 
 def get_src_key(file_metadata: dict):
@@ -73,27 +79,26 @@ def get_manifest_files(bundle_id: str, version: str, replica: Replica):
 
 def validate_file_dst(dst_bucket: str, dst_key: str, replica: Replica):
     try:
-        blobstore.get_all_metadata(dst_bucket, dst_key)
+        Config.get_blobstore_handle(replica).get_user_metadata(dst_bucket, dst_key)
         return True
     except (BlobNotFoundError, BlobStoreUnknownError):
         return False
 
 
 def pre_exec_validate(dss_bucket: str, dst_bucket: str, replica: Replica, bundle_id: str, version: str):
-    cause = None
-    validation_code = validate_dst_bucket(dst_bucket, replica)
+    validation_code, cause = validate_dst_bucket(dst_bucket, replica)
     if validation_code == ValidationEnum.PASSED:
         validation_code, cause = validate_bundle_exists(replica, dss_bucket, bundle_id, version)
     return validation_code, cause
 
 
-def validate_dst_bucket(dst_bucket: str, replica: Replica) -> ValidationEnum:
-    if not blobstore.check_bucket_exists(dst_bucket):
-        return ValidationEnum.WRONG_DST_BUCKET
+def validate_dst_bucket(dst_bucket: str, replica: Replica):
+    if not Config.get_blobstore_handle(replica).check_bucket_exists(dst_bucket):
+        return ValidationEnum.WRONG_DST_BUCKET, f"Bucket {dst_bucket} doesn't exist"
     if not touch_test_file(dst_bucket, replica):
-        return ValidationEnum.WRONG_PERMISSIONS_DST_BUCKET
+        return ValidationEnum.WRONG_PERMISSIONS_DST_BUCKET, f"Insufficient permissions on bucket {dst_bucket}"
 
-    return ValidationEnum.PASSED
+    return ValidationEnum.PASSED, None
 
 
 def validate_bundle_exists(replica: Replica, bucket: str, bundle_id: str, version: str):
@@ -102,11 +107,6 @@ def validate_bundle_exists(replica: Replica, bucket: str, bundle_id: str, versio
         return ValidationEnum.PASSED, None
     except (DSSException, ValueError):
         return ValidationEnum.WRONG_BUNDLE_KEY, "Bundle with specified key does not exist"
-
-
-def get_bucket_region(bucket: str):
-    return blobstore.get_bucket_region(bucket)
-
 
 def get_execution_id() -> str:
     return str(uuid.uuid4())
@@ -126,7 +126,7 @@ def touch_test_file(dst_bucket: str, replica: Replica) -> bool:
             dst_bucket,
             test_object,
             io.BytesIO(b""))
-        blobstore.delete(dst_bucket, test_object)
+        Config.get_blobstore_handle(replica).delete(dst_bucket, test_object)
         return True
     except Exception as e:
         return False

--- a/dss/storage/checkout.py
+++ b/dss/storage/checkout.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import typing
 import uuid
 from enum import Enum, auto
 
@@ -92,7 +93,7 @@ def pre_exec_validate(dss_bucket: str, dst_bucket: str, replica: Replica, bundle
     return validation_code, cause
 
 
-def validate_dst_bucket(dst_bucket: str, replica: Replica):
+def validate_dst_bucket(dst_bucket: str, replica: Replica) -> typing.Tuple[ValidationEnum, str]:
     if not Config.get_blobstore_handle(replica).check_bucket_exists(dst_bucket):
         return ValidationEnum.WRONG_DST_BUCKET, f"Bucket {dst_bucket} doesn't exist"
     if not touch_test_file(dst_bucket, replica):

--- a/dss/util/email.py
+++ b/dss/util/email.py
@@ -1,9 +1,8 @@
 import boto3
-from botocore.exceptions import ClientError
 
-# The character encoding for the email.
 from dss import Replica
 
+# The character encoding for the email.
 CHARSET = "UTF-8"
 SUCCESS_SUBJECT = "Bundle checkout complete"
 FAILURE_SUBJECT = "Bundle checkout failed"

--- a/dss/util/email.py
+++ b/dss/util/email.py
@@ -2,6 +2,8 @@ import boto3
 from botocore.exceptions import ClientError
 
 # The character encoding for the email.
+from dss import Replica
+
 CHARSET = "UTF-8"
 SUCCESS_SUBJECT = "Bundle checkout complete"
 FAILURE_SUBJECT = "Bundle checkout failed"
@@ -37,7 +39,7 @@ def send_email(sender: str, to: str, subject: str, html: str, text: str) -> str:
     )
     return "Email sent! Message ID: {}".format(response['ResponseMetadata']['RequestId'])
 
-def send_checkout_success_email(sender: str, to: str, bucket: str, location: str):
+def send_checkout_success_email(sender: str, to: str, bucket: str, location: str, replica: Replica):
     text = "Hello, your checkout request has been processed. Your files are available at bucket {} location {}.".\
         format(bucket, location)
 
@@ -47,11 +49,11 @@ def send_checkout_success_email(sender: str, to: str, bucket: str, location: str
          <h1>Hello,</h1>
          <p>
             Your checkout request has been processed.
-             Your files are available at <strong>s3://{}/{}</strong>
+             Your files are available at <strong>{}://{}/{}</strong>
          </p>
        </body>
        </html>
-       """.format(bucket, location)
+       """.format(replica.storage_schema, bucket, location)
     return send_email(sender, to, SUCCESS_SUBJECT, html, text)
 
 

--- a/environment
+++ b/environment
@@ -24,6 +24,7 @@ EXPORT_ENV_VARS_TO_LAMBDA_ARRAY=(
     DSS_SUBSCRIPTION_AUTHORIZED_DOMAINS
     DSS_NOTIFICATION_SENDER
     DSS_S3_CHECKOUT_BUCKET
+    DSS_GS_CHECKOUT_BUCKET
 )
 
 set -a
@@ -47,6 +48,11 @@ DSS_GS_BUCKET_TEST=org-humancellatlas-dss-test
 DSS_GS_BUCKET_TEST_FIXTURES=org-humancellatlas-dss-test-fixtures
 DSS_GS_BUCKET_STAGING=org-humancellatlas-dss-staging
 DSS_GS_BUCKET_PROD=org-humancellatlas-dss-prod
+DSS_GS_CHECKOUT_BUCKET=org-humancellatlas-dss-checkout-dev
+DSS_GS_CHECKOUT_BUCKET_TEST=org-humancellatlas-dss-checkout-test
+DSS_GS_CHECKOUT_BUCKET_TEST_FIXTURES=org-humancellatlas-dss-checkout-test-fixtures
+DSS_GS_CHECKOUT_BUCKET_STAGING=org-humancellatlas-dss-checkout-staging
+DSS_GS_CHECKOUT_BUCKET_PROD=org-humancellatlas-dss-checkout-prod
 DSS_NOTIFICATION_SENDER="DSS Notifier <dss.humancellatlas@gmail.com>"
 GOOGLE_APPLICATION_CREDENTIALS="${DSS_HOME}/gcp-credentials.json"
 GOOGLE_APPLICATION_SECRETS="${DSS_HOME}/application_secrets.json"

--- a/iam/policy-templates/dss-checkout-sfn-lambda.json
+++ b/iam/policy-templates/dss-checkout-sfn-lambda.json
@@ -71,7 +71,9 @@
       ],
       "Resource": [
         "arn:aws:states:*:$account_id:stateMachine:dss-s3-copy-sfn*",
-        "arn:aws:states:*:$account_id:execution:dss-s3-copy-sfn*"
+        "arn:aws:states:*:$account_id:execution:dss-s3-copy-sfn*",
+        "arn:aws:states:*:$account_id:stateMachine:dss-gs-copy-sfn*",
+        "arn:aws:states:*:$account_id:execution:dss-gs-copy-sfn*"
       ]
     }
   ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ chalice==1.1.0
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.0.0
+cloud-blobstore==2.0.2
 colorama==0.3.7
 connexion==1.1.15
 cookies==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cffi==1.11.2
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.0.0
+cloud-blobstore==2.0.2
 connexion==1.1.15
 cryptography==2.1.4
 docutils==0.14

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -32,8 +32,14 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)
         self.s3_test_fixtures_bucket = get_env("DSS_S3_BUCKET_TEST_FIXTURES")
-        self.s3_test_checkout_bucket = get_env("DSS_S3_CHECKOUT_BUCKET_TEST")
-        self.s3_test_bucket = get_env("DSS_S3_BUCKET_TEST")
+        self.gs_test_fixtures_bucket = get_env("DSS_GS_BUCKET_TEST_FIXTURES")
+
+    def get_test_fixture_bucket(self, replica: Replica) -> str:
+        if replica == Replica.aws:
+            bucket = self.s3_test_fixtures_bucket
+        elif replica == Replica.gcp:
+            bucket = self.gs_test_fixtures_bucket
+        return bucket
 
     @testmode.integration
     def test_sanity_check_valid(self):
@@ -134,60 +140,60 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         replica = Replica.aws
         file_count = 0
         with override_bucket_config(BucketConfig.TEST_FIXTURE):
-            for file in get_manifest_files(bundle_uuid, version, replica):
+            for _ in get_manifest_files(bundle_uuid, version, replica):
                 file_count += 1
         self.assertEqual(file_count, 1)
 
     @testmode.standalone
     def test_validate_file_dst_fail(self):
         dst_key = "83b76ac9-2470-46d2-ae5e-a415ce86b020"
-        replica = Replica.aws
-        self.assertEquals(validate_file_dst(self.s3_test_checkout_bucket, dst_key, replica), False)
+        for replica in Replica:
+            self.assertEquals(validate_file_dst(replica.checkout_bucket, dst_key, replica), False)
 
     @testmode.standalone
     def test_validate_file_dst(self):
         dst_key = "files/ce55fd51-7833-469b-be0b-5da88ebebfcd.2017-06-18T075702.020366Z"
-        replica = Replica.aws
-        self.assertEquals(validate_file_dst(self.s3_test_fixtures_bucket, dst_key, replica), True)
+        for replica in Replica:
+            bucket = self.get_test_fixture_bucket(replica)
+            self.assertEquals(validate_file_dst(bucket, dst_key, replica), True)
 
     @testmode.standalone
     def test_validate_wrong_key(self):
         bundle_uuid = "WRONG_KEY"
         version = "WRONG_VERSION"
-        replica = Replica.aws
-        valid, cause = pre_exec_validate(self.s3_test_bucket, self.s3_test_checkout_bucket, replica, bundle_uuid,
-                                         version)
-        self.assertIs(valid, ValidationEnum.WRONG_BUNDLE_KEY)
+        for replica in Replica:
+            valid, cause = pre_exec_validate(replica.bucket, replica.checkout_bucket, replica, bundle_uuid, version)
+            self.assertIs(valid, ValidationEnum.WRONG_BUNDLE_KEY)
 
     @testmode.standalone
     def test_validate(self):
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
-        replica = Replica.aws
-        valid, cause = pre_exec_validate(self.s3_test_fixtures_bucket, self.s3_test_checkout_bucket, replica,
-                                         bundle_uuid, version)
-        self.assertIs(valid, ValidationEnum.PASSED)
+        for replica in Replica:
+            valid, cause = pre_exec_validate(self.get_test_fixture_bucket(replica), replica.checkout_bucket, replica,
+                                             bundle_uuid, version)
+            self.assertIs(valid, ValidationEnum.PASSED)
 
     @testmode.standalone
     def test_validate_bundle_exists(self):
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
-        replica = Replica.aws
-        valid, cause = validate_bundle_exists(replica, self.s3_test_fixtures_bucket, bundle_uuid, version)
-        self.assertIs(valid, ValidationEnum.PASSED)
+        for replica in Replica:
+            valid, cause = validate_bundle_exists(replica, self.get_test_fixture_bucket(replica), bundle_uuid, version)
+            self.assertIs(valid, ValidationEnum.PASSED)
 
     @testmode.standalone
     def test_validate_bundle_exists_fail(self):
         bundle_uuid = "WRONG_KEY"
         version = "WRONG_VERSION"
-        replica = Replica.aws
-        valid, cause = validate_bundle_exists(replica, self.s3_test_fixtures_bucket, bundle_uuid, version)
-        self.assertIs(valid, ValidationEnum.WRONG_BUNDLE_KEY)
+        for replica in Replica:
+            valid, cause = validate_bundle_exists(replica, self.get_test_fixture_bucket(replica), bundle_uuid, version)
+            self.assertIs(valid, ValidationEnum.WRONG_BUNDLE_KEY)
 
     @testmode.standalone
     def test_touch_file(self):
-        replica = Replica.aws
-        self.assertEqual(touch_test_file(self.s3_test_checkout_bucket, replica), True)
+        for replica in Replica:
+            self.assertEqual(touch_test_file(replica.checkout_bucket, replica), True)
 
     @testmode.standalone
     def test_execution_id(self):
@@ -197,7 +203,6 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             UUID(exec_id, version=4)
         except ValueError:
             self.fail("Invalid execution id. Valid UUID v.4 is expected.")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -42,11 +42,6 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         return bucket
 
     @testmode.integration
-    def test_sanity_check_valid(self):
-        for replica in Replica:
-            self.launch_checkout(replica.checkout_bucket, replica)
-
-    @testmode.integration
     def test_pre_execution_check_doesnt_exist(self):
         replica = Replica.aws
         non_existent_bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf111"

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -37,7 +37,8 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
     @testmode.integration
     def test_sanity_check_valid(self):
-        self.launch_checkout(self.s3_test_checkout_bucket)
+        for replica in Replica:
+            self.launch_checkout(replica.checkout_bucket, replica)
 
     @testmode.integration
     def test_pre_execution_check_doesnt_exist(self):
@@ -77,8 +78,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                 request_body
             )
 
-    def launch_checkout(self, dst_bucket: str) -> str:
-        replica = Replica.aws
+    def launch_checkout(self, dst_bucket: str, replica: Replica) -> str:
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
         request_body = {"destination": dst_bucket, "email": "rkisin@chanzuckerberg.com"}
@@ -101,29 +101,31 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
     @testmode.integration
     def test_status_success(self):
-        exec_arn = self.launch_checkout(self.s3_test_checkout_bucket)
-        url = str(UrlBuilder().set(path="/v1/bundles/checkout/" + exec_arn))
-        with override_bucket_config(BucketConfig.TEST_FIXTURE):
-            resp_obj = self.assertGetResponse(
-                url,
-                requests.codes.ok
-            )
-        status = resp_obj.json.get('status')
-        self.assertIsNotNone(status)
-        self.assertIn(status, ['RUNNING', 'SUCCEEDED'])
+        for replica in Replica:
+            exec_arn = self.launch_checkout(replica.checkout_bucket, replica)
+            url = str(UrlBuilder().set(path="/v1/bundles/checkout/" + exec_arn))
+            with override_bucket_config(BucketConfig.TEST_FIXTURE):
+                resp_obj = self.assertGetResponse(
+                    url,
+                    requests.codes.ok
+                )
+            status = resp_obj.json.get('status')
+            self.assertIsNotNone(status)
+            self.assertIn(status, ['RUNNING', 'SUCCEEDED'])
 
     @testmode.integration
     def test_status_fail(self):
-        exec_arn = self.launch_checkout('e47114c9-bb96-480f-b6f5-c3e07aae399f')
-        url = str(UrlBuilder().set(path="/v1/bundles/checkout/" + exec_arn))
-        with override_bucket_config(BucketConfig.TEST_FIXTURE):
-            resp_obj = self.assertGetResponse(
-                url,
-                requests.codes.ok
-            )
-        status = resp_obj.json.get('status')
-        self.assertIsNotNone(status)
-        self.assertIn(status, ['RUNNING', 'FAILED'])
+        for replica in Replica:
+            exec_arn = self.launch_checkout('e47114c9-bb96-480f-b6f5-c3e07aae399f', replica)
+            url = str(UrlBuilder().set(path="/v1/bundles/checkout/" + exec_arn))
+            with override_bucket_config(BucketConfig.TEST_FIXTURE):
+                resp_obj = self.assertGetResponse(
+                    url,
+                    requests.codes.ok
+                )
+            status = resp_obj.json.get('status')
+            self.assertIsNotNone(status)
+            self.assertIn(status, ['RUNNING', 'FAILED'])
 
     @testmode.standalone
     def test_manifest_files(self):

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -4,7 +4,6 @@ from unittest import mock
 
 import os
 
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -9,7 +9,6 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss.util.email
-from dss import Replica
 from tests.infra import testmode
 from dss import Replica
 

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -4,11 +4,13 @@ from unittest import mock
 
 import os
 
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss.util.email
 from tests.infra import testmode
+from dss import Replica
 
 
 class TestEmail(unittest.TestCase):
@@ -32,7 +34,7 @@ class TestEmail(unittest.TestCase):
     @mock.patch('dss.util.email.send_email')
     def test_send_checkout_success_email(self, send_email_func):
         send_email_func.return_value = 'Success'
-        dss.util.email.send_checkout_success_email('sender', 'to', 'bucket', 'location')
+        dss.util.email.send_checkout_success_email('sender', 'to', 'bucket', 'location', Replica.aws)
 
         args, kwargs = send_email_func.call_args
         self.assertEqual(args[0], 'sender')

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -9,6 +9,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss.util.email
+from dss import Replica
 from tests.infra import testmode
 from dss import Replica
 


### PR DESCRIPTION
Google Cloud for the checkout service. Implementation relies on dss-gs-copy-sfn* step function for file copy and cloud_blobstore as an abstraction layer for the storage access

### Test plan
manual testing:
1. initiate checkout
2. readiness check 
3. get location prefix from email
4. use CLI to confirm validity of the prefix

Extend existing integration tests to GCP implementation
