### PR TITLE
Fix duplicate notifications

### DIFF
--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -44,7 +44,7 @@ def dispatch_gs_indexer_event(event, context):
 
 def _handle_event(replica, event, context):
     executor = ThreadPoolExecutor(len(DEFAULT_BACKENDS))
-    # We can't use ecxecutor as context manager because we don't want the shutdown to block
+    # We can't use executor as context manager because we don't want the shutdown to block
     try:
         remaining_time = AdjustedRemainingTime(actual=RemainingLambdaContextTime(context),
                                                offset=-10)  # leave 10s for shutdown

--- a/daemons/dss-notify/app.py
+++ b/daemons/dss-notify/app.py
@@ -9,6 +9,8 @@ sys.path.insert(0, pkg_root)  # noqa
 from dss import Config
 from dss.logging import configure_lambda_logging
 from dss.notify.notifier import Notifier
+from dss.util.time import RemainingLambdaContextTime
+from dss.util.types import LambdaContext
 
 configure_lambda_logging()
 
@@ -22,6 +24,6 @@ app = domovoi.Domovoi(configure_logs=False)
 
 
 @app.scheduled_function("rate(1 minute)", rule_name='run_notifier_' + Config.deployment_stage())
-def run_notifier(event, context):
+def run_notifier(event, context: LambdaContext):
     notifier = Notifier.from_config()
-    notifier.run(context)
+    notifier.run(RemainingLambdaContextTime(context))

--- a/dss/stepfunctions/visitation/implementation.py
+++ b/dss/stepfunctions/visitation/implementation.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 
+from dss.util.time import RemainingLambdaContextTime
 from .registered_visitations import registered_visitations
 from . import DSSVisitationException, WalkerStatus
 
@@ -22,7 +23,8 @@ def vis_obj(event, context):
     if vis_class is None:
         raise DSSVisitationException('Unknown visitation class')
 
-    return vis_class._with_state(event, context)
+    remaining_time = RemainingLambdaContextTime(context)
+    return vis_class._with_state(event, remaining_time)
 
 
 def job_initialize(event, context):

--- a/dss/stepfunctions/visitation/index.py
+++ b/dss/stepfunctions/visitation/index.py
@@ -55,7 +55,7 @@ class IndexVisitation(Visitation):
             backend = CompositeIndexBackend(executor, DEFAULT_BACKENDS, dryrun=self.dryrun, notify=self.notify)
             replica = Replica[self.replica]
             indexer_cls = Indexer.for_replica(replica)
-            indexer = indexer_cls(backend, self._context)
+            indexer = indexer_cls(backend, self._remaining_time)
 
             handle = Config.get_blobstore_handle(replica)
             if self.bucket != replica.bucket:

--- a/dss/util/time.py
+++ b/dss/util/time.py
@@ -1,0 +1,68 @@
+from abc import ABCMeta, abstractmethod
+import time
+
+from dss.util import require
+from dss.util.types import LambdaContext
+
+
+class RemainingTime(metaclass=ABCMeta):
+    """
+    A monotonically decreasing, non-negative estimate of time remaining in a particular context
+    """
+
+    @abstractmethod
+    def get(self) -> float:
+        """
+        Returns the estimated remaining time in seconds
+        """
+        raise NotImplementedError()
+
+
+class RemainingLambdaContextTime(RemainingTime):
+    """
+    The estimated running time in an AWS Lambda context
+    """
+
+    def __init__(self, context: LambdaContext) -> None:
+        super().__init__()
+        self._context = context
+
+    def get(self) -> float:
+        return self._context.get_remaining_time_in_millis() / 1000
+
+
+class RemainingTimeUntil(RemainingTime):
+    """
+    The remaining wall clock time up to a given absolute deadline in terms of time.time()
+    """
+
+    def __init__(self, deadline: float) -> None:
+        super().__init__()
+        self._deadline = deadline
+
+    def get(self) -> float:
+        return max(0.0, self._deadline - time.time())
+
+
+class SpecificRemainingTime(RemainingTimeUntil):
+    """
+    A specific relative amount of wall clock time in seconds
+    """
+
+    def __init__(self, amount: float) -> None:
+        require(amount >= 0, "Inital remaining time must be non-negative")
+        super().__init__(time.time() + amount)
+
+
+class AdjustedRemainingTime(RemainingTime):
+    """
+    Some other estimate of remaining time adjusted by a fixed offset
+    """
+
+    def __init__(self, offset: float, actual: RemainingTime) -> None:
+        super().__init__()
+        self._offset = offset
+        self._actual = actual
+
+    def get(self) -> float:
+        return max(0.0, self._actual.get() + self._offset)

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -32,7 +32,7 @@ from dss.logging import configure_test_logging
 from dss.notify.notification import Notification, attempt_header_name
 from dss.notify.notifier import Notifier
 from dss.util import networking
-from dss.util.types import LambdaContext
+from dss.util.time import SpecificRemainingTime
 from infra import testmode
 
 logger = logging.getLogger(__name__)
@@ -110,13 +110,13 @@ class _TestNotifier(ThreadedHttpServerTestCase):
                                  overhead=self.overhead)
         self.notifier.deploy()
 
