### PR TITLE
Probabilistically return Retry-after header in GET /files/<uuid> request

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -161,6 +161,13 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
+        301:
+          description: Handle asynchronously, downstream users are expected to retry later.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users are expected to retry after the delay.
+              type: integer
+              format: int64
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: |
@@ -190,6 +197,13 @@ paths:
           type: string
           format: date-time
       responses:
+        301:
+          description: Handle asynchronously, downstream users are expected to retry later.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users are expected to retry after the delay.
+              type: integer
+              format: int64
         302:
           description: Redirects to a signed URL with the data.
           headers:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -161,13 +161,6 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
-        301:
-          description: Handle asynchronously, downstream users are expected to retry later.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users are expected to retry after the delay.
-              type: integer
-              format: int64
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: |

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -75,11 +75,11 @@ def get_helper(uuid: str, replica: Replica, version: str=None):
     ))
 
     if request.method == "GET":
-        '''
+        """
         Probabilistically return "Retry-After" header
         The retry-after interval can be relatively short now, but it sets up downstream
         libraries / users for success when we start integrating this with the checkout service.
-        '''
+        """
         if random.randint(0, 100) < REDIRECT_PROBABILITY_PERCENTS:
             response = redirect(request.url, code=301)
             headers = response.headers

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -23,6 +23,13 @@ from dss.util.aws import AWS_MIN_CHUNK_SIZE
 ASYNC_COPY_THRESHOLD = AWS_MIN_CHUNK_SIZE
 """This is the maximum file size that we will copy synchronously."""
 
+"""The retry-after interval in seconds. Sets up downstream libraries / users to
+retry request after the specified interval."""
+RETRY_AFTER_INTERVAL = 3
+
+"""Probability of the 301 redirect with Retry-After header. This is a temporary measure, sets up downstream
+libraries / users for success when we start integrating this with the checkout service. """
+REDIRECT_PROBABILITY = 5
 
 @dss_handler
 def head(uuid: str, replica: str, version: str=None):
@@ -37,17 +44,6 @@ def get(uuid: str, replica: str, version: str=None):
 def get_helper(uuid: str, replica: Replica, version: str=None):
     handle = Config.get_blobstore_handle(replica)
     bucket = replica.bucket
-
-    '''
-    Probabilistically return "Retry-after" header
-    The retry-after interval can be relatively short now, but it sets up downstream libraries / users for success when
-    we start integrating this with the checkout service.
-    '''
-    if random.randint(0, 100) < 5:
-        response = make_response('', 301)
-        headers = response.headers
-        headers['Retry-After'] = 5
-        return response
 
     if version is None:
         # list the files and find the one that is the most recent.
@@ -70,6 +66,17 @@ def get_helper(uuid: str, replica: Replica, version: str=None):
             ).decode("utf-8"))
     except BlobNotFoundError as ex:
         raise DSSException(404, "not_found", "Cannot find file!")
+
+    '''
+    Probabilistically return "Retry-after" header
+    The retry-after interval can be relatively short now, but it sets up downstream libraries / users for success when
+    we start integrating this with the checkout service.
+    '''
+    if random.randint(0, 100) < REDIRECT_PROBABILITY:
+        response = redirect(request.url, code=301)
+        headers = response.headers
+        headers['Retry-After'] = RETRY_AFTER_INTERVAL
+        return response
 
     blob_path = "blobs/" + ".".join((
         file_metadata[FileMetadata.SHA256],

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -1,6 +1,7 @@
 import datetime
 import io
 import json
+import random
 import re
 import typing
 from enum import Enum, auto
@@ -36,6 +37,17 @@ def get(uuid: str, replica: str, version: str=None):
 def get_helper(uuid: str, replica: Replica, version: str=None):
     handle = Config.get_blobstore_handle(replica)
     bucket = replica.bucket
+
+    '''
+    Probabilistically return "Retry-after" header
+    The retry-after interval can be relatively short now, but it sets up downstream libraries / users for success when
+    we start integrating this with the checkout service.
+    '''
+    if random.randint(0, 100) < 5:
+        response = make_response('', 301)
+        headers = response.headers
+        headers['Retry-After'] = 5
+        return response
 
     if version is None:
         # list the files and find the one that is the most recent.

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -163,7 +163,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         with override_bucket_config(BucketConfig.TEST_FIXTURE):
             self.assertHeadResponse(
                 url,
-                requests.codes.ok
+                [requests.codes.ok, requests.codes.moved]
             )
 
             # TODO: (ttung) verify headers

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -11,6 +11,7 @@ import typing
 import unittest
 import uuid
 
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -22,6 +23,11 @@ from dss.util.version import datetime_to_version_format
 from tests.fixtures.cloud_uploader import GSUploader, S3Uploader, Uploader
 from tests.infra import DSSAssertMixin, DSSUploadMixin, ExpectedErrorFields, get_env, generate_test_key, testmode
 from tests.infra.server import ThreadedLocalServer
+from dss.api.files import RETRY_AFTER_INTERVAL
+
+
+# Max number of retries
+FILE_GET_RETRY_COUNT = 10
 
 
 class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
@@ -185,24 +191,31 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .add_query("replica", replica.name)
                   .add_query("version", version))
 
-        with override_bucket_config(BucketConfig.TEST_FIXTURE):
-            resp_obj = self.assertGetResponse(
-                url,
-                requests.codes.found
-            )
+        for i in range(FILE_GET_RETRY_COUNT):
+            with override_bucket_config(BucketConfig.TEST_FIXTURE):
+                resp_obj = self.assertGetResponse(
+                    url,
+                    [requests.codes.found, requests.codes.moved]
+                )
+                if resp_obj.response.status_code == requests.codes.found:
+                    url = resp_obj.response.headers['Location']
+                    sha1 = resp_obj.response.headers['X-DSS-SHA1']
+                    data = requests.get(url)
+                    self.assertEqual(len(data.content), 11358)
+                    self.assertEqual(resp_obj.response.headers['X-DSS-SIZE'], '11358')
 
-            url = resp_obj.response.headers['Location']
-            sha1 = resp_obj.response.headers['X-DSS-SHA1']
-            data = requests.get(url)
-            self.assertEqual(len(data.content), 11358)
-            self.assertEqual(resp_obj.response.headers['X-DSS-SIZE'], '11358')
+                    # verify that the downloaded data matches the stated checksum
+                    hasher = hashlib.sha1()
+                    hasher.update(data.content)
+                    self.assertEqual(hasher.hexdigest(), sha1)
 
-            # verify that the downloaded data matches the stated checksum
-            hasher = hashlib.sha1()
-            hasher.update(data.content)
-            self.assertEqual(hasher.hexdigest(), sha1)
-
-            # TODO: (ttung) verify more of the headers
+                    # TODO: (ttung) verify more of the headers
+                    return
+                elif resp_obj.response.status_code == requests.codes.moved:
+                    retryAfter = int(resp_obj.response.headers['Retry-After'])
+                    self.assertEqual(retryAfter, RETRY_AFTER_INTERVAL)
+                    self.assertIn(url, resp_obj.response.headers['Location'])
+        self.fail(f"Failed after {FILE_GET_RETRY_COUNT} retries.")
 
     @testmode.standalone
     def test_file_get_latest(self):
@@ -219,24 +232,31 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .set(path="/v1/files/" + file_uuid)
                   .add_query("replica", replica.name))
 
-        with override_bucket_config(BucketConfig.TEST_FIXTURE):
-            resp_obj = self.assertGetResponse(
-                url,
-                requests.codes.found
-            )
+        for i in range(FILE_GET_RETRY_COUNT):
+            with override_bucket_config(BucketConfig.TEST_FIXTURE):
+                resp_obj = self.assertGetResponse(
+                    url,
+                    [requests.codes.found, requests.codes.moved]
+                )
+                if resp_obj.response.status_code == requests.codes.found:
+                    url = resp_obj.response.headers['Location']
+                    sha1 = resp_obj.response.headers['X-DSS-SHA1']
+                    data = requests.get(url)
+                    self.assertEqual(len(data.content), 8685)
+                    self.assertEqual(resp_obj.response.headers['X-DSS-SIZE'], '8685')
 
-            url = resp_obj.response.headers['Location']
-            sha1 = resp_obj.response.headers['X-DSS-SHA1']
-            data = requests.get(url)
-            self.assertEqual(len(data.content), 8685)
-            self.assertEqual(resp_obj.response.headers['X-DSS-SIZE'], '8685')
+                    # verify that the downloaded data matches the stated checksum
+                    hasher = hashlib.sha1()
+                    hasher.update(data.content)
+                    self.assertEqual(hasher.hexdigest(), sha1)
 
-            # verify that the downloaded data matches the stated checksum
-            hasher = hashlib.sha1()
-            hasher.update(data.content)
-            self.assertEqual(hasher.hexdigest(), sha1)
-
-            # TODO: (ttung) verify more of the headers
+                    # TODO: (ttung) verify more of the headers
+                    return
+                elif resp_obj.response.status_code == requests.codes.moved:
+                    retryAfter = int(resp_obj.response.headers['Retry-After'])
+                    self.assertEqual(retryAfter, RETRY_AFTER_INTERVAL)
+                    self.assertIn(url, resp_obj.response.headers['Location'])
+        self.fail(f"Failed after {FILE_GET_RETRY_COUNT} retries.")
 
     @testmode.standalone
     def test_file_get_not_found(self):
@@ -330,16 +350,23 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                   .set(path="/v1/files/" + file_uuid)
                   .add_query("replica", replica.name))
 
-        with override_bucket_config(BucketConfig.TEST):
-            resp_obj = self.assertGetResponse(
-                url,
-                requests.codes.found
-            )
-
-            url = resp_obj.response.headers['Location']
-            data = requests.get(url)
-            self.assertEqual(len(data.content), src_size)
-            self.assertEqual(resp_obj.response.headers['X-DSS-SIZE'], str(src_size))
+        for i in range(FILE_GET_RETRY_COUNT):
+            with override_bucket_config(BucketConfig.TEST):
+                resp_obj = self.assertGetResponse(
+                    url,
+                    [requests.codes.found, requests.codes.moved]
+                )
+                if resp_obj.response.status_code == requests.codes.found:
+                    url = resp_obj.response.headers['Location']
+                    data = requests.get(url)
+                    self.assertEqual(len(data.content), src_size)
+                    self.assertEqual(resp_obj.response.headers['X-DSS-SIZE'], str(src_size))
+                    return
+                elif resp_obj.response.status_code == requests.codes.moved:
+                    retryAfter = int(resp_obj.response.headers['Retry-After'])
+                    self.assertEqual(retryAfter, RETRY_AFTER_INTERVAL)
+                    self.assertIn(url, resp_obj.response.headers['Location'])
+        self.fail(f"Failed after {FILE_GET_RETRY_COUNT} retries.")
 
     def upload_file(
             self: typing.Any,


### PR DESCRIPTION
Probabilistically return "Retry-after" header. The retry-after interval can be relatively short now, but it sets up downstream libraries / users for success when we start integrating this with the checkout service.
### Test plan

- [x] Update all unit tests related to Files Get/Head
- [ ] Test with browsers and other http clients
- [x] Update HCA CLI retry, test with CLI