### PR TITLE
 Use stage-specific CW rule names for notifier

### DIFF
--- a/daemons/dss-notify/app.py
+++ b/daemons/dss-notify/app.py
@@ -21,11 +21,7 @@ def deploy_notifier():
 app = domovoi.Domovoi(configure_logs=False)
 
 
+@app.scheduled_function("rate(1 minute)", rule_name='run_notifier_' + Config.deployment_stage())
 def run_notifier(event, context):
     notifier = Notifier.from_config()
     notifier.run(context)
-
-
-# FIXME: https://github.com/HumanCellAtlas/data-store/issues/1211
-run_notifier.__name__ += "_" + Config.deployment_stage()
-run_notifier = app.scheduled_function("rate(1 minute)")(run_notifier)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,7 +30,7 @@ dnspython==1.15.0
 docker==2.6.1
 docker-pycreds==0.2.1
 docutils==0.14
-domovoi==1.5.4
+domovoi==1.5.8
 elasticsearch==5.5.1
 elasticsearch-dsl==5.3.0
 Faker==0.8.11

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,14 @@
 # You should not edit this file directly.  Instead, you should edit requirements-dev.txt.in.
+aegea==2.2.0
+argcomplete==1.9.4
 asn1crypto==0.23.0
 aws-xray-sdk==0.94
 awscli==1.12.2
 azure-common==1.1.8
 azure-nspkg==2.0.0
 azure-storage==0.36.0
+Babel==2.5.3
+bcrypt==3.1.4
 boto==2.48.0
 boto3==1.6.0
 botocore==1.10.8
@@ -14,6 +18,7 @@ cffi==1.11.2
 chalice==1.1.0
 chardet==3.0.4
 click==6.7
+clickclick==1.2.2
 cloud-blobstore==2.1.1
 colorama==0.3.7
 connexion==1.1.15
@@ -21,6 +26,7 @@ cookies==2.2.1
 coverage==4.4.2
 crcmod==1.7
 cryptography==2.1.4
+dnspython==1.15.0
 docker==2.6.1
 docker-pycreds==0.2.1
 docutils==0.14
@@ -42,6 +48,7 @@ httpie==0.9.9
 httplib2==0.11.0
 idna==2.6
 inflection==0.3.1
+ipwhois==1.0.0
 iso8601==0.1.12
 itsdangerous==0.24
 Jinja2==2.10
@@ -49,6 +56,7 @@ jmespath==0.9.3
 jsondiff==1.1.1
 jsonpickle==0.9.5
 jsonschema==2.6.0
+keymaker==1.0.3
 MarkupSafe==1.0
 mccabe==0.6.1
 mock==2.0.0
@@ -57,6 +65,7 @@ moto==1.1.25
 mypy==0.550
 nestedcontext==0.0.4
 oauth2client==4.1.2
+paramiko==2.4.1
 pbr==3.1.1
 protobuf==3.5.0.post1
 psutil==5.4.1
@@ -67,6 +76,7 @@ pycodestyle==2.3.1
 pycparser==2.18
 pyflakes==1.6.0
 Pygments==2.2.0
+PyNaCl==1.2.1
 python-dateutil==2.6.1
 pytz==2017.3
 PyYAML==3.12
@@ -79,8 +89,10 @@ s3transfer==0.1.11
 six==1.11.0
 swagger-spec-validator==2.1.0
 text-unidecode==1.1
+tweak==0.6.7
 typed-ast==1.1.0
 typing==3.5.3.0
+uritemplate==3.0.0
 urllib3==1.22
 websocket-client==0.44.0
 Werkzeug==0.12.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ Babel==2.5.3
 bcrypt==3.1.4
 boto==2.48.0
 boto3==1.6.0
-botocore==1.10.8
+botocore==1.10.16
 cachetools==2.0.1
 certifi==2018.1.18
 cffi==1.11.2

--- a/requirements-dev.txt.in
+++ b/requirements-dev.txt.in
@@ -11,6 +11,6 @@ httpie  >= 0.9.9
 yq  >= 2.3.3
 Faker >= 0.8.11
 rstr >=2.2.6
-click
+click >= 5.7
 aegea >= 2.1.9
 -r requirements.txt.in

--- a/requirements-dev.txt.in
+++ b/requirements-dev.txt.in
@@ -1,7 +1,7 @@
 # Be sure to run "make requirements-dev.txt" after editing this file.
 flake8  >= 3.4.1
 mypy  >= 0.530
-domovoi  >= 1.5.4
+domovoi  >= 1.5.8
 chalice  >= 1.1.0
 coverage  >= 4.4.1
 awscli  >= 1.11.166

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ azure-common==1.1.8
 azure-nspkg==2.0.0
 azure-storage==0.36.0
 boto3==1.6.0
-botocore==1.10.14
+botocore==1.10.16
 cachetools==2.0.1
 certifi==2018.1.18
 cffi==1.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,13 @@ azure-common==1.1.8
 azure-nspkg==2.0.0
 azure-storage==0.36.0
 boto3==1.6.0
-botocore==1.10.8
+botocore==1.9.23
 cachetools==2.0.1
 certifi==2018.1.18
 cffi==1.11.2
 chardet==3.0.4
 click==6.7
+clickclick==1.2.2
 cloud-blobstore==2.1.1
 connexion==1.1.15
 cryptography==2.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ azure-common==1.1.8
 azure-nspkg==2.0.0
 azure-storage==0.36.0
 boto3==1.6.0
-botocore==1.9.23
+botocore==1.10.14
 cachetools==2.0.1
 certifi==2018.1.18
 cffi==1.11.2

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -1,6 +1,7 @@
 # Be sure to run "make requirements.txt requirements-dev.txt" after editing this file.
 azure-storage >= 0.36.0
 boto3 >= 1.6.0
+botocore >= 1.10.8  # 1.9.x does not support AWS secretsmanager support
 cloud-blobstore >= 2.1.1
 connexion == 1.1.15 # pinned by akislyuk due to upstream breaking changes in auth middleware in connexion 1.2
 elasticsearch >= 5.4.0, < 6.0.0

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -1,7 +1,7 @@
 # Be sure to run "make requirements.txt requirements-dev.txt" after editing this file.
 azure-storage >= 0.36.0
 boto3 >= 1.6.0
-botocore >= 1.10.8  # 1.9.x does not support AWS secretsmanager support
+botocore >= 1.10.16  # 1.9.x does not support AWS secretsmanager support
 cloud-blobstore >= 2.1.1
 connexion == 1.1.15 # pinned by akislyuk due to upstream breaking changes in auth middleware in connexion 1.2
 elasticsearch >= 5.4.0, < 6.0.0


### PR DESCRIPTION
(fixes #1211)

Since I had to touch the requirements files, I also fixed three regressions there

- aegea was added to the `.in` but the `.txt` was never updated
- the explicit `.in` entry for `botocore` was missing (we know we need 1.10 and the first commit proves that the downgrade to 1.9 does indeed happen without this entry, as I suspected)
- the lower bound on `click` was missing (we agreed to provide lower bounds in the `.in`)

I clobbered @ttung's manual one-time exclusion of `clickclick`. It may be unnecessary but we can't expect all devs to forever redo the exclusion. We need a way to declaratively exclude it or just accept its presence.