### PR TITLE
Unify all the places where we compose the blob key.

### DIFF
--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -1,4 +1,4 @@
-import os, sys, json, logging, datetime, io, functools
+import json, logging, datetime, io, functools
 from typing import List
 from uuid import uuid4
 from concurrent.futures import ThreadPoolExecutor
@@ -13,7 +13,7 @@ import iso8601
 from dss import Config, Replica
 from dss.error import DSSException, dss_handler
 from dss.storage.blobstore import test_object_exists
-from dss.storage.hcablobstore import FileMetadata, BlobStore
+from dss.storage.hcablobstore import BlobStore, compose_blob_key
 from dss.storage.identifiers import CollectionFQID, CollectionTombstoneID
 from dss.util.version import datetime_to_version_format
 from dss.api.bundles import _idempotent_save
@@ -160,12 +160,7 @@ def resolve_content_item(replica: Replica, blobstore_handle: BlobStore, item: di
             if "fragment" not in item:
                 raise Exception('The "fragment" field is required in collection elements '
                                 'other than files, bundles, and collections')
-            blob_path = "blobs/" + ".".join((
-                item_metadata[FileMetadata.SHA256],
-                item_metadata[FileMetadata.SHA1],
-                item_metadata[FileMetadata.S3_ETAG],
-                item_metadata[FileMetadata.CRC32C],
-            ))
+            blob_path = compose_blob_key(item_metadata)
             # check that item is marked as metadata, is json, and is less than max size
             item_doc = json.loads(blobstore_handle.get(replica.bucket, blob_path))
             item_content = jsonpointer.resolve_pointer(item_doc, item["fragment"])

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -1,10 +1,8 @@
 import datetime
 import io
 import json
-import os
 import random
 import re
-import sys
 import typing
 from enum import Enum, auto
 from uuid import uuid4
@@ -17,7 +15,7 @@ from dss.util.version import datetime_to_version_format
 
 from dss import DSSException, dss_handler, stepfunctions
 from dss.config import Config, Replica
-from dss.storage.hcablobstore import FileMetadata, HCABlobStore
+from dss.storage.hcablobstore import FileMetadata, HCABlobStore, compose_blob_key
 from dss.stepfunctions import gscopyclient, s3copyclient
 from dss.util import tracing
 from dss.util.aws import AWS_MIN_CHUNK_SIZE
@@ -74,12 +72,7 @@ def get_helper(uuid: str, replica: Replica, version: str=None):
         raise DSSException(404, "not_found", "Cannot find file!")
 
     with tracing.Subsegment('make_path'):
-        blob_path = "blobs/" + ".".join((
-            file_metadata[FileMetadata.SHA256],
-            file_metadata[FileMetadata.SHA1],
-            file_metadata[FileMetadata.S3_ETAG],
-            file_metadata[FileMetadata.CRC32C],
-        ))
+        blob_path = compose_blob_key(file_metadata)
 
     if request.method == "GET":
         """

--- a/dss/index/bundle.py
+++ b/dss/index/bundle.py
@@ -5,9 +5,8 @@ from typing import Mapping, Optional, Set
 from cloud_blobstore import BlobNotFoundError, BlobStoreError
 
 from dss import Config, Replica
-from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata
+from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, compose_blob_key
 from dss.storage.identifiers import BundleFQID, ObjectIdentifier, TombstoneID
-from dss.util import create_blob_key
 from dss.util.types import JSON
 
 logger = logging.getLogger(__name__)
@@ -56,7 +55,7 @@ class Bundle:
                 file_name = file_info[BundleFileMetadata.NAME]
                 content_type = file_info[BundleFileMetadata.CONTENT_TYPE]
                 if content_type.startswith('application/json'):
-                    file_blob_key = create_blob_key(file_info)
+                    file_blob_key = compose_blob_key(file_info)
                     try:
                         file_string = handle.get(replica.bucket, file_blob_key).decode("utf-8")
                     except BlobStoreError as ex:

--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -4,7 +4,7 @@ import typing
 from cloud_blobstore import BlobNotFoundError
 
 from dss import Config, DSSException, Replica
-from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata
+from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, compose_blob_key
 from dss.storage.identifiers import DSS_BUNDLE_KEY_REGEX, DSS_BUNDLE_TOMBSTONE_REGEX, TombstoneID, BundleFQID
 from dss.util import UrlBuilder
 from dss.storage.blobstore import test_object_exists
@@ -75,12 +75,7 @@ def get_bundle_from_bucket(
             file_version['url'] = str(UrlBuilder().set(
                 scheme=replica.storage_schema,
                 netloc=bucket,
-                path="blobs/{}.{}.{}.{}".format(
-                    file[BundleFileMetadata.SHA256],
-                    file[BundleFileMetadata.SHA1],
-                    file[BundleFileMetadata.S3_ETAG],
-                    file[BundleFileMetadata.CRC32C],
-                ),
+                path=compose_blob_key(file),
             ))
         filesresponse.append(file_version)
 

--- a/dss/storage/hcablobstore/__init__.py
+++ b/dss/storage/hcablobstore/__init__.py
@@ -78,3 +78,22 @@ class BundleFileMetadata:
     S3_ETAG = "s3-etag"
     SHA1 = "sha1"
     SHA256 = "sha256"
+
+
+def compose_blob_key(file_info: typing.Dict[str, str], key_class=FileMetadata) -> str:
+    """
+    Create the key for a blob, given the file metadata.
+
+    :param file_info: This can either be an object that contains the four keys (SHA256, SHA1, S3_ETAG, and CRC32C) in
+                      the key_class.
+    :param key_class: Due to a mistake early on in implementation, s3_etag is internally represented as s3-etag, and
+                      publicly represented as s3_etag.  If we are reading the bundle file metadata or file metadata
+                      directly from cloud storage, we want s3-etag.  If we are reading from /bundles, then we want
+                      s3_etag.  Fortunately, the classes that hold the string constants allow us to parameterize this.
+    """
+    return "blobs/" + ".".join((
+        file_info[key_class.SHA256],
+        file_info[key_class.SHA1],
+        file_info[key_class.S3_ETAG],
+        file_info[key_class.CRC32C]
+    ))

--- a/dss/util/__init__.py
+++ b/dss/util/__init__.py
@@ -2,17 +2,6 @@ from urllib.parse import SplitResult, urlencode, urlunsplit
 
 import typing
 
-from dss.storage.hcablobstore import BundleFileMetadata
-
-
-def create_blob_key(file_info: typing.Dict[str, str]) -> str:
-    return "blobs/" + ".".join((
-        file_info[BundleFileMetadata.SHA256],
-        file_info[BundleFileMetadata.SHA1],
-        file_info[BundleFileMetadata.S3_ETAG],
-        file_info[BundleFileMetadata.CRC32C]
-    ))
-
 
 def paginate(boto3_paginator, *args, **kwargs):
     for page in boto3_paginator.paginate(*args, **kwargs):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -43,9 +43,9 @@ from dss.index.indexer import Indexer
 from dss.logging import configure_test_logging
 from dss.notify import attachment
 from dss.notify.notification import Endpoint
-from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, FileMetadata
+from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, FileMetadata, compose_blob_key
 from dss.storage.identifiers import BundleFQID, ObjectIdentifier
-from dss.util import UrlBuilder, create_blob_key, networking, RequirementError
+from dss.util import UrlBuilder, networking, RequirementError
 from dss.util.version import datetime_to_version_format
 from dss.util.time import SpecificRemainingTime
 from tests import eventually, get_auth_header, get_bundle_fqid, get_file_fqid, get_version
@@ -1389,7 +1389,7 @@ def create_index_data(blobstore, bucket_name, bundle_key, manifest,
     for file_info in files_info:
         if file_info['indexed'] is True and file_info["name"] not in excluded_file:
             try:
-                file_key = create_blob_key(file_info)
+                file_key = compose_blob_key(file_info)
                 content_type = file_info[BundleFileMetadata.CONTENT_TYPE]
                 if content_type != "application/json":
                     continue


### PR DESCRIPTION
Unify all the places where we compose the blob key.

Self-explanatory, no?

The only problem is that we apparently have a disagreement about s3-etag (what's written to cloud storage) and s3_etag (what's sent to users).  I recall going through and changing them but apparently I missed one place...?