### PR TITLE
Add simple storage replication check (fixes #667) 

### DIFF
--- a/daemons/dss-admin/app.py
+++ b/daemons/dss-admin/app.py
@@ -12,6 +12,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from dss import BucketConfig, Config, Replica
 from dss.logging import configure_lambda_logging
 from dss.stepfunctions.visitation.reindex import Reindex
+from dss.stepfunctions.visitation.storage import StorageVisitation
 from dss.util.types import JSON
 
 
@@ -50,6 +51,21 @@ class IndexTarget(Target):
                                       dryrun=dryrun,
                                       notify=notify)
         return {'visitation_id': visitation_id}
+
+
+class StorageTarget(Target):
+    """
+    Admin operations on the storage buckets and the replication between them.
+    """
+    def __init__(self, replicas: Mapping[str, str]) -> None:
+        replicas = ((Replica[replica], bucket) for replica, bucket in replicas.items())
+        self.replicas = {replica.name: bucket or replica.bucket for replica, bucket in replicas}
+        super().__init__()
+
+    def verify(self, workers: int) -> JSON:
+        assert 1 < workers
+        replicas, buckets = zip(*self.replicas.items())
+        visitation_id = StorageVisitation.start(workers, replicas=replicas, buckets=buckets)
         return {'visitation_id': visitation_id}
 
 

--- a/daemons/dss-admin/app.py
+++ b/daemons/dss-admin/app.py
@@ -44,7 +44,12 @@ class IndexTarget(Target):
 
     def _reindex(self, workers: int, dryrun: bool, notify: Optional[bool]) -> Mapping[str, Any]:
         assert 1 < workers
-        visitation_id = Reindex.start(self.replica.name, self.bucket, workers, dryrun=dryrun, notify=notify)
+        visitation_id = Reindex.start(workers,
+                                      replica=self.replica.name,
+                                      bucket=self.bucket,
+                                      dryrun=dryrun,
+                                      notify=notify)
+        return {'visitation_id': visitation_id}
         return {'visitation_id': visitation_id}
 
 

--- a/daemons/dss-admin/app.py
+++ b/daemons/dss-admin/app.py
@@ -12,6 +12,7 @@ sys.path.insert(0, pkg_root)  # noqa
 from dss import BucketConfig, Config, Replica
 from dss.logging import configure_lambda_logging
 from dss.stepfunctions.visitation.reindex import Reindex
+from dss.util.types import JSON
 
 
 Config.set_config(BucketConfig.NORMAL)
@@ -35,10 +36,10 @@ class IndexTarget(Target):
         self.replica = Replica[replica]
         self.bucket = bucket or self.replica.bucket
 
-    def repair(self, workers: int) -> Mapping[str, Any]:
+    def repair(self, workers: int) -> JSON:
         return self._reindex(workers, dryrun=False, notify=None)
 
-    def verify(self, workers: int) -> Mapping[str, Any]:
+    def verify(self, workers: int) -> JSON:
         return self._reindex(workers, dryrun=True, notify=False)
 
     def _reindex(self, workers: int, dryrun: bool, notify: Optional[bool]) -> Mapping[str, Any]:
@@ -66,6 +67,7 @@ class DSSAdmin(domovoi.Domovoi):
         action = getattr(target, action_name)
         result = _invoke(action, options)
         return json.dumps(result)
+
 
 configure_lambda_logging()
 app = DSSAdmin(configure_logs=False)

--- a/dss/logging.py
+++ b/dss/logging.py
@@ -1,5 +1,5 @@
 import logging
-from logging import DEBUG, INFO, WARNING
+from logging import DEBUG, INFO, WARNING, ERROR
 import os
 import sys
 from typing import Mapping, Union, Tuple, Optional
