### PR TITLE
Lengthen nearline storage timeouts in TestGSCopy

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -116,13 +116,21 @@ class Config:
 
     @staticmethod
     @functools.lru_cache()
-    def get_native_handle(replica: "Replica") -> typing.Any:
+    def get_native_handle(replica: "Replica",
+                          connect_timeout: float=None,
+                          read_timeout: float=None) -> typing.Any:
+
+        if connect_timeout is None:
+            connect_timeout = Config.BLOBSTORE_CONNECT_TIMEOUT
+        if read_timeout is None:
+            read_timeout = Config.BLOBSTORE_READ_TIMEOUT
+
         if replica == Replica.aws:
             return boto3.client(
                 "s3",
                 config=botocore.config.Config(
-                    connect_timeout=Config.BLOBSTORE_CONNECT_TIMEOUT,
-                    read_timeout=Config.BLOBSTORE_READ_TIMEOUT,
+                    connect_timeout=connect_timeout,
+                    read_timeout=read_timeout,
                     retries={'max_attempts': Config.BLOBSTORE_BOTO_RETRIES}
                 )
             )
@@ -133,7 +141,7 @@ class Config:
             # stdlib `requests` package, which has straightforward timeout usage.
             class SessionWithTimeouts(google.auth.transport.requests.AuthorizedSession):
                 def request(self, *args, **kwargs):
-                    kwargs['timeout'] = (Config.BLOBSTORE_CONNECT_TIMEOUT, Config.BLOBSTORE_READ_TIMEOUT)
+                    kwargs['timeout'] = (connect_timeout, read_timeout)
                     return super().request(*args, **kwargs)
 
             credentials = service_account.Credentials.from_service_account_file(

--- a/tests/test_gscopyclient.py
+++ b/tests/test_gscopyclient.py
@@ -51,7 +51,12 @@ class TestGSCopy(unittest.TestCase):
         # NOTE: compose(…) does not seem to support setting a storage class.  The canonical way of changing storage
         # class is to call update_storage_class(…), but Google's libraries does not seem to handle
         # update_storage_class(…) calls for large objects.
-        final_blob_obj = bucket_obj.blob(final_key)
+        # Second NOTE: nearline storage is not as snappy as normal storage, and requires longer timeouts.
+        final_blob_obj = Config.get_native_handle(
+            Replica.gcp,
+            connect_timeout=60,
+            read_timeout=60,
+        ).bucket(self.test_bucket).blob(final_key)
         final_blob_obj.storage_class = "NEARLINE"
         final_blob_src = bucket_obj.get_blob(test_src_keys[-1])
         token = None

--- a/tests/test_gscopyclient.py
+++ b/tests/test_gscopyclient.py
@@ -51,7 +51,7 @@ class TestGSCopy(unittest.TestCase):
         # NOTE: compose(…) does not seem to support setting a storage class.  The canonical way of changing storage
         # class is to call update_storage_class(…), but Google's libraries does not seem to handle
         # update_storage_class(…) calls for large objects.
-        # Second NOTE: nearline storage is not as snappy as normal storage, and requires longer timeouts.
+        # Second NOTE: nearline storage upload is not as snappy as normal storage, and requires longer timeouts.
         final_blob_obj = Config.get_native_handle(
             Replica.gcp,
             connect_timeout=60,


### PR DESCRIPTION
Fix for integration test failures.

During test setup, TestGSCopy uploads a blob to GCP "nearline" storage, which is a semi-cold storage service. Since nearline storage uploads do not appear to be particularly snappy, use longer connect/read timeouts during upload.