### PR TITLE
Introduce get_bundle_manifest(..)

### DIFF
--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -3,19 +3,23 @@ import typing
 
 from cloud_blobstore import BlobNotFoundError
 
-from dss import Config, DSSException, Replica
-from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, compose_blob_key
+from dss import Config, Replica
 from dss.storage.identifiers import DSS_BUNDLE_KEY_REGEX, DSS_BUNDLE_TOMBSTONE_REGEX, TombstoneID, BundleFQID
-from dss.util import UrlBuilder
 from dss.storage.blobstore import test_object_exists
 
 
-def get_bundle_from_bucket(
+def get_bundle_manifest(
         uuid: str,
         replica: Replica,
         version: typing.Optional[str],
-        bucket: typing.Optional[str],
-        directurls: bool=False):
+        *,
+        bucket: typing.Optional[str]=None) -> typing.Optional[dict]:
+    """
+    Return the contents of the bundle manifest file from cloud storage, subject to the rules of tombstoning.  If version
+    is None, return the latest version, once again, subject to the rules of tombstoning.
+
+    If the bundle cannot be found, return None
+    """
     uuid = uuid.lower()
 
     handle = Config.get_blobstore_handle(replica)
@@ -31,7 +35,7 @@ def get_bundle_from_bucket(
     # 1. the whole bundle is deleted
     # 2. the specific version of the bundle is deleted
     if tombstone_exists(uuid, None) or (version and tombstone_exists(uuid, version)):
-        raise DSSException(404, "not_found", "EMPTY Cannot find file!")
+        return None
 
     # handle the following deletion case
     # 3. no version is specified, we want the latest _non-deleted_ version
@@ -43,50 +47,16 @@ def get_bundle_from_bucket(
 
     if version is None:
         # no matches!
-        raise DSSException(404, "not_found", "Cannot find file!")
+        return None
 
     bundle_fqid = BundleFQID(uuid=uuid, version=version)
 
     # retrieve the bundle metadata.
     try:
-        bundle_metadata = json.loads(
-            handle.get(
-                bucket,
-                bundle_fqid.to_key(),
-            ).decode("utf-8"))
+        bundle_manifest_blob = handle.get(bucket, bundle_fqid.to_key()).decode("utf-8")
+        return json.loads(bundle_manifest_blob)
     except BlobNotFoundError:
-        raise DSSException(404, "not_found", "Cannot find file!")
-
-    filesresponse = []  # type: typing.List[dict]
-    for file in bundle_metadata[BundleMetadata.FILES]:
-        file_version = {
-            'name': file[BundleFileMetadata.NAME],
-            'content-type': file[BundleFileMetadata.CONTENT_TYPE],
-            'size': file[BundleFileMetadata.SIZE],
-            'uuid': file[BundleFileMetadata.UUID],
-            'version': file[BundleFileMetadata.VERSION],
-            'crc32c': file[BundleFileMetadata.CRC32C],
-            's3_etag': file[BundleFileMetadata.S3_ETAG],
-            'sha1': file[BundleFileMetadata.SHA1],
-            'sha256': file[BundleFileMetadata.SHA256],
-            'indexed': file[BundleFileMetadata.INDEXED],
-        }
-        if directurls:
-            file_version['url'] = str(UrlBuilder().set(
-                scheme=replica.storage_schema,
-                netloc=bucket,
-                path=compose_blob_key(file),
-            ))
-        filesresponse.append(file_version)
-
-    return dict(
-        bundle=dict(
-            uuid=uuid,
-            version=version,
-            files=filesresponse,
-            creator_uid=bundle_metadata[BundleMetadata.CREATOR_UID],
-        )
-    )
+        return None
 
 
 def _latest_version_from_object_names(object_names: typing.Iterator[str]) -> str:
@@ -112,17 +82,3 @@ def _latest_version_from_object_names(object_names: typing.Iterator[str]) -> str
             version = current_version
 
     return version
-
-
-def get_bundle(
-        uuid: str,
-        replica: Replica,
-        version: str=None,
-        directurls: bool=False):
-    return get_bundle_from_bucket(
-        uuid,
-        replica,
-        version,
-        None,
-        directurls
-    )

--- a/dss/storage/hcablobstore/__init__.py
+++ b/dss/storage/hcablobstore/__init__.py
@@ -94,20 +94,16 @@ class BundleFileMetadata:
     SHA256 = "sha256"
 
 
-def compose_blob_key(file_info: typing.Dict[str, str], key_class=FileMetadata) -> str:
+def compose_blob_key(file_info: typing.Dict[str, str]) -> str:
     """
     Create the key for a blob, given the file metadata.
 
     :param file_info: This can either be an object that contains the four keys (SHA256, SHA1, S3_ETAG, and CRC32C) in
                       the key_class.
-    :param key_class: Due to a mistake early on in implementation, s3_etag is internally represented as s3-etag, and
-                      publicly represented as s3_etag.  If we are reading the bundle file metadata or file metadata
-                      directly from cloud storage, we want s3-etag.  If we are reading from /bundles, then we want
-                      s3_etag.  Fortunately, the classes that hold the string constants allow us to parameterize this.
     """
     return "blobs/" + ".".join((
-        file_info[key_class.SHA256],
-        file_info[key_class.SHA1],
-        file_info[key_class.S3_ETAG],
-        file_info[key_class.CRC32C]
+        file_info[FileMetadata.SHA256],
+        file_info[FileMetadata.SHA1],
+        file_info[FileMetadata.S3_ETAG],
+        file_info[FileMetadata.CRC32C]
     ))

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -24,7 +24,7 @@ from dss.config import BucketConfig, Config, override_bucket_config, Replica
 from dss.util import UrlBuilder
 from dss.storage.blobstore import test_object_exists
 from dss.util.version import datetime_to_version_format
-from dss.storage.bundles import get_bundle_from_bucket
+from dss.storage.bundles import get_bundle_manifest
 from tests.infra import DSSAssertMixin, DSSUploadMixin, ExpectedErrorFields, get_env, testmode
 from tests.infra.server import ThreadedLocalServer
 from tests import get_auth_header
@@ -137,17 +137,15 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                                  version: typing.Optional[str],
                                  expected_version: typing.Optional[str]):
         with override_bucket_config(BucketConfig.TEST_FIXTURE):
-            try:
-                response = get_bundle_from_bucket(
-                    uuid=bundle_uuid,
-                    replica=replica,
-                    version=version,
-                    bucket=None,
-                )
-            except DSSException:
-                response = dict()
+            bundle_metadata = get_bundle_manifest(
+                uuid=bundle_uuid,
+                replica=replica,
+                version=version,
+                bucket=None,
+            )
+            bundle_version = None if bundle_metadata is None else bundle_metadata['version']
         self.assertEquals(
-            response['bundle']['version'] if 'bundle' in response else None,
+            bundle_version,
             expected_version
         )
 

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -28,7 +28,7 @@ from tests.infra import DSSAssertMixin, DSSUploadMixin, get_env, testmode
 from tests.infra.server import ThreadedLocalServer
 
 
-class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
+class TestCheckoutApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
     @classmethod
     def setUpClass(cls):
         cls.app = ThreadedLocalServer()


### PR DESCRIPTION
storage/bundles transacts in what is stored on cloud storage.  The logic that translates what is stored in cloud storage into what the API endpoint is expecting is moved to dss.api.bundles.

This allows us to get rid of the awkward hack for compose_blob_key(..), as well as some unnecessary ['bundle'] indirection.
