### PR TITLE
Fix admin_user_emails_length if statement

### DIFF
--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -60,7 +60,7 @@ fi
 # Add service account email to list of authorized emails for ci-cd testing.
 service_account_email=`jq -r ".client_email" chalicelib/gcp-credentials.json`
 admin_user_emails_length=${#ADMIN_USER_EMAILS}
-if $admin_user_emails_length>0; then
+if [[ $admin_user_emails_length>0 ]]; then
 	export ADMIN_USER_EMAILS="${ADMIN_USER_EMAILS},${service_account_email}"
 else
 	export ADMIN_USER_EMAILS="${service_account_email}"


### PR DESCRIPTION
Before this PR: `source environment && cd chalice && ./build_deploy_config.sh` gives:
```
./build_deploy_config.sh: line 63: 0: command not found
```
After this PR, it succeeds.

Not sure how things are working on Travis. (Also, I'm pretty sure build_deploy_config.sh was working for me earlier, not sure what changed.)
