### PR TITLE
Consolidate indexer run time tracking in Indexer class (mostly)

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -324,6 +324,18 @@ class Config:
         value = os.environ.get('DSS_NOTIFY_WORKERS')
         return int(value) if value else None
 
+    @classmethod
+    def get_elasticsearch_host(cls):
+        return os.environ.get('DSS_ES_ENDPOINT', "localhost")
+
+    @classmethod
+    def get_elasticsearch_port(cls):
+        return int(os.environ.get('DSS_ES_PORT', "443"))
+
+    @classmethod
+    def get_elasticsearch_timeout(cls):
+        return int(os.environ.get('DSS_ES_TIMEOUT', "10"))
+
 
 class Replica(Enum):
     aws = (Config.get_s3_bucket, Config.get_s3_checkout_bucket, "s3", S3BlobStore, S3HCABlobStore)

--- a/dss/index/bundle.py
+++ b/dss/index/bundle.py
@@ -1,9 +1,7 @@
 import json
 import logging
-from collections import deque
-from typing import Iterable, Mapping, Optional, Sequence
+from typing import Mapping, Optional, Set
 
-import time
 from cloud_blobstore import BlobNotFoundError, BlobStoreError
 
 from dss import Config, Replica
@@ -31,7 +29,7 @@ class Bundle:
         self.files = files
 
     @classmethod
-    def from_replica(cls, replica: Replica, fqid: BundleFQID):
+    def load(cls, replica: Replica, fqid: BundleFQID):
         manifest = cls._read_bundle_manifest(replica, fqid)
         files = cls._read_file_infos(replica, fqid, manifest)
         self = cls(replica, fqid, manifest=manifest, files=files)
@@ -50,32 +48,20 @@ class Bundle:
     @classmethod
     def _read_file_infos(cls, replica: Replica, fqid: BundleFQID, manifest: JSON) -> Mapping[str, JSON]:
         handle = Config.get_blobstore_handle(replica)
-        bucket_name = replica.bucket
-        files_info_original = manifest[BundleMetadata.FILES]
-        assert isinstance(files_info_original, list)
-        files_info = deque((file, 0) for file in files_info_original if file[BundleFileMetadata.INDEXED] is True)
         index_files = {}
-        while len(files_info) != 0:
-            file_info, attempts = files_info.popleft()
-            content_type = file_info[BundleFileMetadata.CONTENT_TYPE]
-            file_name = file_info[BundleFileMetadata.NAME]
-            if content_type.startswith('application/json'):
-                file_blob_key = create_blob_key(file_info)
-                try:
-                    file_string = handle.get(bucket_name, file_blob_key).decode("utf-8")
-                except BlobStoreError as ex:
-                    if attempts < 5:
-                        logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet could "
-                                       f"not be accessed. Retrying.")
-                        # Only wait before retries, not first attempts to load a file.
-                        if attempts:
-                            time.sleep(5)
-                        # Requeue at the end, yielding to other files we may not have tried yet
-                        files_info.append((file_info, attempts + 1))
-                    else:
+        file_infos = manifest[BundleMetadata.FILES]
+        assert isinstance(file_infos, list)
+        for file_info in file_infos:
+            if file_info[BundleFileMetadata.INDEXED]:
+                file_name = file_info[BundleFileMetadata.NAME]
+                content_type = file_info[BundleFileMetadata.CONTENT_TYPE]
+                if content_type.startswith('application/json'):
+                    file_blob_key = create_blob_key(file_info)
+                    try:
+                        file_string = handle.get(replica.bucket, file_blob_key).decode("utf-8")
+                    except BlobStoreError as ex:
                         raise RuntimeError(f"{ex} This bundle will not be indexed. Bundle: {fqid}, File Blob Key: "
                                            f"{file_blob_key}, File Name: '{file_name}'") from ex
-                else:
                     try:
                         file_json = json.loads(file_string)
                         # TODO (mbaumann) Are there other JSON-related exceptions that should be checked below?
@@ -85,10 +71,10 @@ class Bundle:
                     else:
                         logger.debug(f"Loaded file: {file_name}")
                         index_files[file_name] = file_json
-            else:
-                logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet has "
-                               f"content type '{content_type}' instead of the required content type "
-                               f"'application/json'. This file will not be indexed.")
+                else:
+                    logger.warning(f"In bundle {fqid} the file '{file_name}' is marked for indexing yet has "
+                                   f"content type '{content_type}' instead of the required content type "
+                                   f"'application/json'. This file will not be indexed.")
         return index_files
 
     def lookup_tombstone(self) -> Optional['Tombstone']:
@@ -98,7 +84,7 @@ class Bundle:
         for all_versions in (False, True):
             tombstone_id = self.fqid.to_tombstone_id(all_versions=all_versions)
             try:
-                return Tombstone.from_replica(self.replica, tombstone_id)
+                return Tombstone.load(self.replica, tombstone_id)
             except BlobNotFoundError:
                 pass
         return None
