### PR TITLE
[easy] move file metadata write method.

### DIFF
--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -1,6 +1,6 @@
 from dss import Config, Replica
-from dss.api import files
 from dss.stepfunctions.lambdaexecutor import TimedThread
+from dss.storage.files import write_file_metadata
 
 
 # Public input/output keys for the state object.
@@ -110,7 +110,7 @@ def write_metadata(event, lambda_context):
     handle = Config.get_blobstore_handle(Replica.gcp)
 
     destination_bucket = event[Key.DESTINATION_BUCKET]
-    files.write_file_metadata(
+    write_file_metadata(
         handle,
         destination_bucket,
         event[CopyWriteMetadataKey.FILE_UUID],

--- a/dss/stepfunctions/s3copyclient/implementation.py
+++ b/dss/stepfunctions/s3copyclient/implementation.py
@@ -9,8 +9,8 @@ import typing
 import boto3
 from cloud_blobstore.s3 import S3BlobStore
 
-from dss.api import files
 from dss.stepfunctions.lambdaexecutor import TimedThread
+from dss.storage.files import write_file_metadata
 from dss.util.aws import get_s3_chunk_size
 
 
@@ -300,7 +300,7 @@ def write_metadata(event, lambda_context):
     handle = S3BlobStore.from_environment()
 
     destination_bucket = event[Key.DESTINATION_BUCKET]
-    files.write_file_metadata(
+    write_file_metadata(
         handle,
         destination_bucket,
         event[CopyWriteMetadataKey.FILE_UUID],

--- a/dss/storage/files.py
+++ b/dss/storage/files.py
@@ -1,0 +1,26 @@
+import io
+
+from cloud_blobstore import BlobAlreadyExistsError, BlobNotFoundError, BlobStore
+
+
+def write_file_metadata(
+        handle: BlobStore,
+        dst_bucket: str,
+        file_uuid: str,
+        file_version: str,
+        document: str):
+    # what's the target object name for the file metadata?
+    metadata_key = f"files/{file_uuid}.{file_version}"
+
+    # if it already exists, then it's a failure.
+    try:
+        handle.get_user_metadata(dst_bucket, metadata_key)
+    except BlobNotFoundError:
+        pass
+    else:
+        raise BlobAlreadyExistsError()
+
+    handle.upload_file_handle(
+        dst_bucket,
+        metadata_key,
+        io.BytesIO(document.encode("utf-8")))


### PR DESCRIPTION
This is required to break circular dependencies.
