### PR TITLE
Allow the s3 copy sfn to write to the test checkout bucket.

### DIFF
--- a/iam/policy-templates/dss-s3-copy-sfn-lambda.json
+++ b/iam/policy-templates/dss-s3-copy-sfn-lambda.json
@@ -22,7 +22,9 @@
         "arn:aws:s3:::$DSS_S3_BUCKET_TEST",
         "arn:aws:s3:::$DSS_S3_BUCKET_TEST/*",
         "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET",
-        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET/*"
+        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET/*",
+        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST",
+        "arn:aws:s3:::$DSS_S3_CHECKOUT_BUCKET_TEST/*"
       ]
     },
     {


### PR DESCRIPTION
This is required to do a test checkout.
