### PR TITLE
Fix: chalice app logs a scary message during tests

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -17,14 +17,15 @@ import nestedcontext
 import requests
 from flask import json
 
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-import dss.logging
 from dss import BucketConfig, Config, DeploymentStage, create_app
+from dss.logging import configure_lambda_logging
 from dss.util import paginate
 
-dss.logging.configure_lambda_logging()
+configure_lambda_logging()
 
 Config.set_config(BucketConfig.NORMAL)
 

--- a/dss/__init__.py
+++ b/dss/__init__.py
@@ -184,10 +184,15 @@ def create_app():
             'parameter': DSSParameterValidator,
         },
     )
+    # The Flask/Connection app's logger has its own multi-line formatter and configuration. Rather than suppressing
+    # it we let it do its thing, give it a special name and only enable it if DSS_DEBUG > 1. Most of the DSS web
+    # app's logging is done through the DSSChaliceApp.app logger not the Flask app's logger.
+    #
     app.app.logger_name = 'dss.api'
     debug = Config.debug_level() > 0
     app.app.debug = debug
     app.app.logger.info('Flask debug is %s.', 'enabled' if debug else 'disabled')
+
     resolver = RestyResolver("dss.api", collection_endpoint_name="list")
     app.add_api('../dss-api.yml', resolver=resolver, validate_responses=True, arguments=os.environ)
     return app


### PR DESCRIPTION
Some tests start an instance of the API web app. At that time, test logging is already configured and the web app is expected to complain about logging already being configured. We shouldn't log a scary backtrace in that case: https://travis-ci.org/HumanCellAtlas/data-store/jobs/362872052#L713

@mweiden Import style of configure_lambda_logging should be consistent. Feel free to change the style, but please do so consistently across all modules.