### PR TITLE
[WIP]  Round-trip chunks of visitation state to DynamoDB

### DIFF
--- a/dss/stepfunctions/visitation/implementation.py
+++ b/dss/stepfunctions/visitation/implementation.py
@@ -1,4 +1,6 @@
+import os
 import copy
+import json
 import logging
 
 from dss.util.time import RemainingLambdaContextTime

--- a/iam/policy-templates/dss-visitation-lambda.json
+++ b/iam/policy-templates/dss-visitation-lambda.json
@@ -67,6 +67,11 @@
           "xray:PutTraceSegments"
       ],
       "Resource": "*"
+    },
+    { 
+      "Effect": "Allow",
+      "Action": "dynamodb:*",
+      "Resource": "arn:aws:dynamodb:*:$account_id:table/dss-visitation*"
     }
   ]
 }

--- a/infra/dynamodb/dynamodb.tf
+++ b/infra/dynamodb/dynamodb.tf
@@ -1,0 +1,16 @@
+resource "aws_dynamodb_table" "visitation-dynamodb-table" {
+  name           = "dss-visitation-${var.DSS_DEPLOYMENT_STAGE}"
+  read_capacity  = 1024
+  write_capacity = 1024
+  hash_key       = "key"
+
+  attribute {
+    name = "key"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "expiration-time"
+    enabled = true
+  }
+}


### PR DESCRIPTION
SFN step input/result limit is ~32k:
https://docs.aws.amazon.com/step-functions/latest/dg/limits.html#service-limits-task-executions

DynamoDB Item size limit is ~400k:
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html#limits-items

AWS recommended workaround to avoid state overflow uses S3:
https://docs.aws.amazon.com/step-functions/latest/dg/avoid-exec-failures.html