-    def _mock_context(self, total_attempts):
+    def _estimate_running_time(self, total_attempts) -> float:
         latency = sum(delay for delay in self.delays)
         average_overhead = self.overhead / 3  # FIXME: this is a guess
         average_timeout = self.timeout / 2  # FIXME: this is a guess
         parallelism = self.num_queues + (self.num_workers - self.num_queues) / 5  # FIXME: this is a guess
         total_time = latency + (average_timeout + average_overhead) * total_attempts / parallelism
-        return MockLambdaContext(total_time)
+        return total_time
 
     def tearDown(self):
         self.notifier.destroy()
@@ -170,7 +170,8 @@ class _TestNotifier(ThreadedHttpServerTestCase):
             # … takes a little longer to deliver, but then fails, will be missed
             notify(responses=[(self.timeout / 2, 500)], expect=False)
 
-            self.notifier.run(self._mock_context(total_attempts))
+            remaining_time = SpecificRemainingTime(self._estimate_running_time(total_attempts))
+            self.notifier.run(remaining_time)
 
         actual_receptions = set(PostTestHandler.actual_receptions)
         self.assertEqual(expected_receptions, actual_receptions)
@@ -270,17 +271,6 @@ class TestWorkerQueueAssignment(unittest.TestCase):
         sigma = sqrt(sum((c - avg) ** 2 for c in queue_coverage.values()) / (num_queues - 2))
         # The short queues' covereage should be within one standard deviation
         self.assertTrue(all(abs(c - avg) <= sigma) for c in queue_coverage.values())
-
-
-# noinspection PyAbstractClass
-class MockLambdaContext(LambdaContext):
-
-    def __init__(self, running_time: float) -> None:
-        super().__init__()
-        self.end_time = time.time() + running_time
-
-    def get_remaining_time_in_millis(self) -> int:
-        return int((self.end_time - time.time()) * 1000)
 
 
 class PostTestHandler(BaseHTTPRequestHandler):

--- a/tests/test_visitation.py
+++ b/tests/test_visitation.py
@@ -250,8 +250,9 @@ class TestIndexVisitation(unittest.TestCase):
     @mock.patch('dss.index.bundle.Bundle.load', new=fake_bundle_load)
     @mock.patch('dss.index.es.backend.ElasticsearchIndexBackend.index_bundle')
     def test_timeout(self, index_bundle):
+        timeout = ElasticsearchIndexBackend.timeout + index.IndexVisitation.shutdown_time
         r = index.IndexVisitation._with_state(state={'replica': 'aws'},
-                                              remaining_time=SpecificRemainingTime(ElasticsearchIndexBackend.timeout + 1))
+                                              remaining_time=SpecificRemainingTime(timeout + 1))
         # The third item will sleep for two seconds and that will push the time remaining to below the timeout
         r._walk()
         self.assertEquals(2, index_bundle.call_count)
@@ -264,8 +265,9 @@ class TestIndexVisitation(unittest.TestCase):
     @mock.patch('dss.index.bundle.Bundle.load', new=fake_bundle_load)
     @mock.patch('dss.index.es.backend.ElasticsearchIndexBackend.index_bundle')
     def test_no_time_remaining(self, index_bundle):
+        timeout = ElasticsearchIndexBackend.timeout + index.IndexVisitation.shutdown_time
         r = index.IndexVisitation._with_state(state={'replica': 'aws'},
-                                              remaining_time=SpecificRemainingTime(ElasticsearchIndexBackend.timeout - 1))
+                                              remaining_time=SpecificRemainingTime(timeout - 1))
         r._walk()
         self.assertEquals(0, index_bundle.call_count)
         self.assertIsNone(r.marker)


### PR DESCRIPTION
Another outcome from the F2F at Boston and the collaboration with @rexwangcc there. 

Backend timeouts are currently not handled very well and could cause duplicate notifications. For the remainder of this text, note that we run the actual indexer backend as a task in a thread pool executor.

E = estimated time for writing one document (tombstone or bundle document)
R = remaining time in lambda execution

Currently the main thread times out after waiting E seconds for the backend thread and exits with an exception. The exception will eventually cause the lambda execution to fail and then to be retried. While the main thread is shutting down, the backend thread continues to run in its own pool thread. The pool isn't shut down (by choice, so it doesn't block) and the backend thread keeps running. It is a daemon however and therefore doesn't prevent the termination of the process, in this case the lambda execution context. In other words, it just gets terminated at a random point in its life. Just by chance, the runaway backend thread sometimes succeeds in queueing the notification for the indexed bundle. One of the two built-in retried execution of the lambda will then likely succeed and queue another duplicate notification.

Increasing E from 10s to 60s eliminated this problem but leaves the last 60s of a lambda execution unused. This is ok when indexing but not so much when reindexing where we want to index many bundles per lambda execution. We can do better by decoupling the time the main thread waits for the backend thread from E and use R instead. In other words, we'll leave in place the check that prevents the indexer from comitting to perform the indexing operations alltogether (update the index and queue the notification) if R < E but once it decided to do so, it will be given R instead of E to doing so.

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->
<!-- Use the following Waffle keyword if your PR is related to an issue: "Connects to #123" -->

### Test plan
<!-- Describe how you tested this PR, and how you will test the feature after it is merged. -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
