### PR TITLE
Run indexer integration tests for AWS replica only

### DIFF
--- a/tests/es/__init__.py
+++ b/tests/es/__init__.py
@@ -81,7 +81,7 @@ class ElasticsearchServer:
             status = proc.poll()
             if status is not None:
                 tempdir.cleanup()
-                raise ChildProcessError('ES process died with status {status}')
+                raise ChildProcessError(f"ES process died with status {status}")
 
         deadline = time.time() + timeout
         while True:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1110,6 +1110,7 @@ class TestAWSIndexer(TestIndexerBase):
         return sample_event
 
 
+@testmode.standalone  # It's sufficient to run the integration tests in TestIndexerBase for one replica only
 class TestGCPIndexer(TestIndexerBase):
 
     replica = Replica.gcp


### PR DESCRIPTION
The integration tests in test_indexer don't benefit from being run for each replica. I'm also worried that if those tests run in parallel, they might conflict with each other as in this case:

https://travis-ci.org/HumanCellAtlas/data-store/jobs/370849706#L1256