@@ -32,6 +32,7 @@ The values in this map are tuples of log levels. The first (second or third) tup
 
 test_log_levels: log_level_t = {
     dss.logger: (WARNING, DEBUG),
+    'dss.stepfunctions.visitation.storage': (ERROR, DEBUG),
     'test.es': (INFO, DEBUG)
 }
 """

--- a/dss/stepfunctions/__init__.py
+++ b/dss/stepfunctions/__init__.py
@@ -23,7 +23,6 @@ sfn_sns_topic = f"dss-sfn-{stage}"
 sfn_sns_topic_arn = f"arn:aws:sns:{region}:{accountid}:{sfn_sns_topic}"
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 def step_functions_arn(state_machine_name_template: str) -> str:

--- a/dss/stepfunctions/visitation/__init__.py
+++ b/dss/stepfunctions/visitation/__init__.py
@@ -102,14 +102,12 @@ class Visitation:
         }
 
     @classmethod
-    def start(cls, replica: str, bucket: str, number_of_workers: int, **kwargs) -> str:
+    def start(cls, number_of_workers: int, **kwargs) -> str:
         name = '{}--{}'.format(cls.__name__, str(uuid4()))
 
         inp = {
             **kwargs,
             '_visitation_class_name': cls.__name__,
-            'replica': replica,
-            'bucket': bucket,
             '_number_of_workers': number_of_workers,
         }
         # Invoke directly without reaper/retry

--- a/dss/stepfunctions/visitation/__init__.py
+++ b/dss/stepfunctions/visitation/__init__.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from enum import Enum, auto
 
 from dss.stepfunctions import _step_functions_start_execution
-from dss.util.types import LambdaContext
+from dss.util.types import LambdaContext, JSON
 
 logger = logging.getLogger(__name__)
 
@@ -102,18 +102,16 @@ class Visitation:
         }
 
     @classmethod
-    def start(cls, number_of_workers: int, **kwargs) -> str:
+    def start(cls, number_of_workers: int, **kwargs) -> JSON:
         name = '{}--{}'.format(cls.__name__, str(uuid4()))
-
-        inp = {
+        execution_input = {
             **kwargs,
             '_visitation_class_name': cls.__name__,
             '_number_of_workers': number_of_workers,
         }
         # Invoke directly without reaper/retry
-        _step_functions_start_execution('dss-visitation-{stage}', name, json.dumps(inp))
-
-        return name
+        execution = _step_functions_start_execution('dss-visitation-{stage}', name, json.dumps(execution_input))
+        return dict(arn=execution['executionArn'], name=name, input=execution_input)
 
     def job_initialize(self) -> None:
         """

--- a/dss/stepfunctions/visitation/implementation.py
+++ b/dss/stepfunctions/visitation/implementation.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 
 from .registered_visitations import registered_visitations
@@ -65,7 +66,7 @@ def walker_initialize(event, context, branch):
         """
         Re-initialize user space walker state.
         """
-        setattr(walker, k, v() if callable(v) else v)
+        setattr(walker, k, v() if callable(v) else copy.deepcopy(v))
 
     walker.walker_initialize()
 

--- a/dss/stepfunctions/visitation/registered_visitations.py
+++ b/dss/stepfunctions/visitation/registered_visitations.py
@@ -2,8 +2,7 @@
 from .integration_test import IntegrationTest
 from .reindex import Reindex
 
-
-registered_visitations = {
-    'IntegrationTest': IntegrationTest,
-    'Reindex': Reindex
-}
+registered_visitations = {c.__name__: c for c in [
+    IntegrationTest,
+    Reindex,
+]}

--- a/dss/stepfunctions/visitation/registered_visitations.py
+++ b/dss/stepfunctions/visitation/registered_visitations.py
@@ -1,8 +1,10 @@
 
 from .integration_test import IntegrationTest
 from .reindex import Reindex
+from .storage import StorageVisitation
 
 registered_visitations = {c.__name__: c for c in [
     IntegrationTest,
     Reindex,
+    StorageVisitation,
 ]}

--- a/dss/stepfunctions/visitation/reindex.py
+++ b/dss/stepfunctions/visitation/reindex.py
@@ -54,14 +54,13 @@ class Reindex(Visitation):
         # We can't use executor as context manager because we don't want shutting it down to block
         try:
             backend = CompositeIndexBackend(executor, DEFAULT_BACKENDS, dryrun=self.dryrun, notify=self.notify)
-            indexer_cls = Indexer.for_replica(Replica[self.replica])
+            replica = Replica[self.replica]
+            indexer_cls = Indexer.for_replica(replica)
             indexer = indexer_cls(backend, self._context)
 
