### PR TITLE
Fix cloud-blobstore dep

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ chalice==1.1.0
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.1.0
+cloud-blobstore==2.1.1
 colorama==0.3.7
 connexion==1.1.15
 cookies==2.2.1


### PR DESCRIPTION
Because of the bug fixed by #1193, we didn't update the dependency correctly.