@@ -118,27 +104,25 @@ class Tombstone:
         self.body = body
 
     @classmethod
-    def from_replica(cls, replica: Replica, tombstone_id: TombstoneID):
+    def load(cls, replica: Replica, tombstone_id: TombstoneID):
         blobstore = Config.get_blobstore_handle(replica)
         bucket_name = replica.bucket
         body = json.loads(blobstore.get(bucket_name, tombstone_id.to_key()))
         self = cls(replica, tombstone_id, body)
         return self
 
-    def list_dead_bundles(self) -> Sequence[Bundle]:
+    def list_dead_bundles(self) -> Set[BundleFQID]:
         blobstore = Config.get_blobstore_handle(self.replica)
         bucket_name = self.replica.bucket
         assert isinstance(self.fqid, TombstoneID)
         if self.fqid.is_fully_qualified():
-            # If a version is specified, delete just that bundle …
-            bundle_fqids: Iterable[BundleFQID] = [self.fqid.to_bundle_fqid()]
+            # If a version is specified, return just that bundle …
+            return {self.fqid.to_bundle_fqid()}
         else:
-            # … otherwise, delete all bundles with the same UUID from the index.
+            # … otherwise, return all bundles with the same UUID from the index.
             prefix = self.fqid.to_key_prefix()
-            fqids = [ObjectIdentifier.from_key(k) for k in set(blobstore.list(bucket_name, prefix))]
-            bundle_fqids = filter(lambda fqid: type(fqid) == BundleFQID, fqids)
-        bundles = [Bundle.from_replica(self.replica, bundle_fqid) for bundle_fqid in bundle_fqids]
-        return bundles
+            fqids = map(ObjectIdentifier.from_key, blobstore.list(bucket_name, prefix))
+            return set(fqid for fqid in fqids if type(fqid) == BundleFQID)
 
     def __str__(self):
         return f"{self.__class__.__name__}(replica={self.replica}, fqid='{self.fqid}')"

--- a/dss/index/es/__init__.py
+++ b/dss/index/es/__init__.py
@@ -18,8 +18,6 @@ from dss.util.retry import retry
 
 logger = logging.getLogger(__name__)
 
-TIME_NEEDED = 15
-TIMEOUT = 60
 
 class AWSV4Sign(requests.auth.AuthBase):
     """
@@ -58,10 +56,9 @@ class ElasticsearchClient:
     """
     @staticmethod
     def get() -> Elasticsearch:
-        host = os.getenv('DSS_ES_ENDPOINT', "localhost")  # FIXME: endpoint is the wrong term
-        port = int(os.getenv('DSS_ES_PORT', "443"))
-        timeout: Union[str, None, int] = os.getenv('DSS_ES_TIMEOUT')
-        timeout = int(timeout) if timeout else None
+        host = Config.get_elasticsearch_host()
+        port = Config.get_elasticsearch_port()
+        timeout = Config.get_elasticsearch_timeout()
         return ElasticsearchClient._get(host, port, timeout)
 
     @staticmethod
@@ -100,14 +97,14 @@ def _retryable_exception(e):
 
 
 def _retry_delay(i, delay):
-    return 10 if delay is None else delay * 1.5
+    return .25 if delay is None else delay * 1.5
 
 
 # noinspection PyPep8Naming
 class elasticsearch_retry(retry):
     # noinspection PyShadowingNames
