### PR TITLE
Simplify how test, lint and mypy targets interact [alternative B]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
   include:
   - stage: test
     env:
-    - MAKE_ARGS="-j4 parallel_test"
+    - MAKE_ARGS="-j4 mypy lint parallel_test"
   - stage: test
     env:
     - MAKE_ARGS="-j1 tests/test_search.py"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 include common.mk
 MODULES=dss tests
 
+all: test
+
 lint:
 	flake8 $(MODULES) chalice/*.py daemons/*/*.py
 
@@ -102,5 +104,5 @@ requirements.txt requirements-dev.txt : %.txt : %.txt.in
 
 requirements-dev.txt : requirements.txt.in
 
-.PHONY: lint mypy test safe_test _serial_test all_test integration_test smoketest $(tests)
+.PHONY: all lint mypy test safe_test _serial_test all_test integration_test smoketest $(tests)
 .PHONY: deploy deploy-chalice deploy-daemons

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include common.mk
 MODULES=dss tests
 
-all: test
+all: mypy lint test
 
 lint:
 	flake8 $(MODULES) chalice/*.py daemons/*/*.py
@@ -19,18 +19,18 @@ parallel_tests:=$(filter-out $(serial_tests),$(tests))
 
 # Run all standalone tests in parallel
 #
-test: mypy lint $(tests)
+test: $(tests)
 	coverage combine
 	rm -f .coverage.*
 
 # Serialize the standalone tests that start a local Elasticsearch instance in
 # order to prevent more than one such instance at a time.
 #
-safe_test: mypy lint serial_test parallel_test
+safe_test: serial_test parallel_test
 	coverage combine
 	rm -f .coverage.*
 
-parallel_test: mypy lint $(parallel_tests)
+parallel_test: $(parallel_tests)
 
 serial_test:
 	$(MAKE) -j1 $(serial_tests)


### PR DESCRIPTION
Follow up on https://github.com/HumanCellAtlas/data-store/pull/1055

I don't like how some test targets depend on mypy and lint while others don't. This is the second of two alternative proposals.

It completely decouples test, lint and mypy but makes sure that Travis runs all three and adds a default `all` target that does the same.