### PR TITLE
Replaced scroll with search after

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -29,7 +29,7 @@ paths:
         [GitHub API](https://developer.github.com/v3/guides/traversing-with-pagination/), which is based on
         [RFC 5988](https://tools.ietf.org/html/rfc5988). When the results of an API call exceed the page size
         specified, the HTTP response will contain a `Link` header of the following form:
-        `Link: <https://dss.data.humancellatlas.org/v1/search?replica=aws&per_page=100&_scroll_id=123>; rel="next"`.
+        `Link: <https://dss.data.humancellatlas.org/v1/search?replica=aws&per_page=100&search_after=123>; rel="next"`.
         The URL in the header refers to the next page of the results to be fetched; if no `Link rel="next"` URL is
         included, then all results have been fetched. The client should recognize and parse the `Link` header
         appropriately according to RFC 5988, and retrieve the next page if requested by the user, or if all results
@@ -72,10 +72,10 @@ paths:
           minimum: 10
           maximum: 500
           default: 100
-        - name: _scroll_id
+        - name: search_after
           in: query
           description: |
-            **Scroll-Search-Context**.
+            **Search-After-Context**.
             An internal state pointer parameter for use with pagination. This parameter is referenced by the `Link`
             header as described in the "Pagination" section. The API client should not need to set this parameter
             directly; it should instead directly fetch the URL given in the `Link` header.

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -31,20 +31,20 @@ def post(json_request_body: dict,
          replica: str,
          per_page: int,
          output_format: str,
-         _scroll_id: typing.Optional[str] = None) -> dict:
+         search_after: typing.Optional[str] = None) -> dict:
     es_query = json_request_body['es_query']
     per_page = PerPageBounds.check(per_page)
 
     replica_enum = Replica[replica] if replica is not None else Replica.aws
 
-    logger.debug("Received POST for replica=%s, es_query=%s, per_page=%i, _scroll_id: %s",
-                 replica_enum.name, json.dumps(es_query, indent=4), per_page, _scroll_id)
+    logger.debug("Received POST for replica=%s, es_query=%s, per_page=%i, search_after: %s",
+                 replica_enum.name, json.dumps(es_query, indent=4), per_page, search_after)
 
     # TODO: (tsmith12) determine if a search operation timeout limit is needed
     # TODO: (tsmith12) allow users to retrieve previous search results
     # TODO: (tsmith12) if page returns 0 hits, then all results have been found. delete search id
     try:
-        page = _es_search_page(es_query, replica_enum, per_page, _scroll_id, output_format)
+        page = _es_search_page(es_query, replica_enum, per_page, search_after, output_format)
         request_dict = _format_request_body(page, es_query, replica_enum, output_format)
         request_body = jsonify(request_dict)
 
@@ -52,7 +52,7 @@ def post(json_request_body: dict,
             response = make_response(request_body, requests.codes.ok)
         else:
             response = make_response(request_body, requests.codes.partial)
-            next_url = _build_scroll_url(page, per_page, replica_enum, output_format)
+            next_url = _build_next_url(page, per_page, replica_enum, output_format)
             response.headers['Link'] = _build_link_header({next_url: {"rel": "next"}})
         return response
     except TransportError as ex:
@@ -87,7 +87,7 @@ def post(json_request_body: dict,
 def _es_search_page(es_query: dict,
                     replica: Replica,
                     per_page: int,
-                    _scroll_id: typing.Optional[str],
+                    search_after: typing.Optional[str],
                     output_format: str) -> dict:
     es_query = deepcopy(es_query)
     es_client = ElasticsearchClient.get()
@@ -98,26 +98,25 @@ def _es_search_page(es_query: dict,
 
     # https://www.elastic.co/guide/en/elasticsearch/reference/5.5/search-request-search-after.html
     sort = [
-        # "manifest.version:desc",
-        "_uid:desc"]
+        "manifest.version:desc",
+        "uuid:desc"]
 
-    if _scroll_id is None:
+    if search_after is None:
         page = es_client.search(index=Config.get_es_alias_name(ESIndexType.docs, replica),
                                 doc_type=ESDocType.doc.name,
                                 size=per_page,
                                 body=es_query,
                                 sort=sort
                                 )
-        logger.debug("Created ES scroll instance")
     else:
-        es_query['search_after'] = [_scroll_id]
+        es_query['search_after'] = search_after.split(',')
         page = es_client.search(index=Config.get_es_alias_name(ESIndexType.docs, replica),
                                 doc_type=ESDocType.doc.name,
                                 size=per_page,
                                 body=es_query,
                                 sort=sort,
                                 )
-        logger.debug(f"Retrieved ES results from scroll instance Scroll_id: {_scroll_id}")
+        logger.debug(f"Retrieved ES results from page after: {search_after}")
     return page
 
 
@@ -149,13 +148,13 @@ def _build_bundle_url(hit: dict, replica: Replica) -> str:
                                   )
 
 
-def _build_scroll_url(page: dict, per_page: int, replica: Replica, output_format: str) -> str:
-    _scroll_id = page['hits']['hits'][-1]['sort']
+def _build_next_url(page: dict, per_page: int, replica: Replica, output_format: str) -> str:
+    search_after = ','.join(page['hits']['hits'][-1]['sort'])
     return request.host_url + str(UrlBuilder()
                                   .set(path="v1/search")
                                   .add_query('per_page', str(per_page))
                                   .add_query("replica", replica.name)
-                                  .add_query("_scroll_id", _scroll_id)
+                                  .add_query("search_after", search_after)
                                   .add_query("output_format", output_format)
                                   )
 

--- a/dss/index/es/mapping.json
+++ b/dss/index/es/mapping.json
@@ -45,7 +45,15 @@
             }
           }
         }
