### PR TITLE
Add X-Ray profiling for daemons and subsegments for GET /v1/files

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,10 @@ test-deploy-test cycle after this (the test after the deploy is required to test
         # do stuff     
     ```
 
+#### Enabling Profiling
+AWS Xray tracing is used for profiling the performance of deployed lambdas. This can be enabled for `chalice/app.py` by 
+setting the lambda environment variable `DSS_XRAY_TRACE=1`. For all other daemons you must also check 
+"Enable active tracking" under "Debugging and error handling" in the AWS Lambda console.
 
 [![](https://img.shields.io/badge/slack-%23data--store-557EBF.svg)](https://humancellatlas.slack.com/messages/data-store/)
 [![Build Status](https://travis-ci.com/HumanCellAtlas/data-store.svg?branch=master)](https://travis-ci.com/HumanCellAtlas/data-store)

--- a/chalice/app.py
+++ b/chalice/app.py
@@ -20,23 +20,21 @@ from flask import json
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-DSS_XRAY_TRACE = int(os.environ.get('DSS_XRAY_TRACE', '0')) > 0  # noqa
+from dss import BucketConfig, Config, DeploymentStage, create_app
+from dss.logging import configure_lambda_logging
+from dss.util import paginate
+from dss.util.tracing import DSS_XRAY_TRACE
 
 if DSS_XRAY_TRACE:  # noqa
-    from aws_xray_sdk.core import xray_recorder, patch
+    from aws_xray_sdk.core import xray_recorder
     from aws_xray_sdk.core.context import Context
     from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
-    patch(('boto3', 'requests'))
     xray_recorder.configure(
         service='DSS',
         dynamic_naming=f"*{os.environ['API_DOMAIN_NAME']}*",
         context=Context(),
         context_missing='LOG_ERROR'
     )
-
-from dss import BucketConfig, Config, DeploymentStage, create_app
-from dss.logging import configure_lambda_logging
-from dss.util import paginate
 
 configure_lambda_logging()
 

--- a/daemons/dss-admin/app.py
+++ b/daemons/dss-admin/app.py
@@ -13,6 +13,7 @@ from dss import BucketConfig, Config, Replica
 from dss.logging import configure_lambda_logging
 from dss.stepfunctions.visitation.index import IndexVisitation
 from dss.stepfunctions.visitation.storage import StorageVisitation
+from dss.util import tracing
 from dss.util.types import JSON
 
 

--- a/daemons/dss-checkout-sfn/app.py
+++ b/daemons/dss-checkout-sfn/app.py
@@ -12,6 +12,7 @@ from dss.config import Replica
 from dss.logging import configure_lambda_logging
 
 from dss.stepfunctions.checkout.checkout_states import state_machine_def
+from dss.util import tracing
 from dss.util.email import send_checkout_success_email, send_checkout_failure_email
 from dss.storage.checkout import (parallel_copy, get_dst_bundle_prefix, get_manifest_files,
                                   validate_file_dst, pre_exec_validate, put_status_succeeded, put_status_failed,

--- a/daemons/dss-dlq-reaper/app.py
+++ b/daemons/dss-dlq-reaper/app.py
@@ -6,12 +6,12 @@ import sys
 import boto3
 import domovoi
 
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from dss.logging import configure_lambda_logging
 from dss.util.aws import send_sns_msg
+from dss.util import tracing
 
 logger = logging.getLogger(__name__)
 configure_lambda_logging()

--- a/daemons/dss-gs-copy-write-metadata-sfn/app.py
+++ b/daemons/dss-gs-copy-write-metadata-sfn/app.py
@@ -7,6 +7,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib')
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss.stepfunctions.gscopyclient as gscopyclient
+from dss.util import tracing
 
 app = domovoi.Domovoi()
 app.register_state_machine(gscopyclient.copy_write_metadata_sfn)

--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -14,9 +14,13 @@ from dss.index import DEFAULT_BACKENDS
 from dss.index.backend import CompositeIndexBackend
 from dss.index.indexer import Indexer
 from dss.logging import configure_lambda_logging
+from dss.util import tracing
 from dss.util.time import RemainingLambdaContextTime, AdjustedRemainingTime
 
+
 app = domovoi.Domovoi(configure_logs=False)
+
+
 configure_lambda_logging()
 
 dss.Config.set_config(dss.BucketConfig.NORMAL)

--- a/daemons/dss-notify/app.py
+++ b/daemons/dss-notify/app.py
@@ -10,6 +10,7 @@ from dss import Config
 from dss.logging import configure_lambda_logging
 from dss.notify.notifier import Notifier
 from dss.util.time import RemainingLambdaContextTime
+from dss.util import tracing
 from dss.util.types import LambdaContext
 
 configure_lambda_logging()

--- a/daemons/dss-s3-copy-sfn/app.py
+++ b/daemons/dss-s3-copy-sfn/app.py
@@ -8,6 +8,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from dss.logging import configure_lambda_logging
 import dss.stepfunctions.s3copyclient as s3copyclient
+from dss.util import tracing
 
 
 configure_lambda_logging()

--- a/daemons/dss-s3-copy-write-metadata-sfn/app.py
+++ b/daemons/dss-s3-copy-write-metadata-sfn/app.py
@@ -8,6 +8,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from dss.logging import configure_lambda_logging
 import dss.stepfunctions.s3copyclient as s3copyclient
+from dss.util import tracing
 
 
 configure_lambda_logging()

--- a/daemons/dss-sfn-launcher/app.py
+++ b/daemons/dss-sfn-launcher/app.py
@@ -7,12 +7,12 @@ import boto3
 import domovoi
 from botocore.exceptions import ClientError
 
-
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'domovoilib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from dss import stepfunctions
 from dss.stepfunctions import SFN_TEMPLATE_KEY, SFN_EXECUTION_KEY, SFN_INPUT_KEY, sfn_sns_topic
+from dss.util import tracing
 from dss.logging import configure_lambda_logging
 
 logger = logging.getLogger(__name__)

--- a/daemons/dss-sync/app.py
+++ b/daemons/dss-sync/app.py
@@ -19,6 +19,7 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss.logging import configure_lambda_logging
 from dss.events.handlers.sync import sync_blob, compose_gs_blobs, copy_part, parts_per_worker, sns_topics
+from dss.util import tracing
 from dss.util.aws import ARN, send_sns_msg, clients, resources
 from dss.config import Replica
 

--- a/daemons/dss-visitation/app.py
+++ b/daemons/dss-visitation/app.py
@@ -8,6 +8,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from dss import BucketConfig, Config
 from dss.logging import configure_lambda_logging
+from dss.util import tracing
 from dss.stepfunctions.visitation.implementation import sfn
 
 

--- a/dss/util/tracing.py
+++ b/dss/util/tracing.py
@@ -1,0 +1,43 @@
+import os
+from functools import wraps
+import typing
+from aws_xray_sdk.core import xray_recorder, patch
+from aws_xray_sdk.core.context import Context
+
+
+DSS_XRAY_TRACE = int(os.environ.get('DSS_XRAY_TRACE', '0')) > 0  # noqa
+
+patched = False
+
+if DSS_XRAY_TRACE and not patched:  # noqa
+    patch(('boto3', 'requests'))
+    xray_recorder.configure(context_missing='LOG_ERROR')
+    patched = True
+
+
+def capture_segment(name: str) -> typing.Callable:
+    """Used to conditionally wrap functions with `xray_recorder.capture` when DSS_XRAY_TRACE is enabled."""
+    def decorate(func):
+        if DSS_XRAY_TRACE:  # noqa
+            from aws_xray_sdk.core import xray_recorder
+
+            @wraps(func)
+            def call(*args, **kwargs):
+                return xray_recorder.capture(name)(func)(*args, **kwargs)
+        else:
+
+            @wraps(func)
+            def call(*args, **kwargs):
+                return func(*args, **kwargs)
+        return call
+    return decorate
+
+
+def begin_segment(name: str) -> None:
+    if DSS_XRAY_TRACE:
+        xray_recorder.begin_subsegment(name)
+
+
+def end_segment(name: str) -> None:
+    if DSS_XRAY_TRACE:
+        xray_recorder.end_subsegment(name)


### PR DESCRIPTION
## Need (User story)
As a DSS operator
I want to profile uninstrumented (unpatched) DSS application logic (code not in `boto3` or `requests`)
so that I know what parts of an endpoint's logic are slow.

## Approach
Add xray tracing subsegments to the GET /files logic.

Adding xray tracing subsegments to the GET /files logic will allow us to profile unpatched code.

## Deployment Instructions

Must be deployed from a privileged account in order to update AWS Permissions for lambdas