### PR TITLE
[WIP] Add X-Ray subsegments for profiling to GET /v1/files

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -16,27 +16,16 @@ import chalice
 import nestedcontext
 import requests
 from flask import json
+from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), 'chalicelib'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-DSS_XRAY_TRACE = int(os.environ.get('DSS_XRAY_TRACE', '0')) > 0  # noqa
-
-if DSS_XRAY_TRACE:  # noqa
-    from aws_xray_sdk.core import xray_recorder, patch
-    from aws_xray_sdk.core.context import Context
-    from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
-    patch(('boto3', 'requests'))
-    xray_recorder.configure(
-        service='DSS',
-        dynamic_naming=f"*{os.environ['API_DOMAIN_NAME']}*",
-        context=Context(),
-        context_missing='LOG_ERROR'
-    )
-
 from dss import BucketConfig, Config, DeploymentStage, create_app
 from dss.logging import configure_lambda_logging
 from dss.util import paginate
+from dss.util.tracing import DSS_XRAY_TRACE
 
 configure_lambda_logging()
 

--- a/dss/util/tracing.py
+++ b/dss/util/tracing.py
@@ -1,0 +1,24 @@
+import os
+from aws_xray_sdk.core import xray_recorder, patch
+from aws_xray_sdk.core.context import Context
+
+DSS_XRAY_TRACE = int(os.environ.get('XRAY_TRACE', '0')) > 0
+
+if DSS_XRAY_TRACE:
+    patch(('boto3', 'requests'))
+    xray_recorder.configure(
+        service='DSS',
+        dynamic_naming=f"*{os.environ['API_DOMAIN_NAME']}*",
+        context=Context(),
+        context_missing='LOG_ERROR'
+    )
+
+
+def begin_segment(name):
+    if DSS_XRAY_TRACE:
+        xray_recorder.begin_subsegment(name)
+
+
+def end_segment(name):
+    if DSS_XRAY_TRACE:
+        xray_recorder.end_subsegment(name)


### PR DESCRIPTION
## Need (User story)
As a DSS operator
I want to profile uninstrumented (unpatched) DSS application logic (code not in `boto3` or `requests`)
so that I know what parts of an endpoint's logic are slow.

# Approach
Add xray tracing subsegments to the GET /files logic.

Adding xray tracing subsegments to the GET /files logic will allow us to profile unpatched code.