### PR TITLE
Add an L1 health check endpoint

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -175,6 +175,13 @@ def get_chalice_app(flask_app) -> DSSChaliceApp:
                                 headers={"Content-Type": "text/html"},
                                 body=swagger_ui_html)
 
+    @app.route("/internal/health")
+    @time_limited(app)
+    def health():
+        return chalice.Response(status_code=200,
+                                headers={"Content-Type": "text/html"},
+                                body="OK")
+
     @app.route("/internal/slow_request", methods=["GET"])
     @time_limited(app)
     def slow_request():


### PR DESCRIPTION
<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->
Currently the health check app pings the `/v1/swagger.json` endpoint. We should have a basic health check endpoint instead that we can build L2 and L3 health check functionality on top of. This PR introduces that endpoint.

<!-- ### Test plan
Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
