### PR TITLE
fixed logging from lambdas by add logger name 'app'

### DIFF
--- a/dss/logging.py
+++ b/dss/logging.py
@@ -13,6 +13,7 @@ log_level_t = Mapping[Union[None, str, logging.Logger], Tuple[int, ...]]
 main_log_levels: log_level_t = {
     None: (WARNING, INFO, DEBUG),
     dss.logger: (INFO, DEBUG),
+    'app': (INFO, DEBUG),
     'botocore.vendored.requests.packages.urllib3.connectionpool': (WARNING, WARNING, DEBUG)
 }
 """


### PR DESCRIPTION
## Testing
Ran smoke test before change and verified logs from dss-sync where not present.
Ran smoke test  after change and verified logs from dss-sync lambda function were present.
```[INFO]	2018-04-03T23:16:56.428Z	1a2a61b5-3795-11e8-b3f5-073ab1df4c00	Copying blobs/190a817c2f89732021d118945cb2f1629bb778957601cca9858da04d4b397609.778911c46874cd319dd1ceb75a27727a546d24d6.16a405357a4b5ff8d85a261294d51e00-2.68ba65c9:{'id': 1, 'start': 0, 'end': 67108864, 'total_parts': 1} from s3://dss-tsmith1 to gs://dss-tsmith1```