### PR TITLE
[2/2] New PUT /bundle error incorrect_file_bundle_uuid

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -77,14 +77,13 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str = None):
                     file_metadata = handle.get(bucket, metadata_key)
                 except BlobNotFoundError:
                     continue
-                file_metadata_dict = json.loads(file_metadata)
-                if uuid != file_metadata_dict['bundle_uuid']:
+                file['file_metadata'] = json.loads(file_metadata)
+                if uuid != file['file_metadata']['bundle_uuid']:
                     raise DSSException(
                         requests.codes.conflict,
                         "incorrect_file_bundle_uuid",
-                        f"File bundle_uuid {file_metadata_dict['bundle_uuid']} does not equal bundle uuid {uuid}"
+                        f"File bundle_uuid {file['file_metadata']['bundle_uuid']} does not equal bundle uuid {uuid}"
                     )
-                file['file_metadata'] = json.loads(file_metadata)
 
         # check to see if any file metadata is still not yet loaded.
         for file in files:

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -77,6 +77,13 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str = None):
                     file_metadata = handle.get(bucket, metadata_key)
                 except BlobNotFoundError:
                     continue
+                file_metadata_dict = json.loads(file_metadata)
+                if uuid != file_metadata_dict['bundle_uuid']:
+                    raise DSSException(
+                        requests.codes.conflict,
+                        "incorrect_file_bundle_uuid",
+                        f"File bundle_uuid {file_metadata_dict['bundle_uuid']} does not equal bundle uuid {uuid}"
+                    )
                 file['file_metadata'] = json.loads(file_metadata)
 
         # check to see if any file metadata is still not yet loaded.
@@ -97,8 +104,6 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str = None):
             "file_missing",
             f"Could not find file {missing_file_user_metadata['uuid']}/{missing_file_user_metadata['version']}."
         )
-
-    # TODO: (ttung) should validate the files' bundle UUID points back at us.
 
     # build a manifest consisting of all the files.
     bundle_metadata = {

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -160,7 +160,6 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         schema = replica.storage_schema
 
         bundle_uuid = str(uuid.uuid4())
-        incorrect_bundle_uuid = str(uuid.uuid4())
         file_uuid = str(uuid.uuid4())
         missing_file_uuid = str(uuid.uuid4())
         resp_obj = self.upload_file_wait(
@@ -213,18 +212,11 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
         # should *NOT* be able to upload a bundle containing a file with an incorrect bundle_uuid
         # but we should get requests.codes.conflict
-        resp_obj = self.upload_file_wait(
-            f"{schema}://{fixtures_bucket}/test_good_source_data/0",
-            replica,
-            file_uuid,
-            bundle_uuid=incorrect_bundle_uuid,
-        )
-        inc_file_version = resp_obj.json['version']
         with nestedcontext.bind(time_left=lambda: 0):
             resp_obj = self.put_bundle(
                 replica,
-                bundle_uuid,
-                [(file_uuid, inc_file_version, "LICENSE")],
+                str(uuid.uuid4()),  # uploading new bundle with old file
+                [(file_uuid, file_version, "LICENSE")],
                 datetime_to_version_format(datetime.datetime.utcnow()),
                 expected_code=requests.codes.conflict,
             )


### PR DESCRIPTION
depends on: #1147 

Require file `bundle_uuid`'s match their bundle in `PUT /bundle`

Addresses:
https://github.com/HumanCellAtlas/data-store/blob/7007beac418dec45d6f097dabdf131b96d094cf4/dss/api/bundles/__init__.py#L101

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->