-    def __init__(self, logger) -> None:
-        super().__init__(timeout=TIMEOUT,  # seconds
+    def __init__(self, logger, timeout=None) -> None:
+        super().__init__(timeout=timeout,  # seconds
                          limit=10,  # retries
                          inherit=True,  # nested retries should obey the outer-most retry's timeout
                          retryable=_retryable_exception,

--- a/dss/stepfunctions/visitation/__init__.py
+++ b/dss/stepfunctions/visitation/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Sequence, Any, Union
+from typing import Sequence, Any, Mapping, MutableMapping
 
 import copy
 import json
@@ -7,6 +7,7 @@ from uuid import uuid4
 from enum import Enum, auto
 
 from dss.stepfunctions import _step_functions_start_execution
+from dss.util.types import LambdaContext
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,9 @@ class WalkerStatus(Enum):
     walk = auto()
     finished = auto()
     end = auto()
+
+
+Spec = Mapping[str, Any]
 
 
 class Visitation:
@@ -48,10 +52,10 @@ class Visitation:
         work_id=str,
         work_result=None
     )
-    state_spec: dict = dict()
-    walker_state_spec: dict = dict()
+    state_spec: Spec = dict()
+    walker_state_spec: Spec = dict()
 
-    def __init__(self, state_spec: dict, state: dict, context) -> None:
+    def __init__(self, state_spec: Spec, state: Spec, context: LambdaContext) -> None:
         """
         Pull in fields defined in state specifications and set as instance properties
         """
@@ -59,7 +63,7 @@ class Visitation:
         self._context = context
         state = copy.deepcopy(state)
 
-        self.work_result: Union[Any, Sequence] = None  # mypy needs this
+        self.work_result: MutableMapping[str, Any] = None
 
         for k, default in state_spec.items():
             v = state.get(k, None)

--- a/dss/stepfunctions/visitation/reindex.py
+++ b/dss/stepfunctions/visitation/reindex.py
@@ -9,7 +9,7 @@ from cloud_blobstore import BlobPagingError
 from dss.config import Config, Replica
 from dss.index import DEFAULT_BACKENDS
 from dss.index.backend import CompositeIndexBackend
-from dss.index.indexer import Indexer
+from dss.index.indexer import Indexer, IndexerTimeout
 from . import Visitation, WalkerStatus
 
 logger = logging.getLogger(__name__)
@@ -44,16 +44,6 @@ class Reindex(Visitation):
         else:
             self.work_ids = [a + b for a in prefix_chars for b in prefix_chars]
 
-    def process_item(self, indexer, key):
-        self.work_result['processed'] += 1
-        try:
-            indexer.index_object(key)
-        except Exception:
-            self.work_result['failed'] += 1
-            logger.warning(f'Reindex operation failed for {key}', exc_info=True)
-        else:
-            self.work_result['indexed'] += 1
-
     def walker_finalize(self):
         logger.info(f'Work result: {self.work_result}')
         self.marker = None
@@ -63,10 +53,9 @@ class Reindex(Visitation):
         executor = ThreadPoolExecutor(len(DEFAULT_BACKENDS))
         # We can't use executor as context manager because we don't want shutting it down to block
         try:
-            backend = CompositeIndexBackend(executor, DEFAULT_BACKENDS, dryrun=self.dryrun, notify=self.notify,
-                                            context=self._context)
+            backend = CompositeIndexBackend(executor, DEFAULT_BACKENDS, dryrun=self.dryrun, notify=self.notify)
             indexer_cls = Indexer.for_replica(Replica[self.replica])
-            indexer = indexer_cls(backend)
+            indexer = indexer_cls(backend, self._context)
 
             handle = Config.get_blobstore_handle(Replica[self.replica])
             default_bucket = Replica[self.replica].bucket
@@ -84,15 +73,21 @@ class Reindex(Visitation):
             for key in blobs:
                 # Timing out while recording paging info could cause an inconsistent paging state, leading to repeats
                 # of large amounts of work. This can be avoided by checking for timeouts only during actual
-                # re-indexing.
-                timeout = self.remaining_runtime() - 10  # ten seconds of safety for letting lambda shut down
-                if timeout < 10:  # don't even try to index an item with less then 10 seconds left
-                    logger.warning(f'{self.work_id} timed out during reindex')
-                    return
-                backend._timeout = timeout
-                self.process_item(indexer, key)
-                self.marker = blobs.start_after_key
-                self.token = blobs.token
+                # re-indexing. The indexer performs this check for every item.
+                self.work_result['processed'] += 1
+                try:
+                    indexer.index_object(key)
+                except IndexerTimeout as e:
+                    self.work_result['failed'] += 1
+                    logger.warning(f'{self.work_id} timed out during reindex: {e}')
+                    break
+                except Exception:
+                    self.work_result['failed'] += 1
+                    logger.warning(f'Reindex operation failed for {key}', exc_info=True)
+                else:
+                    self.work_result['indexed'] += 1
+                    self.marker = blobs.start_after_key
+                    self.token = blobs.token
             else:
                 self._status = WalkerStatus.finished.name
         finally:

--- a/tests/infra/__init__.py
+++ b/tests/infra/__init__.py
@@ -34,7 +34,7 @@ class MockLambdaContext(LambdaContext):
     A mock of the class an instance of which the AWS Lambda Python runtime injects into each invocation.
     """
 
-    def __init__(self, timeout: float=250.0) -> None:
+    def __init__(self, timeout: float=300.0) -> None:
         self.deadline = time.time() + timeout
 
     def get_remaining_time_in_millis(self):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -195,7 +195,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         from elasticsearch.client import Elasticsearch
         real_method = getattr(Elasticsearch, retry_method)
         from elasticsearch.exceptions import ConflictError
-        i = iter([ConflictError(409)])
+        i = iter([ConflictError(409, "mock exception", None)])
 
         def mock_method(*args, **kwargs):
             try:


### PR DESCRIPTION
So far we've been neglecting to accurately track the Lambda invocation's remaining run time in the indexer. No one noticed until we started retrying to load metadata blobs in #1137 as a fix for #1115. The retries could potentially take so much time that there wouldn't be anything left for the actual indexing operation, like interacting with ES. We should make reasonably sure that there is sufficient time to complete an indexing operation before we commence it, because if we are interrupted, we'll leave the index inconsistent. This PR fixes that on a best effort basis. I've opened #1164 to retry the entire invocation if that best effort fails.