### PR TITLE
Increasing memory from 128MB to 512MB to on DSS-API Lambda

### DIFF
--- a/chalice/.chalice/config.json
+++ b/chalice/.chalice/config.json
@@ -12,5 +12,6 @@
       }
     }
   },
-  "lambda_timeout": 300
+  "lambda_timeout": 300,
+  "lambda_memory_size": 512
 }


### PR DESCRIPTION
Increasing the memory for the DSS-API lambda will prevent timeouts when burst loads are encountered by the DSS-API. This fixes #1300. If larger burst loads are expected we may need to further increase the memory allocation in the future. Further optimization of the lambda maybe need in the future.