### PR TITLE
Reaper circumvention requires json string.

### DIFF
--- a/dss/stepfunctions/__init__.py
+++ b/dss/stepfunctions/__init__.py
@@ -67,7 +67,7 @@ def step_functions_invoke(state_machine_name_template: str, execution_name: str,
 
 
 def _step_functions_start_execution(state_machine_name_template: str, execution_name: str,
-                                    execution_input) -> typing.Any:
+                                    execution_input: str) -> typing.Any:
     """
     Invoke a step functions state machine.  The name of the state machine to be invoked will be derived from
     `state_machine_name_template`, with string formatting to replace {stage} with the dss deployment stage.

--- a/dss/stepfunctions/visitation/__init__.py
+++ b/dss/stepfunctions/visitation/__init__.py
@@ -2,6 +2,7 @@ import logging
 from typing import Sequence, Any, Union
 
 import copy
+import json
 from uuid import uuid4
 from enum import Enum, auto
 
@@ -108,7 +109,7 @@ class Visitation:
             '_number_of_workers': number_of_workers,
         }
         # Invoke directly without reaper/retry
-        _step_functions_start_execution('dss-visitation-{stage}', name, inp)
+        _step_functions_start_execution('dss-visitation-{stage}', name, json.dumps(inp))
 
         return name
 


### PR DESCRIPTION
With the stepfunction DLQ changes, `_step_functions_start_execution` expects a json string for the
`execution_input` parameter.

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
