### PR TITLE
[Easy] Component dirs must contain terraform files

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,4 +1,4 @@
-DIRS=${shell find . -name *.tf -exec dirname {} \; | sort --unique}
+DIRS=${shell find . -name "*.tf" -exec dirname {} \; | sort --unique}
 COMPONENTS=${shell for d in $(DIRS); do basename $$d; done}
 
 all: init-all

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,4 +1,5 @@
-COMPONENTS=${shell find * -not -path "*/.*" -type d}
+DIRS=${shell find . -name *.tf -exec dirname {} \; | sort --unique}
+COMPONENTS=${shell for d in $(DIRS); do basename $$d; done}
 
 all: init-all
 


### PR DESCRIPTION
Subdirectories of /infa are considered components by /infa/Makefile only when they contain terraform files (files ending with .tf).