### PR TITLE
Bump domovoi dependency version

### DIFF
--- a/dss-api
+++ b/dss-api
@@ -14,6 +14,7 @@ from chalice.cli import CLIFactory, run_local_server
 import dss
 
 parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--host", default="")
 parser.add_argument("--port", type=int, default=5000)
 parser.add_argument("--no-debug", dest="debug", action="store_false",
                     help="Disable Chalice/Connexion/Flask debug mode")
@@ -36,8 +37,6 @@ factory = CLIFactory(project_dir=args.project_dir, debug=args.debug)
 config = factory.create_config_obj(
     chalice_stage_name=os.environ["DSS_DEPLOYMENT_STAGE"]
 )
-# TODO: Remove this hack when https://github.com/aws/chalice/pull/579 is pulled into our repo.
-config._user_provided_params['lambda_timeout'] = 30000
 app_obj = factory.load_chalice_app()
 # When running `chalice local`, a stdout logger is configured
 # so you'll see the same stdout logging as you would when
@@ -47,5 +46,5 @@ app_obj = factory.load_chalice_app()
 # FIXME: (hannes) I don't think this works. basicConfig() only does anything if there aren't any handlers, so a second
 # invocation is usually pointless unless something removed all handlers in between.
 logging.basicConfig(stream=sys.stdout)
-server = factory.create_local_server(app_obj, config, args.port)
+server = factory.create_local_server(app_obj=app_obj, config=config, host=args.host, port=args.port)
 server.serve_forever()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ botocore==1.8.3
 cachetools==2.0.1
 certifi==2018.1.18
 cffi==1.11.2
-chalice==1.0.4
+chalice==1.1.0
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
@@ -25,7 +25,7 @@ cryptography==2.1.4
 docker==2.6.1
 docker-pycreds==0.2.1
 docutils==0.14
-domovoi==1.4.5
+domovoi==1.5.3
 elasticsearch==5.5.1
 elasticsearch-dsl==5.3.0
 Faker==0.8.11

--- a/requirements-dev.txt.in
+++ b/requirements-dev.txt.in
@@ -1,8 +1,8 @@
 # Be sure to run "make requirements-dev.txt" after editing this file.
 flake8  >= 3.4.1
 mypy  >= 0.530
-domovoi  >= 1.4.5
-chalice  >= 1.0.3
+domovoi  >= 1.5.3
+chalice  >= 1.1.0
 coverage  >= 4.4.1
 awscli  >= 1.11.166
 moto  >= 1.1.21

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -48,7 +48,7 @@ class ThreadedLocalServer(threading.Thread):
 
         config = chalice.config.Config.create(lambda_timeout=self._chalice_app._override_exptime_seconds)
 
-        self._server = LocalDevServer(self._chalice_app, config, self._port, handler_cls=SilentHandler)
+        self._server = LocalDevServer(self._chalice_app, config, host="", port=self._port, handler_cls=SilentHandler)
         self._server_ready.set()
         self._server.server.serve_forever()
 


### PR DESCRIPTION
This is required to pull in a fix in domovoi that should avoid triggering a Lambda CreateAlias API call error limit when creating aliases for step function states. We see this error sporadically causing failed deployments.