### PR TITLE
Deploy test buckets only from the dev stage

### DIFF
--- a/infra/buckets/gs_buckets.tf
+++ b/infra/buckets/gs_buckets.tf
@@ -1,14 +1,13 @@
 resource google_storage_bucket dss_gs_bucket {
-  count = "${length(var.DSS_GS_BUCKET) > 0 ? 1 : 0}"
   name = "${var.DSS_GS_BUCKET}"
   provider = "google"
   location = "${length(var.DSS_GS_BUCKET_REGION) > 0 ?
     "${var.DSS_GS_BUCKET_REGION}" : "${var.GCP_DEFAULT_REGION}"}"
-  storage_class = "REGIONAL"
+  storage_class = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? "REGIONAL" : "STANDARD"}"
 }
 
 resource google_storage_bucket dss_gs_bucket_test {
-  count = "${length(var.DSS_GS_BUCKET_TEST) > 0 ? 1 : 0}"
+  count = "${local.create_test_buckets ? 1 : 0}"
   name = "${var.DSS_GS_BUCKET_TEST}"
   provider = "google"
   location = "${length(var.DSS_GS_BUCKET_TEST_REGION) > 0 ?
@@ -26,7 +25,7 @@ resource google_storage_bucket dss_gs_bucket_test {
 }
 
 resource google_storage_bucket dss_gs_bucket_test_fixtures {
-  count = "${length(var.DSS_GS_BUCKET_TEST_FIXTURES) > 0 ? 1 : 0}"
+  count = "${local.create_test_buckets ? 1 : 0}"
   name = "${var.DSS_GS_BUCKET_TEST_FIXTURES}"
   provider = "google"
   location = "${length(var.DSS_GS_BUCKET_TEST_FIXTURES_REGION) > 0 ?
@@ -35,7 +34,6 @@ resource google_storage_bucket dss_gs_bucket_test_fixtures {
 }
 
 resource google_storage_bucket dss_gs_checkout_bucket {
-  count = "${length(var.DSS_GS_CHECKOUT_BUCKET) > 0 ? 1 : 0}"
   name = "${var.DSS_GS_CHECKOUT_BUCKET}"
   provider = "google"
   location = "${var.GCP_DEFAULT_REGION}"
@@ -52,7 +50,7 @@ resource google_storage_bucket dss_gs_checkout_bucket {
 }
 
 resource google_storage_bucket dss_gs_checkout_bucket_test {
-  count = "${length(var.DSS_GS_CHECKOUT_BUCKET_TEST) > 0 ? 1 : 0}"
+  count = "${local.create_test_buckets ? 1 : 0}"
   name = "${var.DSS_GS_CHECKOUT_BUCKET_TEST}"
   provider = "google"
   location = "${var.GCP_DEFAULT_REGION}"

--- a/infra/buckets/locals.tf
+++ b/infra/buckets/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  # There is a Terraform state file for each stage (dev, integration, staging, prod)
+  # However, test buckets are shared. We choose to create test buckets when deploying infra
+  # for the dev stage.
+  create_test_buckets = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? true : false}"
+}

--- a/infra/buckets/s3_buckets.tf
+++ b/infra/buckets/s3_buckets.tf
@@ -1,10 +1,9 @@
 resource aws_s3_bucket dss_s3_bucket {
-  count = "${length(var.DSS_S3_BUCKET) > 0 ? 1 : 0}"
   bucket = "${var.DSS_S3_BUCKET}"
 }
 
 resource aws_s3_bucket dss_s3_bucket_test {
-  count = "${length(var.DSS_S3_BUCKET_TEST) > 0 ? 1 : 0}"
+  count = "${local.create_test_buckets ? 1 : 0}"
   bucket = "${var.DSS_S3_BUCKET_TEST}"
   lifecycle_rule {
     id      = "prune old things"
@@ -17,12 +16,11 @@ resource aws_s3_bucket dss_s3_bucket_test {
 }
 
 resource aws_s3_bucket dss_s3_bucket_test_fixtures {
-  count = "${length(var.DSS_S3_BUCKET_TEST_FIXTURES) > 0 ? 1 : 0}"
+  count = "${local.create_test_buckets ? 1 : 0}"
   bucket = "${var.DSS_S3_BUCKET_TEST_FIXTURES}"
 }
 
 resource aws_s3_bucket dss_s3_checkout_bucket {
-  count = "${length(var.DSS_S3_CHECKOUT_BUCKET) > 0 ? 1 : 0}"
   bucket = "${var.DSS_S3_CHECKOUT_BUCKET}"
   lifecycle_rule {
     id      = "dss_checkout_expiration"
@@ -34,7 +32,7 @@ resource aws_s3_bucket dss_s3_checkout_bucket {
 }
 
 resource aws_s3_bucket dss_s3_checkout_bucket_test {
-  count = "${length(var.DSS_S3_CHECKOUT_BUCKET_TEST) > 0 ? 1 : 0}"
+  count = "${local.create_test_buckets ? 1 : 0}"
   bucket = "${var.DSS_S3_CHECKOUT_BUCKET_TEST}"
   lifecycle_rule {
     id      = "dss_checkout_expiration"


### PR DESCRIPTION
* All stages share test buckets
* Test buckets are only deployed from `dev`
* Add Terraform logic to accommodate GS buckets with different storage region settings.