### PR TITLE
Precompile all .py files to .pyc before deploying

### DIFF
--- a/scripts/dss-chalice
+++ b/scripts/dss-chalice
@@ -4,11 +4,11 @@
 # for https://github.com/aws/chalice/issues/479. TODO: (akislyuk)
 # revert to using the standard entry point when fixed.
 
-import os, sys
+import os, sys, compileall
 
 from chalice.cli import main
 
-import chalice.awsclient, chalice.deploy.deployer, chalice.deploy.packager
+import chalice.awsclient, chalice.deploy.deployer, chalice.deploy.packager, chalice.package
 
 class DSSChaliceTypedAWSClient(chalice.awsclient.TypedAWSClient):
     def update_function(self, *args, **kwargs):
@@ -17,6 +17,21 @@ class DSSChaliceTypedAWSClient(chalice.awsclient.TypedAWSClient):
 
 chalice.awsclient.TypedAWSClient = DSSChaliceTypedAWSClient
 chalice.deploy.deployer.TypedAWSClient = DSSChaliceTypedAWSClient
+
+class DSSDependencyBuilder(chalice.deploy.packager.DependencyBuilder):
+    def _install_wheels(self, src_dir, dst_dir, wheels):
+        if self._osutils.directory_exists(dst_dir):
+            self._osutils.rmtree(dst_dir)
+        self._osutils.makedirs(dst_dir)
+        for wheel in wheels:
+            zipfile_path = self._osutils.joinpath(src_dir, wheel.filename)
+            self._osutils.extract_zipfile(zipfile_path, dst_dir)
+            self._install_purelib_and_platlib(wheel, dst_dir)
+        compileall.compile_dir(dst_dir)
+
+chalice.deploy.packager.DependencyBuilder = DSSDependencyBuilder
+chalice.deploy.deployer.DependencyBuilder = DSSDependencyBuilder
+chalice.package.DependencyBuilder = DSSDependencyBuilder
 
 # See https://github.com/aws/chalice/issues/497 for discussion
 chalice.deploy.packager.subprocess_python_base_environ = {"PATH": os.environ["PATH"]}


### PR DESCRIPTION
Chalice does not currently compile all `py` files to `pyc` files before deploying lambdas. For this reason, lambda cold start will be slower. This PR introduces compilation as part of the package and deployment of chalice apps.