### PR TITLE
Configure chalice apps with lambda logging config

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -1,7 +1,6 @@
 import collections
 import datetime
 import functools
-import logging
 import os
 import random
 import re
@@ -18,12 +17,15 @@ import nestedcontext
 import requests
 from flask import json
 
+import dss.logging
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from dss import BucketConfig, Config, DeploymentStage, create_app
 from dss.util import paginate
 
+dss.logging.configure_lambda_logging()
 
 Config.set_config(BucketConfig.NORMAL)
 

--- a/daemons/dss-admin/app.py
+++ b/daemons/dss-admin/app.py
@@ -10,7 +10,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')
 sys.path.insert(0, pkg_root)  # noqa
 
 from dss import BucketConfig, Config, Replica
-from dss.logging import configure_daemon_logging
+from dss.logging import configure_lambda_logging
 from dss.stepfunctions.visitation.reindex import Reindex
 
 
@@ -67,5 +67,5 @@ class DSSAdmin(domovoi.Domovoi):
         result = _invoke(action, options)
         return json.dumps(result)
 
-configure_daemon_logging()
+configure_lambda_logging()
 app = DSSAdmin(configure_logs=False)

--- a/daemons/dss-checkout-sfn/app.py
+++ b/daemons/dss-checkout-sfn/app.py
@@ -9,7 +9,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss.config import Replica
-from dss.logging import configure_daemon_logging
+from dss.logging import configure_lambda_logging
 
 from dss.stepfunctions.checkout.checkout_states import state_machine_def
 from dss.util.email import send_checkout_success_email, send_checkout_failure_email
@@ -19,7 +19,7 @@ from dss.storage.checkout import (parallel_copy, get_dst_bundle_prefix, get_mani
 
 logger = logging.getLogger(__name__)
 
-configure_daemon_logging()
+configure_lambda_logging()
 app = domovoi.Domovoi(configure_logs=False)
 
 dss.Config.set_config(dss.BucketConfig.NORMAL)

--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -13,10 +13,10 @@ from dss import Replica
 from dss.index import DEFAULT_BACKENDS
 from dss.index.backend import CompositeIndexBackend
 from dss.index.indexer import Indexer
-from dss.logging import configure_daemon_logging
+from dss.logging import configure_lambda_logging
 
 app = domovoi.Domovoi(configure_logs=False)
-configure_daemon_logging()
+configure_lambda_logging()
 
 dss.Config.set_config(dss.BucketConfig.NORMAL)
 

--- a/daemons/dss-s3-copy-sfn/app.py
+++ b/daemons/dss-s3-copy-sfn/app.py
@@ -6,12 +6,12 @@ import domovoi
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from dss.logging import configure_daemon_logging
+from dss.logging import configure_lambda_logging
 import dss.stepfunctions.s3copyclient as s3copyclient
 import dss.stepfunctions.generator as generator
 
 
-configure_daemon_logging()
+configure_lambda_logging()
 app = domovoi.Domovoi(configure_logs=False)
 
 annotation_processor = generator.StateMachineAnnotationProcessor()

--- a/daemons/dss-s3-copy-write-metadata-sfn/app.py
+++ b/daemons/dss-s3-copy-write-metadata-sfn/app.py
@@ -6,12 +6,12 @@ import domovoi
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from dss.logging import configure_daemon_logging
+from dss.logging import configure_lambda_logging
 import dss.stepfunctions.s3copyclient as s3copyclient
 import dss.stepfunctions.generator as generator
 
 
-configure_daemon_logging()
+configure_lambda_logging()
 app = domovoi.Domovoi(configure_logs=False)
 
 annotation_processor = generator.StateMachineAnnotationProcessor()

--- a/daemons/dss-sync/app.py
+++ b/daemons/dss-sync/app.py
@@ -17,7 +17,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss.logging import configure_daemon_logging
+from dss.logging import configure_lambda_logging
 from dss.events.handlers.sync import sync_blob, compose_gs_blobs, copy_part, parts_per_worker, sns_topics
 from dss.util.aws import ARN, send_sns_msg, clients, resources
 from dss.config import Replica
@@ -25,7 +25,7 @@ from dss.config import Replica
 
 logger = logging.getLogger(__name__)
 
-configure_daemon_logging()
+configure_lambda_logging()
 app = domovoi.Domovoi(configure_logs=False)
 
 dss.Config.set_config(dss.BucketConfig.NORMAL)

--- a/daemons/dss-visitation/app.py
+++ b/daemons/dss-visitation/app.py
@@ -7,11 +7,11 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')
 sys.path.insert(0, pkg_root)  # noqa
 
 from dss import BucketConfig, Config
-from dss.logging import configure_daemon_logging
+from dss.logging import configure_lambda_logging
 from dss.stepfunctions.visitation.implementation import sfn
 
 
-configure_daemon_logging()
+configure_lambda_logging()
 app = domovoi.Domovoi(configure_logs=False)
 Config.set_config(BucketConfig.NORMAL)
 

--- a/daemons/scheduled-ci-build/app.py
+++ b/daemons/scheduled-ci-build/app.py
@@ -7,10 +7,10 @@ import requests
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from dss.logging import configure_daemon_logging
+from dss.logging import configure_lambda_logging
 
 
-configure_daemon_logging()
+configure_lambda_logging()
 app = domovoi.Domovoi(configure_logs=False)
 
 

--- a/dss/logging.py
+++ b/dss/logging.py
@@ -46,7 +46,7 @@ def configure_cli_logging():
     _configure_logging(stream=sys.stderr)
 
 
-def configure_daemon_logging():
+def configure_lambda_logging():
     """
     Prepare logging for use within a AWS Lambda function.
     """


### PR DESCRIPTION
<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->
Lambdas deployed with chalice are not currently configured to emit logs. This PR makes the daemon log configuration general to all lambdas and adds the logging configuration to chalice lambdas.

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