-            handle = Config.get_blobstore_handle(Replica[self.replica])
-            default_bucket = Replica[self.replica].bucket
-
-            if self.bucket != default_bucket:
-                logger.warning(f'Indexing bucket {self.bucket} instead of default {default_bucket}.')
+            handle = Config.get_blobstore_handle(replica)
+            if self.bucket != replica.bucket:
+                logger.warning(f'Indexing bucket {self.bucket} instead of default {self.bucket}.')
 
             blobs = handle.list_v2(
                 self.bucket,

--- a/dss/stepfunctions/visitation/storage.py
+++ b/dss/stepfunctions/visitation/storage.py
@@ -1,0 +1,105 @@
+import logging
+import string
+from typing import Mapping, MutableMapping, Sequence, List, Optional, Tuple
+
+from cloud_blobstore import PagedIter
+
+from dss.config import Config, Replica
+from dss.util.iterators import zipalign
+from . import Visitation, WalkerStatus
+
+logger = logging.getLogger(__name__)
+
+
+# noinspection PyAttributeOutsideInit
+class StorageVisitation(Visitation):
+
+    # A central pattern in this class is to use covariant arrays that have one element per replica. For example,
+    # `self.buckets[i]` is the custom bucket to be used for the replica whose name is `self.replicas[i]`. Similarly,
+    # `self.work_result['missing'][i]` is the number of missing keys in the bucket for the replica whose name is
+    # `self.replicas[i]`. While this is not especially readable, it is efficient and fits best with the convention
+    # established by the super class which encourages state to be a dict with static keys. Instead of arrays I
+    # experimented with dicts keyed on replica name but that turned out to be unwieldy. The covariant array approach
+    # allows for the use of zip() to merge two such arrays and iterate over the result. The most readable and
+    # efficient pattern would be to use a single dict that maps replica names to objects or dicts representing all
+    # replica-specific items, but again, that approach didn't seem to fit well with the superclass.
+
+    shutdown_time = 10
+
+    state_spec = dict(replicas=None,
+                      buckets=None,
+                      work_result=dict(present=None,
+                                       missing=None))
+
+    prefix_chars = list(set(string.hexdigits.lower()))
+
+    def job_initialize(self):
+        if self._number_of_workers <= 16:
+            self.work_ids = self.prefix_chars
+        else:
+            self.work_ids = [a + b for b in self.prefix_chars for a in self.prefix_chars]
+        n = len(self.replicas)
+        self.work_result = {k: [0] * n for k in self.work_result.keys()}
+
+    walker_state_spec = dict(tokens=None,
+                             row=None)
+
+    def walker_initialize(self) -> None:
+        n = len(self.replicas)
+        self.row: Tuple[Optional[str], ...] = (None,) * n
+        self.tokens = [None] * n
+
+    def walker_walk(self) -> None:
+        columns = []
+        for replica, bucket, key, token in zip(self.replicas, self.buckets, self.row, self.tokens):
+            replica = Replica[replica]
+            if bucket is None:
+                bucket = replica.bucket
+            elif bucket != replica.bucket:
+                logger.warning(f'Checking bucket {bucket} instead of default {replica.bucket} for replica {replica}.')
+            handle = Config.get_blobstore_handle(replica)
+            column: PagedIter = handle.list_v2(bucket,
+                                               prefix='bundles/' + self.work_id,
+                                               token=token,
+                                               start_after_key=key)
+            columns.append(column)
+
+        diff = zipalign(columns=map(iter, columns), row=self.row)
+        while self.shutdown_time < self.remaining_runtime():
+            try:
+                row = next(diff)
+            except StopIteration:
+                logger.info("Finished checking replicas.")
+                self._status = WalkerStatus.finished.name
+                break
+            else:
+                for i, key in enumerate(row.norm()):
+                    replica = self.replicas[i]
+                    if key is None:
+                        logger.warning(f"Replica {replica} is missing {row.min}")
+                        self.work_result['missing'][i] += 1
+                    else:
+                        logger.debug(f"Replica {replica} contains {key}")
+                        self.work_result['present'][i] += 1
+                self.row = row.values
+        else:
+            self.tokens = [column.token for column in columns]
+            logger.debug('Not enough time left in lambda execution, exiting.')
+
+    def walker_finalize(self):
+        self.tokens = None
+        self.row = None
+        logger.info(f'Work result: {self.work_result}')
+
+    def _aggregate(self, work_results: Sequence[Mapping[str, List[int]]]) -> MutableMapping[str, List[int]]:
+        aggregate: MutableMapping[str, List[int]] = {}
+        for work_result in work_results:
+            for name, deltas in work_result.items():
+                try:
+                    counters = aggregate[name]
+                except KeyError:
+                    aggregate[name] = list(deltas)
+                else:
+                    for i, delta in enumerate(deltas):
+                        counters[i] += delta
+        return aggregate

--- a/dss/util/iterators.py
+++ b/dss/util/iterators.py
@@ -1,0 +1,177 @@
+from itertools import tee
+from typing import Iterator, TypeVar, Optional, Tuple, Iterable, NamedTuple
+
+T = TypeVar('T')
+OT = Optional[T]
+Column = Iterator[T]
+
+
+class zipalign(Iterator['zipalign.Row']):
+    """
+    An iterator that detects differences between any number of input iterators as long as the input iterators yield
+    their elements in strictly ascending order. The signature is similar to that of itertools.zip_longest(*).
+
+    For example, given three tuples …
+
+    >>> columns = [(1, 2),(0, 2),(0, 2, 3)]
+
+    … (written vertically in columnar form) zipalign yields the representation on the right:
+
+    ┌───┬───┬───┐   Align       ┌───┬───┐    Prepend    ┌───┬───┬───┬───┐
+    │ 1 │ 0 │ 0 │    by         │ 0 │ 0 │  column with  │ 0 │ 1 │ 0 │ 0 │
+    ├───┼───┼───┤   value   ┌───┼───┴───┘    minimum    ├───┼───┼───┼───┤    (Empty
+    │ 2 │ 2 │ 2 │ ────────▶ │ 1 │         ────────────▶ │ 1 │ 1 │ 2 │ 2 │    cells
+    └───┴───┼───┤           ├───┼───┬───┐  Values not   ├───┼───┼───┼───┤    denote
+            │ 3 │           │ 2 │ 2 │ 2 │   equal to    │ 2 │ 2 │ 2 │ 2 │    None)
+            └───┘           └───┴───┼───┤    minimum    ├───┼───┴───┼───┤
+                                    │ 3 │   are to be   │ 3 │       │ 3 │
+                                    └───┘    ignored    └───┘       └───┘
+
+    While the center representation is the most intuitive one, zipalign returns the one on the right as it allows for
+    the elimination of intrinsic state and more efficient execution. It is also richer in that it distinguishes
+    between cells missing from an iterator (value != min) and cells past the end of an iterator (value is None).
+
+    >>> i = zipalign(columns)
+    >>> next(i)
+    Row(min=0, values=(1, 0, 0))
+    >>> next(i)
+    Row(min=1, values=(1, 2, 2))
+    >>> next(i)
+    Row(min=2, values=(2, 2, 2))
+    >>> next(i)
+    Row(min=3, values=(None, None, 3))
+    >>> next(i)
+    Traceback (most recent call last):
+    ...
+    StopIteration
+
+    Converting the actual result back to the more intuitive representation is straight-forward …
+
+    >>> [tuple(val if val == row.min else None for val in row.values) for row in zipalign(columns)]
+    [(None, 0, 0), (1, None, None), (2, 2, 2), (None, None, 3)]
+
+    … and row objects offer a convenience method for that:
+
+    >>> [row.norm() for row in zipalign(columns)]
+    [(None, 0, 0), (1, None, None), (2, 2, 2), (None, None, 3)]
+
+    A few more properties: For one, exhaustion is permanent:
+
+    >>> next(i)
+    Traceback (most recent call last):
+    ...
+    StopIteration
+
+    If any input iterators violate the ordering constraint, the behavior is well-defined: an exception is raised as
+    soon as the out-of-order element is detected.
+
+    >>> list(zipalign([(1, 0)]))
+    Traceback (most recent call last):
+    ...
+    ValueError: Input iterator yielded value out of order
+
+    Given a Row object, a zipalign iterator can resume where another zipalign iterator left off:
+
+    >>> columns = list(map(iter, columns))
+    >>> row = next(zipalign(columns)); row
+    Row(min=0, values=(1, 0, 0))
+    >>> next(zipalign(columns, row=row))
+    Row(min=1, values=(1, 2, 2))
+
+    Resumption also works with a plain iterable instead of a Row instance …
+
+    >>> next(zipalign(columns, row=[1, 2, 2]))
+    Row(min=2, values=(2, 2, 2))
+
+    … provided that its length is equal to the number of columns.
+
+    >>> next(zipalign(columns, row=[1, 2, 2, 3]))
+    Traceback (most recent call last):
+    ValueError: Row length (4) does not match # of columns (3)
+
+    We can resume at any stage …
+
+    >>> next(zipalign(columns, row=[2, 2, 2]))
+    Row(min=3, values=(None, None, 3))
+
+    … even at the last row.
+
+    >>> next(zipalign(columns, row=[None, None, 3]))
+    Traceback (most recent call last):
+    ...
+    StopIteration
+    """
+
+    class Row(NamedTuple):
+        """
+        The type of the elements yielded by zipalign. It consists of a tuple of values (the row) and their minimum.
+
+        >>> Row = zipalign.Row
+        >>> row = Row(min=1, values=(1, 2, 3))
+
+        While a Row is a typing.NamedTuple consisting of the `min` and `values` elements, its length and iterator are
+        those of the `values` element:
+
+        >>> len(row)
+        3
+        >>> list(row)
+        [1, 2, 3]
+
+        This comes in handy when converting Row instances to JSON and back:
+
+        >>> import json
+        >>> row == Row.from_values(json.loads(json.dumps(row)))
+        True
+        """
+        min: OT
+        values: Tuple[OT, ...]
+
+        @classmethod
+        def from_values(cls, values: Iterable[OT]):
+            v1, v2 = tee(values)
+            # noinspection PyArgumentList
+            return cls(min=min((val for val in v1 if val is not None), default=None), values=tuple(v2))
+
+        def _fetch(self, val: OT, column: Column) -> OT:
+            if val == self.min:
+                try:
+                    val = next(column)
+                except StopIteration:
+                    val = None
+                else:
+                    if not (self.min is None or self.min < val):
+                        raise ValueError(f"Input iterator yielded value out of order")
+            return val
+
+        def next(self, columns: Tuple[Column, ...]):
+            return self.from_values(map(self._fetch, self.values, columns))
+
+        def norm(self) -> Tuple[OT, ...]:
+            return tuple(val if val == self.min else None for val in self.values)
+
+        def __iter__(self):
+            return iter(self.values)
+
+        def __len__(self) -> int:
+            return len(self.values)
+
+    def __init__(self, columns: Iterable[Column], row: Optional[Iterable[OT]] = None) -> None:
+        self.columns = tuple(map(iter, columns))
+        if row is None:
+            self.row = self.Row.from_values((None,) * len(self.columns))
+        else:
+            self.row = self.Row.from_values(row)
+            if len(self.row) != len(self.columns):
+                raise ValueError(f"Row length ({len(self.row)}) does not match # of columns ({len(self.columns)})")
+
+    def __next__(self) -> Row:
+        if self.row is None:
+            raise StopIteration
+        else:
+            row = self.row.next(self.columns)
+            if all(val is None for val in row.values):
+                self.row = None
+                raise StopIteration
+            else:
+                self.row = row
+                return row

--- a/scripts/admin-cli.py
+++ b/scripts/admin-cli.py
@@ -36,6 +36,7 @@ def parse_args(args):
     index = targets.add_parser('index')
     index.add_argument('--replica', required=True, choices=replicas)
     index.add_argument('--bucket')
+    index.add_argument('--prefix')
     index_actions = index.add_subparsers(dest='action')
     index_actions.required = True
     index_actions.add_parser('verify')

--- a/scripts/admin-cli.py
+++ b/scripts/admin-cli.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 """Perform administrative tasks on the Human Cell Atlas data store"""
 
 import argparse
@@ -7,6 +9,7 @@ import sys
 import boto3
 import os
 
+replicas = ['aws', 'gcp']
 
 # This script should ultimately be moved into its own distribution such that it can be installed independently of the
 # main data-store project. Specifically it should not have a code dependency on the data-store project itself.
@@ -26,17 +29,35 @@ def main(args):
 def parse_args(args):
     cli = argparse.ArgumentParser(description=__doc__)
     cli.add_argument('--stage', default=os.environ.get('DSS_DEPLOYMENT_STAGE'))
+    cli.add_argument('--workers', type=int, default=32)
     targets = cli.add_subparsers(dest='target')
     targets.required = True
+
     index = targets.add_parser('index')
-    index.add_argument('replica', choices=['aws', 'gcp'])
+    index.add_argument('--replica', required=True, choices=replicas)
     index.add_argument('--bucket')
-    index.add_argument('--workers', type=int, default=10)
     index_actions = index.add_subparsers(dest='action')
     index_actions.required = True
     index_actions.add_parser('verify')
     index_actions.add_parser('repair')
+
+    storage = targets.add_parser('storage')
+    storage.add_argument('--replica', dest='replicas', required=True, choices=replicas, action='append')
+    for replica in replicas:
+        assert '-' not in replica  # a dash would convert to
+        storage.add_argument(f'--{replica}-bucket')
+    storage_actions = storage.add_subparsers(dest='action')
+    storage_actions.required = True
+    storage_actions.add_parser('verify')
+
     options = cli.parse_args(args)
+
+    if options.target == 'storage':
+        options.replicas = set(options.replicas)
+        if len(options.replicas) < 2:
+            cli.error('Must specify at least two replicas for a consistency check')
+        options.replicas = {replica: getattr(options, f'{replica}_bucket') for replica in options.replicas}
+
     return options
 
 

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -16,6 +16,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite('dss.util.retry'))
+    tests.addTests(doctest.DocTestSuite('dss.util.iterators'))
     tests.addTests(doctest.DocTestSuite('dss.index.es'))
     return tests
 

