### PR TITLE
Connect/read blobstore timeouts enabled only for API server

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -28,6 +28,10 @@ from dss.util import paginate
 configure_lambda_logging()
 
 Config.set_config(BucketConfig.NORMAL)
+Config.BLOBSTORE_CONNECT_TIMEOUT = 5
+Config.BLOBSTORE_READ_TIMEOUT = 5
+Config.BLOBSTORE_BOTO_RETRIES = 2
+Config.BLOBSTORE_GS_MAX_CUMULATIVE_RETRY = 15
 
 
 EXECUTION_TERMINATION_THRESHOLD_SECONDS = 5.0

--- a/dss/config.py
+++ b/dss/config.py
@@ -125,7 +125,7 @@ class Config:
 
     @staticmethod
     def _get_native_aws_handle() -> typing.Any:
-        if (Config.BLOBSTORE_CONNECT_TIMEOUT, Config.BLOBSTORE_READ_TIMEOUT) == (None, None):
+        if Config.BLOBSTORE_CONNECT_TIMEOUT is None or Config.BLOBSTORE_READ_TIMEOUT is None:
             return boto3.client("s3")
         else:
             return boto3.client(
@@ -142,7 +142,7 @@ class Config:
         if Config.BLOBSTORE_GS_MAX_CUMULATIVE_RETRY is not None:
             google.resumable_media.common.MAX_CUMULATIVE_RETRY = Config.BLOBSTORE_GS_MAX_CUMULATIVE_RETRY
 
-        if (Config.BLOBSTORE_CONNECT_TIMEOUT, Config.BLOBSTORE_READ_TIMEOUT) == (None, None):
+        if Config.BLOBSTORE_CONNECT_TIMEOUT is None or Config.BLOBSTORE_READ_TIMEOUT is None:
             return Client.from_service_account_json(
                 os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
             )

--- a/dss/config.py
+++ b/dss/config.py
@@ -116,21 +116,13 @@ class Config:
 
     @staticmethod
     @functools.lru_cache()
-    def get_native_handle(replica: "Replica",
-                          connect_timeout: float=None,
-                          read_timeout: float=None) -> typing.Any:
-
-        if connect_timeout is None:
-            connect_timeout = Config.BLOBSTORE_CONNECT_TIMEOUT
-        if read_timeout is None:
-            read_timeout = Config.BLOBSTORE_READ_TIMEOUT
-
+    def get_native_handle(replica: "Replica") -> typing.Any:
         if replica == Replica.aws:
             return boto3.client(
                 "s3",
                 config=botocore.config.Config(
-                    connect_timeout=connect_timeout,
-                    read_timeout=read_timeout,
+                    connect_timeout=Config.BLOBSTORE_CONNECT_TIMEOUT,
+                    read_timeout=Config.BLOBSTORE_READ_TIMEOUT,
                     retries={'max_attempts': Config.BLOBSTORE_BOTO_RETRIES}
                 )
             )
@@ -141,7 +133,7 @@ class Config:
             # stdlib `requests` package, which has straightforward timeout usage.
             class SessionWithTimeouts(google.auth.transport.requests.AuthorizedSession):
                 def request(self, *args, **kwargs):
-                    kwargs['timeout'] = (connect_timeout, read_timeout)
+                    kwargs['timeout'] = (Config.BLOBSTORE_CONNECT_TIMEOUT, Config.BLOBSTORE_READ_TIMEOUT)
                     return super().request(*args, **kwargs)
 
             credentials = service_account.Credentials.from_service_account_file(

--- a/tests/test_gscopyclient.py
+++ b/tests/test_gscopyclient.py
@@ -51,12 +51,7 @@ class TestGSCopy(unittest.TestCase):
         # NOTE: compose(…) does not seem to support setting a storage class.  The canonical way of changing storage
         # class is to call update_storage_class(…), but Google's libraries does not seem to handle
         # update_storage_class(…) calls for large objects.
-        # Second NOTE: nearline storage upload is not as snappy as normal storage, and requires longer timeouts.
-        final_blob_obj = Config.get_native_handle(
-            Replica.gcp,
-            connect_timeout=60,
-            read_timeout=60,
-        ).bucket(self.test_bucket).blob(final_key)
+        final_blob_obj = bucket_obj.blob(final_key)
         final_blob_obj.storage_class = "NEARLINE"
         final_blob_src = bucket_obj.get_blob(test_src_keys[-1])
         token = None


### PR DESCRIPTION
* Use default client timeouts for daemons, which are unconstrained by API Gateway.
* Revert timeout changes to `tests/test_gscopyclient.py`