### PR TITLE
Fix DSS_DEBUG not being propagated to lambdas

### DIFF
--- a/environment
+++ b/environment
@@ -28,6 +28,7 @@ EXPORT_ENV_VARS_TO_LAMBDA_ARRAY=(
     DSS_NOTIFY_DELAYS
     DSS_NOTIFY_TIMEOUT
     DSS_XRAY_TRACE
+    DSS_DEBUG
 )
 
 set -a
@@ -83,6 +84,7 @@ EVENT_RELAY_AWS_ACCESS_KEY_SECRETS_NAME="event-relay-user-aws-access-key"
 GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME="gcp-credentials.json"
 GOOGLE_APPLICATION_SECRETS_SECRETS_NAME="application_secrets.json"
 ES_ALLOWED_SOURCE_IP_SECRETS_NAME="es_source_ip"
+DSS_DEBUG=0
 
 # `{account_id}`, if present, will be replaced with the account ID associated with the AWS credentials used for
 # deployment. It can be safely omitted.


### PR DESCRIPTION
Before this PR:
- Put `DSS_DEBUG=1` in `environment.local`
- `cd chalice && make deploy`
- Observe that `chalice/.chalice/config.json` does't have `DSS_DEBUG`

After this PR, `chalice/.chalice/config.json` has `DSS_DEBUG`.