### PR TITLE
Function for verifying that the cloud-provided checksum matches metadata written to dss storage

### DIFF
--- a/dss/storage/hcablobstore/__init__.py
+++ b/dss/storage/hcablobstore/__init__.py
@@ -44,6 +44,19 @@ class HCABlobStore:
         """
         raise NotImplementedError()
 
+    def verify_blob_checksum_from_dss_metadata(
+            self, bucket: str, key: str, dss_metadata: typing.Dict[str, str]) -> bool:
+        """
+        Given a blob, verify that the checksum on the cloud store matches the checksum in the metadata stored in the
+        DSS.  Each cloud-specific implementation of ``HCABlobStore`` should extract the correct field and check it
+        against the cloud-provided checksum.
+        :param bucket:
+        :param key:
+        :param dss_metadata:
+        :return: True iff the checksum is correct.
+        """
+        raise NotImplementedError()
+
 
 class FileMetadata:
     FILE_FORMAT_VERSION = "0.0.4"

--- a/dss/storage/hcablobstore/gs.py
+++ b/dss/storage/hcablobstore/gs.py
@@ -18,3 +18,17 @@ class GSHCABlobStore(HCABlobStore):
         checksum = self.handle.get_cloud_checksum(bucket, key)
         metadata_checksum_key = typing.cast(str, HCABlobStore.MANDATORY_STAGING_METADATA['CRC32C']['keyname'])
         return checksum.lower() == metadata[metadata_checksum_key].lower()
+
+    def verify_blob_checksum_from_dss_metadata(
+            self, bucket: str, key: str, dss_metadata: typing.Dict[str, str]) -> bool:
+        """
+        Given a blob, verify that the checksum on the cloud store matches the checksum in the metadata stored in the
+        DSS.  Each cloud-specific implementation of ``HCABlobStore`` should extract the correct field and check it
+        against the cloud-provided checksum.
+        :param bucket:
+        :param key:
+        :param dss_metadata:
+        :return: True iff the checksum is correct.
+        """
+        checksum = self.handle.get_cloud_checksum(bucket, key)
+        return checksum.lower() == dss_metadata["crc32c"].lower()

--- a/dss/storage/hcablobstore/s3.py
+++ b/dss/storage/hcablobstore/s3.py
@@ -18,3 +18,17 @@ class S3HCABlobStore(HCABlobStore):
         checksum = self.handle.get_cloud_checksum(bucket, key)
         metadata_checksum_key = typing.cast(str, HCABlobStore.MANDATORY_STAGING_METADATA['S3_ETAG']['keyname'])
         return checksum.lower() == metadata[metadata_checksum_key].lower()
+
+    def verify_blob_checksum_from_dss_metadata(
+            self, bucket: str, key: str, dss_metadata: typing.Dict[str, str]) -> bool:
+        """
+        Given a blob, verify that the checksum on the cloud store matches the checksum in the metadata stored in the
+        DSS.  Each cloud-specific implementation of ``HCABlobStore`` should extract the correct field and check it
+        against the cloud-provided checksum.
+        :param bucket:
+        :param key:
+        :param dss_metadata:
+        :return: True iff the checksum is correct.
+        """
+        checksum = self.handle.get_cloud_checksum(bucket, key)
+        return checksum.lower() == dss_metadata["s3-etag"].lower()

--- a/tests/hcablobstore_base.py
+++ b/tests/hcablobstore_base.py
@@ -1,3 +1,5 @@
+import json
+
 from cloud_blobstore import BlobNotFoundError
 
 from tests.infra import testmode
@@ -10,7 +12,7 @@ class HCABlobStoreTests:
     """
 
     @testmode.standalone
-    def test_verify_blob_checksum(self):
+    def test_verify_blob_checksum_from_staging_metadata(self):
         bucket = self.test_fixtures_bucket
         key = "test_good_source_data/0"
         self.assertTrue(
@@ -28,3 +30,25 @@ class HCABlobStoreTests:
         with self.assertRaises(BlobNotFoundError):
             self.hcahandle.verify_blob_checksum_from_staging_metadata(
                 bucket, key, {})
+
+    @testmode.standalone
+    def test_verify_blob_checksum_from_dss_metadata(self):
+        bucket = self.test_fixtures_bucket
+        key = ("blobs/cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30."
+               "2b8b815229aa8a61e483fb4ba0588b8b6c491890.3b83ef96387f14655fc854ddc3c6bd57.e16e07b9")
+        bundle_key = "bundles/011c7340-9b3c-4d62-bf49-090d79daf198.2017-06-20T214506.766634Z"
+        bundle = json.loads(self.blobhandle.get(bucket, bundle_key))
+        self.assertTrue(
+            self.hcahandle.verify_blob_checksum_from_dss_metadata(
+                bucket, key, bundle['files'][0]))
+
+        key = ("blobs/9cdc9050cecf59381fed55a2433140b69596fc861bee55abeafd1f9150f3e2da."
+               "15684690e8132044f378b4d4af8a7331c8da17b1.7f54939b30ae7b6d45d473a4c82a41b0.114dee2c")
+        self.assertFalse(
+            self.hcahandle.verify_blob_checksum_from_dss_metadata(
+                bucket, key, bundle['files'][0]))
+
+        key = "DOES_NOT_EXIST"
+        with self.assertRaises(BlobNotFoundError):
+            self.hcahandle.verify_blob_checksum_from_dss_metadata(
+                bucket, key, bundle['files'][0])


### PR DESCRIPTION
This is useful for verifying that checkouts are completed correctly.

Depends on #1339 