### PR TITLE
[easy] Fix: Visitation instances inadvertently alter the state spec

### DIFF
--- a/dss/stepfunctions/visitation/__init__.py
+++ b/dss/stepfunctions/visitation/__init__.py
@@ -68,7 +68,7 @@ class Visitation:
                 if callable(default):
                     v = default()
                 else:
-                    v = default
+                    v = copy.deepcopy(default)
 
             setattr(self, k, v)
 


### PR DESCRIPTION
When a state dict value is assigned from the default value from the state spec, and if that value is of a reference type, the default value needs to copied. Otherwise the state will refer to the value from the state spec and updates to it will inadvertently modify the spec which should be strictly read-only.

This shouldn't occur in the wild but it does occur during tests where it causes one test failure to cascade into another failure of a test that would otherwise succeed. It's actually a coincidence that this doesn't occur all the time. For example, if `test_reindex_timeout` fails and leaves the `state['work_result']` dict with anything but zero for its values, `test_reindex_walk`, the next test in alphabetic order—the order unittest runs tests in—will fail when asserting the `state['work_result']` dict.

