### PR TITLE
Remove backlink from file to bundle

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -127,9 +127,6 @@ paths:
           description: Returns metadata
           headers:
             # edits to here should probably be reflected in the 302 section immediately below.
-            X-DSS-BUNDLE-UUID:
-              description: A RFC4122-compliant ID for the bundle that contains this file.
-              type: string
             X-DSS-CREATOR-UID:
               description: User ID who created this file.
               type: integer
@@ -201,9 +198,6 @@ paths:
           description: Redirects to a signed URL with the data.
           headers:
             # edits to here should probably be reflected in the 200 section above.
-            X-DSS-BUNDLE-UUID:
-              description: A RFC4122-compliant ID for the bundle that contains this file.
-              type: string
             X-DSS-CREATOR-UID:
               description: User ID who created this file.
               type: integer
@@ -289,16 +283,12 @@ paths:
                 description: Cloud URL for source data.
                 type: string
                 pattern: "^(gs|s3|wasb)://"
-              bundle_uuid:
-                description: A RFC4122-compliant ID for the bundle that contains this file.
-                type: string
               creator_uid:
                 description: User ID who is creating this file.
                 type: integer
                 format: int64
             required:
               - source_url
-              - bundle_uuid
               - creator_uid
       responses:
         200:
@@ -815,10 +805,7 @@ paths:
                       The code `file_missing` indicates that one of the files does not exist on the cloud provider.
                       Because the storage backend only guarantees eventual consistency, it may be desirable to retry
                       requests that return this error code.
-
-                      The code `incorrect_file_bundle_uuid` indicates that the value of the file metadata field
-                      bundle_uuid does not match the uuid of the bundle.
-                    enum: [bundle_already_exists, file_missing, incorrect_file_bundle_uuid]
+                    enum: [bundle_already_exists, file_missing]
                 required:
                   - code
         default:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1111,28 +1111,6 @@ definitions:
           - name
           - content-type
           - indexed
-  file_metadata:
-    type: object
-    description: Object describing a single file in the files list of a bundle.
-    allOf:
-      - $ref: '#/definitions/blob_common_metadata'
-      - type: object
-        properties:
-          version:
-            type: string
-            description: Version of the file metadata object.
-          bundle_uuid:
-            type: string
-            description: A RFC4122-compliant ID for the bundle that contains this file.
-            pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
-          creator_uid:
-            type: integer
-            format: int64
-            description: User ID who created this file.
-        required:
-          - version
-          - bundle_uuid
-          - creator_uid
   Bundle:
     type: object
     properties:

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -78,12 +78,6 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str = None):
                 except BlobNotFoundError:
                     continue
                 file['file_metadata'] = json.loads(file_metadata)
-                if uuid != file['file_metadata']['bundle_uuid']:
-                    raise DSSException(
-                        requests.codes.conflict,
-                        "incorrect_file_bundle_uuid",
-                        f"File bundle_uuid {file['file_metadata']['bundle_uuid']} does not equal bundle uuid {uuid}"
-                    )
 
         # check to see if any file metadata is still not yet loaded.
         for file in files:

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -93,7 +93,6 @@ def get_helper(uuid: str, replica: Replica, version: str=None):
         response = make_response('', 200)
 
     headers = response.headers
-    headers['X-DSS-BUNDLE-UUID'] = file_metadata[FileMetadata.BUNDLE_UUID]
     headers['X-DSS-CREATOR-UID'] = file_metadata[FileMetadata.CREATOR_UID]
     headers['X-DSS-VERSION'] = version
     headers['X-DSS-CONTENT-TYPE'] = file_metadata[FileMetadata.CONTENT_TYPE]
