### PR TITLE
Move json_gen to a shared location; run import test on all daemons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,11 @@ parallel_tests:=$(filter-out $(serial_tests),$(tests))
 
 # Run all standalone tests in parallel
 #
-test: $(tests)
+test: $(tests) daemon-import-test
 	coverage combine
 	rm -f .coverage.*
+
+daemon-import-test:
 	$(MAKE) -C daemons import-test
 
 # Serialize the standalone tests that start a local Elasticsearch instance in
@@ -31,7 +33,7 @@ safe_test: serial_test parallel_test
 	coverage combine
 	rm -f .coverage.*
 
-parallel_test: $(parallel_tests)
+parallel_test: $(parallel_tests) daemon-import-test
 
 serial_test:
 	$(MAKE) -j1 $(serial_tests)
@@ -105,5 +107,5 @@ requirements.txt requirements-dev.txt : %.txt : %.txt.in
 
 requirements-dev.txt : requirements.txt.in
 
-.PHONY: all lint mypy test safe_test _serial_test all_test integration_test smoketest $(tests)
+.PHONY: all lint mypy test safe_test _serial_test all_test integration_test smoketest daemon-import-test $(tests)
 .PHONY: deploy deploy-chalice deploy-daemons

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ parallel_tests:=$(filter-out $(serial_tests),$(tests))
 test: $(tests)
 	coverage combine
 	rm -f .coverage.*
+	$(MAKE) -C daemons import-test
 
 # Serialize the standalone tests that start a local Elasticsearch instance in
 # order to prevent more than one such instance at a time.

--- a/daemons/Makefile
+++ b/daemons/Makefile
@@ -2,7 +2,7 @@ include ../common.mk
 
 SERIAL_AWS_DAEMONS := \
 	dss-sync \
-	dss-index \
+	dss-index
 
 SERIAL_GCP_DAEMONS :=
 
@@ -14,6 +14,7 @@ PARALLEL_AWS_DAEMONS := \
 	dss-s3-copy-sfn \
 	dss-s3-copy-write-metadata-sfn \
 	dss-visitation \
+	dss-scalability-test
 
 PARALLEL_GCP_DAEMONS := \
 	dss-gs-event-relay
@@ -23,29 +24,26 @@ deploy-serial: $(SERIAL_AWS_DAEMONS) $(SERIAL_GCP_DAEMONS)
 deploy-parallel: $(PARALLEL_AWS_DAEMONS) $(PARALLEL_GCP_DAEMONS)
 
 $(SERIAL_AWS_DAEMONS) $(PARALLEL_AWS_DAEMONS) scheduled-ci-build:
