### PR TITLE
Add response metrics and logging

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -29,6 +29,8 @@ configure_lambda_logging()
 
 Config.set_config(BucketConfig.NORMAL)
 
+cloudwatch = boto3.client('cloudwatch')
+
 
 EXECUTION_TERMINATION_THRESHOLD_SECONDS = 5.0
 """We will terminate execution if we have this many seconds left to process the request."""
@@ -107,6 +109,7 @@ def time_limited(chalice_app: DSSChaliceApp):
 
 def get_chalice_app(flask_app) -> DSSChaliceApp:
     app = DSSChaliceApp(app_name=flask_app.name, configure_logs=False)
+    ex = ThreadPoolExecutor(max_workers=2)
 
     @time_limited(app)
     def dispatch(*args, **kwargs):
@@ -134,6 +137,33 @@ def get_chalice_app(flask_app) -> DSSChaliceApp:
             maybe_fake_504_result = maybe_fake_504()
             if maybe_fake_504_result is not None:
                 return maybe_fake_504_result
+
+        def request_metrics(path_pattern, method, status_code):
+            status_class = str(status_code)[0] + 'xx'
+            try:
+                cloudwatch.put_metric_data(
+                    Namespace='DSS',
+                    MetricData=[
+                        dict(MetricName='HttpRequests by StatusClass',
+                             Dimensions=[
+                                 dict(Name='StatusClass', Value=status_class),
+                             ],
+                             Value=1.0,
+                             Unit='Count',
+                             StorageResolution=60),
+                        dict(MetricName='HttpRequests by Path, Method, StatusCode',
+                             Dimensions=[
+                                 dict(Name='Path', Value=path_pattern),
+                                 dict(Name='Method', Value=method),
+                                 dict(Name='StatusCode', Value=str(status_code))
+                             ],
+                             Value=1.0,
+                             Unit='Count',
+                             StorageResolution=60),
+                    ]
+                )
+            except Exception as e:
+                app.log.exception('Metrics post failed!', e)
 
         status_code = None
         try:
@@ -164,6 +194,9 @@ def get_chalice_app(flask_app) -> DSSChaliceApp:
         # API Gateway/Cloudfront adds a duplicate Content-Length with a different value (not sure why)
         res_headers = dict(flask_res.headers)
         res_headers.pop("Content-Length", None)
+
+        # observability logic is deferred to a different thread so as not to delay response
+        ex.submit(request_metrics, path_pattern, method, status_code)
 
         return chalice.Response(status_code=status_code,
                                 headers=res_headers,

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -31,6 +31,12 @@ Config.set_config(BucketConfig.NORMAL)
 
 cloudwatch = boto3.client('cloudwatch')
 
+# This executor handles requests and metrics submission tasks
+# Lambda gives you only one main thread, so this executor essentially defers work to be done sequentially
+MAX_EXECUTOR_WORKERS = 8
+metrics_executor = ThreadPoolExecutor(max_workers=MAX_EXECUTOR_WORKERS, thread_name_prefix='MetricsExecutor')
+requests_executor = ThreadPoolExecutor(max_workers=MAX_EXECUTOR_WORKERS, thread_name_prefix='RequestsExecutor')
+
 
 EXECUTION_TERMINATION_THRESHOLD_SECONDS = 5.0
 """We will terminate execution if we have this many seconds left to process the request."""
@@ -78,6 +84,16 @@ def timeout_response() -> chalice.Response:
     )
 
 
+def log_loaded_executors(logger, executor):
+    queue_size = executor._work_queue.qsize()
+    if queue_size >= MAX_EXECUTOR_WORKERS / 2:
+        logger.info("Chalice executor {} worker utilization is {}/{}".format(
+            executor._thread_name_prefix,
+            queue_size,
+            executor._max_workers
+        ))
+
+
 def time_limited(chalice_app: DSSChaliceApp):
     """
     When this decorator is applied to a route handler, we will process the request in a secondary thread.  If the
@@ -86,30 +102,26 @@ def time_limited(chalice_app: DSSChaliceApp):
     def real_decorator(method: callable):
         @functools.wraps(method)
         def wrapper(*args, **kwargs):
-            executor = ThreadPoolExecutor()
-            try:
-                future = executor.submit(method, *args, **kwargs)
-                time_remaining_s = chalice_app._override_exptime_seconds  # type: typing.Optional[float]
-                if time_remaining_s is None:
-                    time_remaining_s = min(
-                        API_GATEWAY_TIMEOUT_SECONDS,
-                        chalice_app.lambda_context.get_remaining_time_in_millis() / 1000)
-                    time_remaining_s = max(0.0, time_remaining_s - EXECUTION_TERMINATION_THRESHOLD_SECONDS)
+            log_loaded_executors(chalice_app.log, requests_executor)
+            future = requests_executor.submit(method, *args, **kwargs)
+            time_remaining_s = chalice_app._override_exptime_seconds  # type: typing.Optional[float]
+            if time_remaining_s is None:
+                time_remaining_s = min(
+                    API_GATEWAY_TIMEOUT_SECONDS,
+                    chalice_app.lambda_context.get_remaining_time_in_millis() / 1000)
+                time_remaining_s = max(0.0, time_remaining_s - EXECUTION_TERMINATION_THRESHOLD_SECONDS)
 
-                try:
-                    chalice_response = future.result(timeout=time_remaining_s)
-                    return chalice_response
-                except TimeoutError:
-                    return timeout_response()
-            finally:
-                executor.shutdown(wait=False)
+            try:
+                chalice_response = future.result(timeout=time_remaining_s)
+                return chalice_response
+            except TimeoutError:
+                return timeout_response()
         return wrapper
     return real_decorator
 
 
 def get_chalice_app(flask_app) -> DSSChaliceApp:
     app = DSSChaliceApp(app_name=flask_app.name, configure_logs=False)
-    ex = ThreadPoolExecutor(max_workers=2)
 
     @time_limited(app)
     def dispatch(*args, **kwargs):
@@ -196,7 +208,8 @@ def get_chalice_app(flask_app) -> DSSChaliceApp:
         res_headers.pop("Content-Length", None)
 
         # observability logic is deferred to a different thread so as not to delay response
-        ex.submit(request_metrics, path_pattern, method, status_code)
+        log_loaded_executors(app.log, metrics_executor)
+        metrics_executor.submit(request_metrics, path_pattern, method, status_code)
 
         return chalice.Response(status_code=status_code,
                                 headers=res_headers,

--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -153,6 +153,11 @@
     },
     {
       "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
       "Action": [
         "sqs:*"
       ],

--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -39,6 +39,11 @@
     },
     {
       "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
       "Action": [
         "es:ESHttpGet",
         "es:ESHttpHead",


### PR DESCRIPTION
<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->
This PR adds logging and metrics for requests and their response codes in the DSS HTTP API.

I've used CloudWatch Metrics, but may change this in the future if we decide on a different metrics system.

The call to the metrics server is done on its own thread to prevent the API from lagging if CloudWatch metrics is slow in responding.

HTTP metric data is grouped into two CloudWatch metrics, `HttpRequests by StatusClass` and `HttpRequests by Path, Method, StatusClass`. `HttpRequests by StatusClass` is for dashboarding and will allow coarse-grained indication of errors on the API. `HttpRequests by Path, Method, StatusClass` will allow us to drill down to the problematic endpoint and method when an issue is spotted in logs or on coarser metric plots. The HTTP return codes are grouped in the metrics into different status classes to allow easy visualization.
<!--
### Test plan
 Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