@@ -180,7 +179,6 @@ def put(uuid: str, json_request_body: dict, version: str=None):
     # build the json document for the file metadata.
     file_metadata = {
         FileMetadata.FORMAT: FileMetadata.FILE_FORMAT_VERSION,
-        FileMetadata.BUNDLE_UUID: json_request_body['bundle_uuid'],
         FileMetadata.CREATOR_UID: json_request_body['creator_uid'],
         FileMetadata.VERSION: version,
         FileMetadata.CONTENT_TYPE: content_type,

--- a/dss/storage/hcablobstore/__init__.py
+++ b/dss/storage/hcablobstore/__init__.py
@@ -48,7 +48,6 @@ class FileMetadata:
     FILE_FORMAT_VERSION = "0.0.3"
 
     FORMAT = "format"
-    BUNDLE_UUID = "bundle_uuid"
     CREATOR_UID = "creator_uid"
     VERSION = "version"
     CONTENT_TYPE = "content-type"

--- a/tests/infra/storage_mixin.py
+++ b/tests/infra/storage_mixin.py
@@ -26,7 +26,6 @@ class TestBundle:
 
 class TestFile:
     def __init__(self, file_key, bundle, replica: Replica) -> None:
-        self.bundle = bundle
         self.metadata = bundle.handle.get_user_metadata(bundle.bucket, file_key)
         self.indexed = bundle.handle.get_content_type(bundle.bucket, file_key) == "application/json"
         self.name = os.path.basename(file_key)
@@ -55,8 +54,7 @@ class DSSStorageMixin:
         response = self.upload_file_wait(
             bundle_file.url,
             replica,
-            file_uuid=bundle_file.uuid,
-            bundle_uuid=bundle_file.bundle.uuid,
+            file_uuid=bundle_file.uuid
         )
         response_data = json.loads(response[1])
         self.assertIs(type(response_data), dict)
@@ -121,5 +119,4 @@ class DSSStorageMixin:
                     .add_query('replica', replica.name)),
                 requests.codes.found,
             )
-            self.assertEqual(bundle_file.bundle.uuid, response[0].headers['X-DSS-BUNDLE-UUID'])
             self.assertEqual(bundle_file.version, response[0].headers['X-DSS-VERSION'])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,6 +38,10 @@ class TestApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin, DSSStorageMixin
 
     @testmode.standalone
     def test_creation_and_retrieval_of_files_and_bundle(self):
+
+        # FIXME: This test doesn't do much because it uses the test bucket which lacks the fixtures for the test bundle.
+        # FIMXE: In particular it does not test any of the /files routes. (hannes)
+
         """
         Test file and bundle lifecycle.
         Exercises:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -210,18 +210,6 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             )
             self.assertEqual(resp_obj.json['code'], "file_missing")
 
-        # should *NOT* be able to upload a bundle containing a file with an incorrect bundle_uuid
-        # but we should get requests.codes.conflict
-        with nestedcontext.bind(time_left=lambda: 0):
-            resp_obj = self.put_bundle(
-                replica,
-                str(uuid.uuid4()),  # uploading new bundle with old file
-                [(file_uuid, file_version, "LICENSE")],
-                datetime_to_version_format(datetime.datetime.utcnow()),
-                expected_code=requests.codes.conflict,
-            )
-            self.assertEqual(resp_obj.json['code'], "incorrect_file_bundle_uuid")
-
         # uploads a file, but delete the file metadata. put it back after a delay.
         self.upload_file_wait(
             f"{schema}://{fixtures_bucket}/test_good_source_data/0",

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -76,8 +76,8 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self.upload_file(source_url, file_uuid, bundle_uuid=bundle_uuid,
                          version=version, expected_code=requests.codes.ok)
 
-        # should *NOT* be able to do this twice (i.e., different payload, same UUIDs)
-        self.upload_file(source_url, file_uuid, version=version, expected_code=requests.codes.conflict)
+        # should be able to do this twice (i.e., different payload, same UUIDs)
+        self.upload_file(source_url, file_uuid, version=version, expected_code=requests.codes.ok)
 
     @testmode.integration
     def test_file_put_large(self):


### PR DESCRIPTION
Remove backlink from file to bundle (fixes #1172)

This makes it possible for a file to belong to more than one bundle. It has implications on the physical deletion of files. We cannot remove a file without enumerating all bundles, loading their metadata and then checking if any other bundles reference that file. However this is no different to the physical deletion of blobs: since one blob can belong to many files, the same enumeration is required there. Ultimately, physical deletion due to lack of consent will always require the deletion of the actual data, i.e. the blob. These changes do not significantly complicate the search for files and bundles that refer to it, or, IOW, the presence of a backlink from file to bundle does not siginifcantly simplify the problem.
