### PR TITLE
Remove asynchronous API metrics push

### DIFF
--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -147,11 +147,6 @@
     },
     {
       "Effect": "Allow",
-      "Action": "cloudwatch:PutMetricData",
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
       "Action": [
         "sqs:*"
       ],

--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -39,11 +39,6 @@
     },
     {
       "Effect": "Allow",
-      "Action": "cloudwatch:PutMetricData",
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
       "Action": [
         "es:ESHttpGet",
         "es:ESHttpHead",


### PR DESCRIPTION
The threading model in the asynchronous metrics push was concern enough that we decided to pull this change out and generate the metrics asynchronously.

This PR backs out the metrics push. The generation of the metrics will be done with logs or processed in a separate PR.