-	git clean -df $@/domovoilib $@/vendor
-	shopt -s nullglob; for wheel in $@/vendor.in/*/*.whl; do unzip -q -o -d $@/vendor $$wheel; done
-	cp -R ../dss ../dss-api.yml $@/domovoilib
-	@if [[ $@ == "dss-scalability-test" ]]; then \
-	    mkdir -p $@/domovoilib/tests; \
-        cp -R ../tests/scalability/ $@/domovoilib/tests/scalability; \
-        $(DSS_HOME)/scripts/deploy_scale_dashboard.py; \
-        $(DSS_HOME)/scripts/deploy_scale_tables.py; \
-	fi
-	cp "$(GOOGLE_APPLICATION_CREDENTIALS)" $@/domovoilib/gcp-credentials.json
-	chmod -R ugo+rX $@/domovoilib
+	./build_daemon.sh $@
 	./build_deploy_config.sh $@
 	cd $@; domovoi deploy --stage $(DSS_DEPLOYMENT_STAGE)
 	@if [[ $@ == "dss-sync" || $@ == "dss-index" ]]; then \
-		./invoke_lambda.sh $@ $(DSS_DEPLOYMENT_STAGE) \
-			../tests/daemons/sample_s3_bundle_created_event.json.template \
-			../tests/daemons/a47b90b2-0967-4fbf-87bc-c6c12db3fedf.2017-07-12T055120.037644Z; \
-	fi
+            ./invoke_lambda.sh $@ $(DSS_DEPLOYMENT_STAGE) \
+            ../tests/daemons/sample_s3_bundle_created_event.json.template \
+            ../tests/daemons/a47b90b2-0967-4fbf-87bc-c6c12db3fedf.2017-07-12T055120.037644Z; \
+        fi
 	@if [[ $@ == "dss-s3-copy-sfn" || %@ == "dss-s3-copy-write-metadata-sfn" || $@ == "dss-checkout" || $@ == "dss-scalability-test" ]]; then \
-	    $(DSS_HOME)/scripts/deploy_checkout_lifecycle.py; \
-	fi
+            $(DSS_HOME)/scripts/deploy_checkout_lifecycle.py; \
+        fi
 
 dss-gs-event-relay:
 	$(DSS_HOME)/scripts/deploy_gcf.py $@ --entry-point "dss_gs_bucket_events_$(subst -,_,$(DSS_GS_BUCKET))"
 
-.PHONY: deploy deploy-serial deploy-parallel scheduled-ci-build $(SERIAL_AWS_DAEMONS) $(SERIAL_GCP_DAEMONS) $(PARALLEL_AWS_DAEMONS) $(PARALLEL_GCP_DAEMONS)
+import-test:
+	set -e; \
+        for daemon in $(SERIAL_AWS_DAEMONS) $(PARALLEL_AWS_DAEMONS); do \
+            ./package_daemon.sh $$daemon; \
+            python $$daemon/app.py; \
+        done
+
+.PHONY: deploy deploy-serial deploy-parallel scheduled-ci-build import-test $(SERIAL_AWS_DAEMONS) $(SERIAL_GCP_DAEMONS) $(PARALLEL_AWS_DAEMONS) $(PARALLEL_GCP_DAEMONS)

--- a/daemons/build_deploy_config.sh
+++ b/daemons/build_deploy_config.sh
@@ -62,3 +62,8 @@ if [[ -f $iam_policy_template ]]; then
     cat "$iam_policy_template" | envsubst '$DSS_S3_BUCKET $DSS_S3_BUCKET_TEST $DSS_S3_BUCKET_TEST_FIXTURES $DSS_S3_CHECKOUT_BUCKET $DSS_S3_CHECKOUT_BUCKET_TEST $dss_es_domain $account_id $stage' > "$policy_json"
     cp "$policy_json" "$stage_policy_json"
 fi
+
+if [[ $daemon_name == "dss-scalability-test" ]]; then
+    $DSS_HOME/scripts/deploy_scale_dashboard.py
+    $DSS_HOME/scripts/deploy_scale_tables.py
+fi

--- a/daemons/dss-scalability-test/domovoilib/json_generator/__init__.py
+++ b/daemons/dss-scalability-test/domovoilib/json_generator/__init__.py
@@ -2,7 +2,7 @@ import json
 import random
 import string
 
-from tests.json_gen.hca_generator import HCAJsonGenerator
+from dss.util.json_gen.hca_generator import HCAJsonGenerator
 
 
 def id_generator(size=30, chars=string.ascii_uppercase + string.digits):

--- a/daemons/dss-scalability-test/domovoilib/json_generator/__init__.py
+++ b/daemons/dss-scalability-test/domovoilib/json_generator/__init__.py
@@ -16,8 +16,10 @@ schema_urls = [
     "https://schema.humancellatlas.org/bundle/5.1.0/protocol"
 ]
 
-json_faker = HCAJsonGenerator(schema_urls)
-
+json_faker = None
 
 def generate_sample() -> str:
+    global json_faker
+    if json_faker is None:
+        json_faker = HCAJsonGenerator(schema_urls)
     return json_faker.generate()

--- a/daemons/package_daemon.sh
+++ b/daemons/package_daemon.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# != 1 ]]; then
+    echo "Usage: $(basename $0) daemon-name"
+    exit 1
+fi
+
+if [[ -z $DSS_DEPLOYMENT_STAGE ]]; then
+    echo 'Please run "source environment" in the data-store repo root directory before running this command'
+    exit 1
+fi
+
+daemon=$1
+
+echo "Running pre-packaging steps for $daemon"
+
+git clean -df $daemon/domovoilib $daemon/vendor
+
+shopt -s nullglob
+for wheel in $daemon/vendor.in/*/*.whl; do
+    unzip -q -o -d $daemon/vendor $wheel
+done
+
+cp -R ../dss ../dss-api.yml $daemon/domovoilib
+
+if [[ $daemon == "dss-scalability-test" ]]; then
+    mkdir -p $daemon/domovoilib/tests
+    $DSS_HOME/scripts/deploy_scale_dashboard.py
+    $DSS_HOME/scripts/deploy_scale_tables.py
+fi
+
+cp "$GOOGLE_APPLICATION_CREDENTIALS" $daemon/domovoilib/gcp-credentials.json
+chmod -R ugo+rX $daemon/domovoilib

