### PR TITLE
Allow multi-version-schema bundles to be indexed

### DIFF
--- a/dss/index/es/document.py
+++ b/dss/index/es/document.py
@@ -236,8 +236,7 @@ class BundleDocument(IndexDocument):
             schema_info = SchemaInfo.from_json(file_content)
             if schema_info is not None:
                 key_name = file_name.split('_')[0]
-                v_major, _, _ = schema_info.version.split('.')
-                schema_version_list.append((key_name, v_major))
+                schema_version_list.append((key_name, schema_info.version))
             else:
                 logger.warning(f"Unable to obtain JSON schema info from file '{file_name}'. The file will be indexed "
                                f"as is, without sanitization. This may prevent subsequent, valid files from being "

--- a/dss/index/es/document.py
+++ b/dss/index/es/document.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import ipaddress
 import json
 import logging
@@ -231,21 +230,25 @@ class BundleDocument(IndexDocument):
         This should be an extension point that is customizable by other projects according to
         their metadata.
         """
-        schema_version_map = defaultdict(set)  # type: typing.MutableMapping[str, typing.MutableSet[str]]
+        schema_version_list = list()  # type: typing.MutableSequence[typing.Tuple[str, str]]
         for file_name, file_content in self.files.items():
+            assert file_name.endswith('_json')
             schema_info = SchemaInfo.from_json(file_content)
             if schema_info is not None:
-                schema_version_map[schema_info.version].add(schema_info.type)
+                key_name = file_name.split('_')[0]
+                v_major, _, _ = schema_info.version.split('.')
+                schema_version_list.append((key_name, v_major))
             else:
                 logger.warning(f"Unable to obtain JSON schema info from file '{file_name}'. The file will be indexed "
                                f"as is, without sanitization. This may prevent subsequent, valid files from being "
                                f"indexed correctly.")
 
-        if schema_version_map:
-            schema_versions = schema_version_map.keys()
-            assert len(schema_versions) == 1, \
-                "The bundle contains mixed schema major version numbers: {}".format(sorted(list(schema_versions)))
-            return "v" + list(schema_versions)[0]
+        if schema_version_list:
+            schema_version_list = sorted(schema_version_list, key=lambda e: e[0])
+            if 1 == len(set(e[1] for e in schema_version_list)):
+                return 'v' + schema_version_list[0][1]
+            else:
+                return 'v-' + '-'.join([e[0]+e[1] for e in schema_version_list])
         else:
             return None  # No files with schema identifiers were found
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -508,10 +508,11 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             self.assertEqual(index_document.get_shape_descriptor(), "v3")
 
         index_document['files']['assay_json']['core']['schema_version'] = "4.0.0"
-        with self.subTest("Mixed/inconsistent metadata schema release versions in the same bundle"):
-            with self.assertRaisesRegex(AssertionError,
-                                        "The bundle contains mixed schema major version numbers: \['3', '4'\]"):
-                index_document.get_shape_descriptor()
+#        xbrianh hack: Allow mixed schema version for HCA "integration day" breakout 6-March, 2018
+#        with self.subTest("Mixed/inconsistent metadata schema release versions in the same bundle"):
+#            with self.assertRaisesRegex(AssertionError,
+#                                        "The bundle contains mixed schema major version numbers: \['3', '4'\]"):
+#                index_document.get_shape_descriptor()
 
         index_document['files']['sample_json']['core']['schema_version'] = "4.0.0"
         with self.subTest("Consistent versions, with a different version value"):
@@ -548,10 +549,11 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
 
         v4_assay_url = "http://schema.humancellatlas.org/module/4.0.0/assay.json"
         index_document['files']['assay_json']['describedBy'] = v4_assay_url
-        with self.subTest("Mixed/inconsistent metadata schema release versions in the same bundle"):
-            with self.assertRaisesRegex(AssertionError,
-                                        "The bundle contains mixed schema major version numbers: \['4', '5'\]"):
-                index_document.get_shape_descriptor()
+#        xbrianh hack: Allow mixed schema version for HCA "integration day" breakout 6-March, 2018
+#        with self.subTest("Mixed/inconsistent metadata schema release versions in the same bundle"):
+#            with self.assertRaisesRegex(AssertionError,
+#                                        "The bundle contains mixed schema major version numbers: \['4', '5'\]"):
+#                index_document.get_shape_descriptor()
 
         v4_sample_url = "http://schema.humancellatlas.org/module/4.0.0/sample.json"
         index_document['files']['sample_json']['describedBy'] = v4_sample_url


### PR DESCRIPTION
This is a lightly tested PR to allow integration day efforts (6-March, 2018) to move forward with the most reason meta data bundle example, which involves files of mixed schema versions.

This commit may subsequently be reverted upon completion of integration testing. Alternatively, unit tests may be brought up to date with new ES index names.

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
