### PR TITLE
Set default logging level to INFO

### DIFF
--- a/dss/logging.py
+++ b/dss/logging.py
@@ -62,7 +62,7 @@ def configure_test_logging():
 
 def _configure_logging(test=False, **kwargs):
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.WARNING)
+    root_logger.setLevel(logging.INFO)
     if 'AWS_LAMBDA_LOG_GROUP_NAME' in os.environ:
         pass  # On AWS Lambda, we assume that its runtime already configured logging as appropriate
     elif len(root_logger.handlers) == 0:


### PR DESCRIPTION
<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->
## Why?
Logs of requests to the DSS API are not currently showing up in CloudWatch Logs. We need these logs for debugging and analytics.

## What?
The default log level seems to be warning. Given that the order of logging levels is `ALL < DEBUG < INFO < WARN < ERROR < FATAL < OFF`, we will not recover the `INFO`-level API logs in CloudWatch Logs. This PR sets the default to `INFO`.

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
