### PR TITLE
Retry get file blob if not found else raise error (fixes #1115)

### DIFF
--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -47,7 +47,7 @@ def _handle_event(replica, event, context):
     executor = ThreadPoolExecutor(len(DEFAULT_BACKENDS))
     # We can't use ecxecutor as context manager because we don't want the shutdown to block
     try:
-        backend = CompositeIndexBackend(executor, DEFAULT_BACKENDS, timeout=timeout)
+        backend = CompositeIndexBackend(executor, DEFAULT_BACKENDS, timeout=timeout, context=context)
         indexer_cls = Indexer.for_replica(replica)
         indexer = indexer_cls(backend)
         indexer.process_new_indexable_object(event)

--- a/dss/index/backend.py
+++ b/dss/index/backend.py
@@ -83,7 +83,7 @@ class CompositeIndexBackend(IndexBackend):
     def timeout(self):
         """
         The time in which concurrently executed operations have to be completed by all underlying backends. If a
-        backend operation does not complete within the specified timeout, and exceptions will be raised. A value of
+        backend operation does not complete within the specified timeout, an exceptions will be raised. A value of
         None disables the timeout, potentially causing the calling thread to block forever.
         """
         return self._timeout

--- a/dss/index/backend.py
+++ b/dss/index/backend.py
@@ -5,6 +5,7 @@ from abc import ABCMeta, abstractmethod
 from operator import methodcaller
 
 from dss.index.bundle import Bundle, Tombstone
+from dss.util.types import LambdaContext
 
 
 class IndexBackend(metaclass=ABCMeta):
@@ -12,7 +13,7 @@ class IndexBackend(metaclass=ABCMeta):
     An abstract class defining the interface between the data store and a particular document database for the
     purpose of indexing and querying metadata associated with bundles and the files contained in them.
     """
-    def __init__(self, dryrun: bool = False, notify: Optional[bool] = True) -> None:
+    def __init__(self, context: LambdaContext, dryrun: bool = False, notify: Optional[bool] = True) -> None:
         """
         Create a new index backend.
 
@@ -24,6 +25,7 @@ class IndexBackend(metaclass=ABCMeta):
         """
         self.dryrun = dryrun
         self.notify = notify
+        self.context = context
 
     @abstractmethod
     def index_bundle(self, bundle: Bundle):
@@ -83,7 +85,7 @@ class CompositeIndexBackend(IndexBackend):
     def timeout(self):
         """
         The time in which concurrently executed operations have to be completed by all underlying backends. If a
-        backend operation does not complete within the specified timeout, an exceptions will be raised. A value of
+        backend operation does not complete within the specified timeout, an exception will be raised. A value of
         None disables the timeout, potentially causing the calling thread to block forever.
         """
         return self._timeout

--- a/dss/index/bundle.py
+++ b/dss/index/bundle.py
@@ -1,7 +1,9 @@
 import json
 import logging
+from collections import deque
 from typing import Iterable, Mapping, Optional, Sequence
 
+import time
 from cloud_blobstore import BlobNotFoundError, BlobStoreError
 
 from dss import Config, Replica
@@ -49,35 +51,52 @@ class Bundle:
     def _read_file_infos(cls, replica: Replica, fqid: BundleFQID, manifest: JSON) -> Mapping[str, JSON]:
         handle = Config.get_blobstore_handle(replica)
         bucket_name = replica.bucket
-        files_info = manifest[BundleMetadata.FILES]
-        assert isinstance(files_info, list)
+        files_info_original = manifest[BundleMetadata.FILES]
+        assert isinstance(files_info_original, list)
+        files_info = deque((file, 0) for file in files_info_original if file[BundleFileMetadata.INDEXED] is True)
+        time_wait = 10  # time in sec
+        max_attempts = 5
         index_files = {}
-        for file_info in files_info:
-            if file_info[BundleFileMetadata.INDEXED] is True:
-                content_type = file_info[BundleFileMetadata.CONTENT_TYPE]
-                file_name = file_info[BundleFileMetadata.NAME]
-                if not content_type.startswith('application/json'):
-                    logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet has "
-                                   f"content type '{content_type}' instead of the required content type "
-                                   f"'application/json'. This file will not be indexed.")
+        while len(files_info) != 0:
+            file_info, attempts = files_info.popleft()
+            content_type = file_info[BundleFileMetadata.CONTENT_TYPE]
+            file_name = file_info[BundleFileMetadata.NAME]
+            if not content_type.startswith('application/json'):
+                logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet has "
+                               f"content type '{content_type}' instead of the required content type "
+                               f"'application/json'. This file will not be indexed.")
+                continue
+            file_blob_key = create_blob_key(file_info)
+            try:
+                file_string = handle.get(bucket_name, file_blob_key).decode("utf-8")
+            except BlobStoreError as ex:
+                if attempts < max_attempts:
+                    logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet could "
+                                   f"not be accessed. Retrying.")
+                    # if on the last file when it failed wait before retrying, else try the other files first.
+                    # Shorter
+                    # if len(files_info) == 0:
+                    #     time.sleep(time_wait)
+
+                    # If this is not the first attempt then wait before trying again.
+                    # more delays, more time for the file to arrive
+                    if attempts != 0:
+                        time.sleep(time_wait)
+                    # If the file info cannot be retrieved, the file is added to the end of the list so it can be
+                    # retried after all other files have been attempted.
+                    files_info.append((file_info, attempts + 1))
                     continue
-                file_blob_key = create_blob_key(file_info)
-                try:
-                    file_string = handle.get(bucket_name, file_blob_key).decode("utf-8")
-                    file_json = json.loads(file_string)
+                raise RuntimeError(f"{ex} This bundle will not be indexed. Bundle: {fqid}, File Blob Key: "
+                                   f"{file_blob_key}, File Name: '{file_name}'") from ex
+            try:
+                file_json = json.loads(file_string)
                 # TODO (mbaumann) Are there other JSON-related exceptions that should be checked below?
-                except json.decoder.JSONDecodeError as ex:
-                    logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet could "
-                                   f"not be parsed. This file will not be indexed. Exception: {ex}")
-                    continue
-                except BlobStoreError as ex:
-                    exception_type = type(ex).__name__
-                    logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet could "
-                                   f"not be accessed. This file will not be indexed. Exception: {exception_type}, "
-                                   f"file blob key: {file_blob_key}")
-                    continue
-                logger.debug(f"Loaded file: {file_name}")
-                index_files[file_name] = file_json
+            except json.decoder.JSONDecodeError as ex:
+                logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet could "
+                               f"not be parsed. This file will not be indexed. Exception: {ex}")
+                continue
+            logger.debug(f"Loaded file: {file_name}")
+            index_files[file_name] = file_json
         return index_files
 
     def lookup_tombstone(self) -> Optional['Tombstone']:

--- a/dss/index/es/__init__.py
+++ b/dss/index/es/__init__.py
@@ -16,6 +16,8 @@ from dss.util.retry import retry
 
 logger = logging.getLogger(__name__)
 
+TIME_NEEDED = 15
+TIMEOUT = 60
 
 class AWSV4Sign(requests.auth.AuthBase):
     """
@@ -101,7 +103,7 @@ def _retry_delay(i, delay):
 class elasticsearch_retry(retry):
     # noinspection PyShadowingNames
     def __init__(self, logger) -> None:
-        super().__init__(timeout=60,  # seconds
+        super().__init__(timeout=TIMEOUT,  # seconds
                          limit=10,  # retries
                          inherit=True,  # nested retries should obey the outer-most retry's timeout
                          retryable=_retryable_exception,

--- a/dss/index/es/backend.py
+++ b/dss/index/es/backend.py
@@ -2,7 +2,7 @@ import logging
 
 from dss.index.backend import IndexBackend, CompositeIndexBackend
 from dss.index.bundle import Bundle, Tombstone
-from . import elasticsearch_retry
+from . import elasticsearch_retry, TIME_NEEDED
 from .document import BundleDocument, BundleTombstoneDocument
 
 logger = logging.getLogger(__name__)
@@ -12,6 +12,7 @@ class ElasticsearchIndexBackend(IndexBackend):
 
     @elasticsearch_retry(logger)
     def index_bundle(self, bundle: Bundle):
+        self._is_enough_time()
         elasticsearch_retry.add_context(bundle=bundle)
         doc = BundleDocument.from_bundle(bundle)
         modified, index_name = doc.index(dryrun=self.dryrun)
@@ -20,9 +21,14 @@ class ElasticsearchIndexBackend(IndexBackend):
 
     @elasticsearch_retry(logger)
     def remove_bundle(self, bundle: Bundle, tombstone: Tombstone):
+        self._is_enough_time()
         elasticsearch_retry.add_context(tombstone=tombstone, bundle=bundle)
         doc = BundleDocument.from_bundle(bundle)
         tombstone_doc = BundleTombstoneDocument.from_tombstone(tombstone)
         modified, index_name = doc.entomb(tombstone_doc, dryrun=self.dryrun)
         if self.notify or modified and self.notify is None:
             doc.notify(index_name)
+
+    def _is_enough_time(self):
+        if self.context.get_remaining_time_in_millis() / 1000 <= TIME_NEEDED:
+            raise RuntimeError("Not enough time to complete indexing operation.")

--- a/dss/stepfunctions/visitation/reindex.py
+++ b/dss/stepfunctions/visitation/reindex.py
@@ -63,7 +63,8 @@ class Reindex(Visitation):
         executor = ThreadPoolExecutor(len(DEFAULT_BACKENDS))
         # We can't use executor as context manager because we don't want shutting it down to block
         try:
-            backend = CompositeIndexBackend(executor, DEFAULT_BACKENDS, dryrun=self.dryrun, notify=self.notify)
+            backend = CompositeIndexBackend(executor, DEFAULT_BACKENDS, dryrun=self.dryrun, notify=self.notify,
+                                            context=self._context)
             indexer_cls = Indexer.for_replica(Replica[self.replica])
             indexer = indexer_cls(backend)
 

--- a/dss/util/types.py
+++ b/dss/util/types.py
@@ -9,3 +9,42 @@ AnyJSON = Union[str, int, float, bool, None, JSONObj, List[Any]]
 # Most JSON structures, however, start with an JSON object, so we'll use the shorter name for that type:
 
 JSON = Mapping[str, AnyJSON]
+
+
+# A stub for the AWS Lambda context
+
+class LambdaContext(object):
+
+    @property
+    def aws_request_id(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def log_group_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def log_stream_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def function_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def memory_limit_in_mb(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def function_version(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def invoked_function_arn(self) -> str:
+        raise NotImplementedError
+
+    def get_remaining_time_in_millis(self) -> int:
+        raise NotImplementedError
+
+    def log(self, msg: str) -> None:
+        raise NotImplementedError

--- a/tests/infra/__init__.py
+++ b/tests/infra/__init__.py
@@ -2,6 +2,8 @@ import inspect
 import os
 import uuid
 
+import time
+
 from .assert_mixin import DSSAssertResponse, DSSAssertMixin, ExpectedErrorFields
 from .storage_mixin import DSSStorageMixin, TestBundle
 from .testmode import integration, standalone
@@ -23,3 +25,12 @@ def generate_test_key() -> str:
     unique_key = str(uuid.uuid4())
 
     return f"{filename}/{info.function}/{unique_key}"
+
+
+class MockLambdaContext:
+
+    def __init__(self, timeout: float=250.0) -> None:
+        self.deadline = time.time() + timeout
+
+    def get_remaining_time_in_millis(self):
+        return int(max(0, self.deadline - time.time()) * 1000)

--- a/tests/test_visitation.py
+++ b/tests/test_visitation.py
@@ -24,8 +24,7 @@ from dss.stepfunctions.visitation import registered_visitations
 from dss.stepfunctions.visitation.timeout import Timeout
 from dss.stepfunctions.visitation import reindex
 
-from tests.infra import get_env, testmode
-
+from tests.infra import get_env, testmode, MockLambdaContext
 
 logger = logging.getLogger(__name__)
 
@@ -259,15 +258,6 @@ class TestVisitationReindex(unittest.TestCase):
                 r = reindex.Reindex._with_state(state, self.context)
                 r.job_initialize()
                 self.assertEquals(num_work_ids, len(set(r.work_ids)))
-
-
-class MockLambdaContext:
-
-    def __init__(self, timeout: float=250.0) -> None:
-        self.deadline = time.time() + timeout
-
-    def get_remaining_time_in_millis(self):
-        return int(max(0, self.deadline - time.time()) * 1000)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Added lambda context to indexer.
- Retry finding files in manifest if not found until lambda times out.
- If file cannot be found an exception is raised.
- fixes #1115 

## Test Method
updated test cases for indexer.

## Deployment
redeploy indexing lambdas