--- a/daemons/package_daemon.sh
+++ b/daemons/package_daemon.sh
@@ -25,11 +25,5 @@ done
 
 cp -R ../dss ../dss-api.yml $daemon/domovoilib
 
-if [[ $daemon == "dss-scalability-test" ]]; then
-    mkdir -p $daemon/domovoilib/tests
-    $DSS_HOME/scripts/deploy_scale_dashboard.py
-    $DSS_HOME/scripts/deploy_scale_tables.py
-fi
-
 cp "$GOOGLE_APPLICATION_CREDENTIALS" $daemon/domovoilib/gcp-credentials.json
 chmod -R ugo+rX $daemon/domovoilib

--- a/dss/util/json_gen/generator.py
+++ b/dss/util/json_gen/generator.py
@@ -1,9 +1,10 @@
 import random
+from typing import Union, List, Optional
+
 import rstr
 from faker import Faker
 from faker.providers.python import Provider as PythonProvider
 from jsonschema import RefResolver, Draft4Validator
-from typing import Union, List, Optional
 
 
 class JsonProvider(PythonProvider):

--- a/dss/util/json_gen/hca_generator.py
+++ b/dss/util/json_gen/hca_generator.py
@@ -4,7 +4,7 @@ import random
 from jsonschema import RefResolver
 
 from dss.util.s3urlcache import S3UrlCache
-from tests.json_gen.generator import JsonGenerator
+from dss.util.json_gen.generator import JsonGenerator
 
 
 class HCAJsonGenerator(object):

--- a/tests/test_hcagenerator.py
+++ b/tests/test_hcagenerator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import json
 import os
 import sys
@@ -7,7 +9,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 from dss import Config, BucketConfig
-from tests.json_gen.hca_generator import HCAJsonGenerator
+from dss.util.json_gen.hca_generator import HCAJsonGenerator
 from tests.infra import testmode
 
 schema_urls = [

--- a/tests/test_jsongenerator.py
+++ b/tests/test_jsongenerator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import json
 import os
 import sys
@@ -11,7 +13,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 from tests.infra import testmode
-from tests.json_gen.generator import JsonGenerator, JsonProvider
+from dss.util.json_gen.generator import JsonGenerator, JsonProvider
 
 type_mapping = {'string': str,
                 'object': dict,


### PR DESCRIPTION
- Move `tests/json_gen` to `dss/util`
- Factor out the daemon pre-packaging staging steps into a shell script
- Introduce a new test built into a make target, `import-test`, that runs the pre-packaging staging steps and then parses the daemon entry point, to make sure code reachable at import time from daemon entry points is runnable

Fixes #1072
Reverts https://github.com/HumanCellAtlas/data-store/commit/ae6e74194f31dc5365167c1b441fb175163c010f

Tested manually.