### PR TITLE
Simplify how test, lint and mypy targets interact [alternative A]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 include common.mk
 MODULES=dss tests
 
+# Run all standalone tests in parallel
+#
+test: mypy lint $(tests)
+	coverage combine
+	rm -f .coverage.*
+
 lint:
 	flake8 $(MODULES) chalice/*.py daemons/*/*.py
 
@@ -14,12 +20,6 @@ serial_tests:=tests/test_search.py \
               tests/test_indexer.py \
               tests/test_subscriptions.py
 parallel_tests:=$(filter-out $(serial_tests),$(tests))
-
-# Run all standalone tests in parallel
-#
-test: mypy lint $(tests)
-	coverage combine
-	rm -f .coverage.*
 
 # Serialize the standalone tests that start a local Elasticsearch instance in
 # order to prevent more than one such instance at a time.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ MODULES=dss tests
 
 # Run all standalone tests in parallel
 #
-test: mypy lint $(tests)
+test: $(tests)
 	coverage combine
 	rm -f .coverage.*
 
@@ -24,18 +24,18 @@ parallel_tests:=$(filter-out $(serial_tests),$(tests))
 # Serialize the standalone tests that start a local Elasticsearch instance in
 # order to prevent more than one such instance at a time.
 #
-safe_test: mypy lint serial_test parallel_test
+safe_test: serial_test parallel_test
 	coverage combine
 	rm -f .coverage.*
 
-parallel_test: mypy lint $(parallel_tests)
+parallel_test: $(parallel_tests)
 
 serial_test:
 	$(MAKE) -j1 $(serial_tests)
 
 # A pattern rule that runs a single test script
 #
-$(tests): %.py :
+$(tests): %.py : mypy lint
 	coverage run -p --source=dss $*.py $(DSS_UNITTEST_OPTS)
 
 # Run standalone and integration tests


### PR DESCRIPTION
Follow up on https://github.com/HumanCellAtlas/data-store/pull/1055

I don't like how some test targets depend on mypy and lint while others don't. This is the first of two alternative proposals.

It ensures that mypy and lint are run once before any test is run.