--- a/tests/test_visitation.py
+++ b/tests/test_visitation.py
@@ -10,11 +10,10 @@ import logging
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock
 import uuid
 
 import boto3
-import mock
+from unittest import mock
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -220,7 +219,7 @@ def fake_bucket(self):
 def fake_bundle_load(cls, bundle_fqid):
     if bundle_fqid.to_key() == FakeBlobStore.Iterator.keys[2]:
         time.sleep(2)
-    return MagicMock(lookup_tombstone=MagicMock(return_value=None))
+    return mock.MagicMock(lookup_tombstone=mock.MagicMock(return_value=None))
 
 
 def fake_index_object(_self, key):


### PR DESCRIPTION
Please ignore the coverage check. The added code is only covered by integration tests.

This uses my original approach that relies on the listings to be strictly sorted. @xbrianh proposed an alternative solution for two replicas that relaxed that requirement to the extent of being able to efficiently handle mostly sorted listings and degraded to using large amounts of state for unsorted listings, but not failing in that case. Then he, @Bento007 and I generalized his proposal to comparing more than two replicas in parallel, a feature that my original approach already offered. So why did I not go with the alternative approach?

For one, I asked on SO and a Google engineer pointed me at the place where Google documents that their bucket listing is sorted—at a somewhat obscure location—but its documented nonetheless. Amazon documents this property of their bucket listings in a prominent place. The disqualifying disadvantage of the alternative solution is that it could potentially accumulate large amounts of state (the tracking dictionary could get large) if the replicas are significantly out of sync, for example, if many keys are missing in one of the replicas. Unfortunately, state is the one thing we have to be frugal with in step functions. The state maintained by the original approach consists of two 100-byte-ish strings per worker and replica, independent of how inconsistent the replicas are.

@Bento007 then proposed stick with the alternative approach by abandoning a consistency check if the state grows beyond a threshold. While this may be an option now, at some point we want to extend the functionality from just verifying consistency to actually fixing it (like we do with `verify` and `repair` operations for the ES index) so it is important that we handle out-of-sync replicas gracefully, efficiently and exhaustively. And even for the purpose of verification it's desirable to produce an exhaustive report of all inconsistencies.

@Bento007 also proposed persisting the consistency checker state to DynamoDB but I think this would involve additional complexity, unwarranted complexity considering that the original approach is 1) much more space-efficient and 2) we've established that the assumptions it makes are documented by the cloud providers. In the unlikely case that their documentation proves be incorrect, the original approach has the property of failing fast as soon as an out-of-order key is detected in the listing. It won't produce false positives or negatives.