### PR TITLE
Fighting the duplicate bundle threat with timeouts

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -143,7 +143,10 @@ class Config:
 
             # _http is a "private" parameter, and we may need to re-visit GCP timeout retry
             # strategies in the future.
-            return Client(_http=SessionWithTimeouts(credentials))
+            return Client(
+                _http=SessionWithTimeouts(credentials),
+                credentials=credentials
+            )
         raise NotImplementedError(f"Replica `{replica.name}` is not implemented!")
 
     @staticmethod

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,6 +53,12 @@ class TestConfig(unittest.TestCase):
             self.assertFalse(None in prop_vals)
             self.assertEqual(len(Replica), len(prop_vals))
 
+    def test_boto_timeout(self):
+        client_config = Config.get_blobstore_handle(Replica.aws).s3_client._client_config
+        self.assertEqual(Config.BLOBSTORE_CONNECT_TIMEOUT, client_config.connect_timeout)
+        self.assertEqual(Config.BLOBSTORE_READ_TIMEOUT, client_config.read_timeout)
+        self.assertEqual(Config.BLOBSTORE_BOTO_RETRIES, client_config.retries['max_attempts'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Connects to #1098 

Gateway timeouts (504 errors) have been probabilistically observed during PUT /bundle.

PUT /bundle should either succeed, or fail with an appropriate error, before the gateway times out. This PR attempts to mitigate against occasionally high latency storage by using a more aggressive timeout strategy.