### PR TITLE
requirements-dev.txt.in should source requirements.txt.in

### DIFF
--- a/requirements-dev.txt.in
+++ b/requirements-dev.txt.in
@@ -11,4 +11,4 @@ httpie  >= 0.9.9
 yq  >= 2.3.3
 Faker >= 0.8.11
 rstr >=2.2.6
--r requirements.txt
+-r requirements.txt.in


### PR DESCRIPTION
Changes to requirements.txt.in should affect how we build requirements-dev.txt.  That is only possible if requirements-dev.txt.in sources requirements.txt.in.