-      ]
+      ],
+      "properties": {
+        "uuid": {"type": "keyword"},
+        "manifest": {
+          "properties":{
+            "version": {"type": "keyword"}
+          }
+        }
+      }
     },
     "query":{
       "properties":{

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -321,10 +321,10 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
         self.assertEqual(parsed_url.path, "/v1/search")
         parsed_q = parse_qs(parsed_url.query)
         self.assertEqual(parsed_q['replica'], [self.replica.name])
-        self.assertIn('_scroll_id', parsed_q.keys())
+        self.assertIn('search_after', parsed_q.keys())
         self.assertEqual(parsed_q['per_page'], [str(per_page)])
         self.assertEqual(parsed_q['output_format'], ['summary'])
-        return parsed_q['_scroll_id'][0]
+        return parsed_q['search_after'][0]
 
     @staticmethod
     def strip_next_url(next_url: str) -> str:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -256,26 +256,6 @@ class TestSearchBase(ElasticsearchTestCase, DSSAssertMixin):
                     json_request_body=dict(es_query=smartseq2_paired_ends_v3_query),
                     **expected)
 
-    def test_search_session_expired_when_session_deleted(self):
-        self.populate_search_index(self.index_document, 20)
-        self.check_count(smartseq2_paired_ends_v3_query, 20)
-        url = self.build_url({"per_page": 10})
-        search_obj = self.assertPostResponse(
-            path=url,
-            json_request_body=dict(es_query=smartseq2_paired_ends_v3_query),
-            expected_code=requests.codes.partial)
-        self.verify_search_result(search_obj.json, smartseq2_paired_ends_v3_query, 20, 10)
-        next_url = self.get_next_url(search_obj.response.headers)
-        scroll_id = self.verify_next_url(next_url, 10)
-        es_client = ElasticsearchClient.get()
-        es_client.clear_scroll(scroll_id)
-        self.assertPostResponse(
-            path=self.strip_next_url(next_url),
-            json_request_body=dict(es_query=smartseq2_paired_ends_v3_query),
-            expected_code=requests.codes.not_found,
-            expected_error=ExpectedErrorFields(code="elasticsearch_context_not_found",
-                                               status=requests.codes.not_found))
-
     def test_verify_dynamic_mapping(self):
         doc1 = {
             "manifest": {"data": "hello world!"},


### PR DESCRIPTION
Using search after for paged searching. This will reduce the overhead required to search beyond 10,000 results at the cost of search results being dynamically generated.

Relates to #835

## Test Plan
Removed test cases relating to scroll_id