### PR TITLE
Use the bucket specified in the SFN message

### DIFF
--- a/dss/stepfunctions/checkout/checkout_states.py
+++ b/dss/stepfunctions/checkout/checkout_states.py
@@ -25,7 +25,7 @@ def schedule_copy(event, context):
     replica = Replica[event["replica"]]
 
     scheduled = 0
-    for src_key, dst_key in get_manifest_files(bundle_fqid, version, replica):
+    for src_key, dst_key in get_manifest_files(dss_bucket, bundle_fqid, version, replica):
         logger.info("Schedule copying a file %s to bucket %s", dst_key, dss_bucket)
         parallel_copy(dss_bucket, src_key, dst_bucket, dst_key, replica)
         scheduled += 1
@@ -37,6 +37,7 @@ def schedule_copy(event, context):
 def get_job_status(event, context):
     bundle_fqid = event["bundle"]
     version = event["version"]
+    dss_bucket = event["dss_bucket"]
     replica = Replica[event["replica"]]
 
     check_count = 0
@@ -45,7 +46,7 @@ def get_job_status(event, context):
 
     complete_count = 0
     total_count = 0
-    for src_key, dst_key in get_manifest_files(bundle_fqid, version, replica):
+    for src_key, dst_key in get_manifest_files(dss_bucket, bundle_fqid, version, replica):
         total_count += 1
         if validate_file_dst(get_dst_bucket(event), dst_key, replica):
             complete_count += 1

--- a/dss/storage/checkout.py
+++ b/dss/storage/checkout.py
@@ -61,8 +61,8 @@ def get_dst_bundle_prefix(bundle_id: str, bundle_version: str) -> str:
     return "checkedout/{}.{}".format(bundle_id, bundle_version)
 
 
-def get_manifest_files(bundle_id: str, version: str, replica: Replica):
-    bundleManifest = get_bundle(bundle_id, replica, version).get('bundle')
+def get_manifest_files(src_bucket: str, bundle_id: str, version: str, replica: Replica):
+    bundleManifest = get_bundle_from_bucket(bundle_id, replica, version, src_bucket).get('bundle')
     files = bundleManifest.get('files')
     dst_bundle_prefix = get_dst_bundle_prefix(bundle_id, version)
 

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -136,7 +136,7 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         replica = Replica.aws
         file_count = 0
         with override_bucket_config(BucketConfig.TEST_FIXTURE):
-            for _ in get_manifest_files(bundle_uuid, version, replica):
+            for _ in get_manifest_files(replica.bucket, bundle_uuid, version, replica):
                 file_count += 1
         self.assertEqual(file_count, 1)
 


### PR DESCRIPTION
Right now, the SFN always uses the bucket configured at deploy time (for DEV, it's DEV).  However, if we want checkout service tests to be able to check out from the TEST bucket, we need to use the bucket specified in the SFN message.

Depends on #1313 
Depends on #1330 permission change being deployed.