### PR TITLE
Checkout: make email optional

### DIFF
--- a/daemons/dss-checkout-sfn/app.py
+++ b/daemons/dss-checkout-sfn/app.py
@@ -86,12 +86,13 @@ def pre_execution_check(event, context):
 @app.step_function_task(state_name="Notify", state_machine_definition=state_machine_def)
 def notify_complete(event, context):
     replica = Replica[event["replica"]]
-    result = send_checkout_success_email(email_sender, event["email"], get_dst_bucket(event),
-                                         event["schedule"]["dst_location"], replica)
+    if "email" in event:
+        result = send_checkout_success_email(email_sender, event["email"], get_dst_bucket(event),
+                                             event["schedule"]["dst_location"], replica)
     # record results of execution into S3
     put_status_succeeded(event['execution_name'], replica, get_dst_bucket(event),
                          event["schedule"]["dst_location"])
-    return {"result": result}
+    return {"result": result} if result else {}
 
 
 @app.step_function_task(state_name="NotifyFailure", state_machine_definition=state_machine_def)
@@ -102,10 +103,11 @@ def notify_complete_failure(event, context):
     elif "validation" in event:
         checkout_status = event["validation"].get("checkout_status", "Unknown error code")
         cause = "{} ({})".format(event["validation"].get("cause", "Unknown error"), checkout_status)
-    result = send_checkout_failure_email(email_sender, event["email"], cause)
+    if "email" in event:
+        result = send_checkout_failure_email(email_sender, event["email"], cause)
     # record results of execution into S3
     put_status_failed(event['execution_name'], cause)
-    return {"result": result}
+    return {"result": result} if result else {}
 
 
 def get_dst_bucket(event):

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -821,7 +821,7 @@ paths:
           enum: [aws, gcp, azure]
         - name: json_request_body
           in: body
-          required: true
+          required: false
           schema:
             type: object
             properties:
@@ -832,8 +832,6 @@ paths:
               destination:
                 description: User-owned destination storage bucket.
                 type: string
-            required:
-              - email
       responses:
         200:
           description: Returned when the bundle UUID with optionally specified version exists and checkout has been initiated.

--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -11,18 +11,19 @@ dss_bucket = Config.get_s3_bucket()
 
 @dss_handler
 def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
-    email = json_request_body['email']
 
     assert replica is not None
 
     bundle = get_bundle(uuid, Replica[replica], version)
-
     execution_id = get_execution_id()
 
     sfn_input = {"dss_bucket": dss_bucket, "bundle": uuid, "version": bundle["bundle"]["version"],
-                 "email": email, "replica": replica, "execution_name": execution_id}
+                 "replica": replica, "execution_name": execution_id}
     if "destination" in json_request_body:
         sfn_input["bucket"] = json_request_body["destination"]
+
+    if "email" in json_request_body:
+        sfn_input["email"] = json_request_body["email"]
 
     put_status_started(execution_id)
 

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -46,7 +46,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         for replica in Replica:
             non_existent_bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf111"
             version = "2017-06-20T214506.766634Z"
-            request_body = {"destination": replica.checkout_bucket, "email": "rkisin@chanzuckerberg.com"}
+            request_body = {"destination": replica.checkout_bucket}
 
             url = str(UrlBuilder()
                       .set(path="/v1/bundles/" + non_existent_bundle_uuid + "/checkout")
@@ -66,7 +66,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
         for replica in Replica:
-            request_body = {"destination": replica.checkout_bucket, "email": "rkisin@chanzuckerberg.com"}
+            request_body = {"destination": replica.checkout_bucket}
 
             url = str(UrlBuilder()
                       .set(path="/v1/bundles/" + bundle_uuid + "/checkout")
@@ -83,7 +83,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
     def launch_checkout(self, dst_bucket: str, replica: Replica) -> str:
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
-        request_body = {"destination": dst_bucket, "email": "rkisin@chanzuckerberg.com"}
+        request_body = {"destination": dst_bucket}
 
         url = str(UrlBuilder()
                   .set(path="/v1/bundles/" + bundle_uuid + "/checkout")


### PR DESCRIPTION
Make email address an optional parameter for checkout service API
### Test plan
- [x] Use curl and HCA CLI to initiate checkout (with and without email address parameter)
- [x] Modified unit tests
- [ ] Run scale test