### PR TITLE
get rid of --method PUT in smoketest

### DIFF
--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -111,7 +111,6 @@ class Smoketest(unittest.TestCase):
                                                         ContentType='application/json'))
             put_response = run_for_json([f'{self.venv_bin}hca', 'dss', 'put-subscription',
                                          '--callback-url', url,
-                                         '--method', 'PUT',
                                          '--es-query', json.dumps(query),
                                          '--replica', replica])
             subscription_id = put_response['uuid']


### PR DESCRIPTION
This seems to make the smoketest not run, as it's not a valid param of the hca tool.
