### PR TITLE
Reorder checkout params so they're generally consistent.

### DIFF
--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -13,9 +13,9 @@ def post(uuid: str, json_request_body: dict, replica: str, version: str=None):
 
     try:
         execution_id = start_bundle_checkout(
+            Replica[replica],
             uuid,
             version,
-            Replica[replica],
             dst_bucket=json_request_body.get('destination', None),
             email_address=json_request_body.get('email', None),
         )
@@ -29,5 +29,5 @@ def post(uuid: str, json_request_body: dict, replica: str, version: str=None):
 def get(replica: str, checkout_job_id: str):
     assert replica is not None
     _replica = Replica[replica]
-    response = CheckoutStatus.get_bundle_checkout_status(_replica.checkout_bucket, checkout_job_id, _replica)
+    response = CheckoutStatus.get_bundle_checkout_status(checkout_job_id, _replica, _replica.checkout_bucket)
     return response, requests.codes.ok

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -114,7 +114,7 @@ def _verify_checkout(
 ) -> typing.Tuple[str, bool]:
     decoded_token: dict
     if token is None:
-        execution_id = start_file_checkout(blob_path, replica)
+        execution_id = start_file_checkout(replica, blob_path)
         start_time = time.time()
         attempts = 0
 

--- a/dss/stepfunctions/checkout/checkout_states.py
+++ b/dss/stepfunctions/checkout/checkout_states.py
@@ -41,9 +41,9 @@ def schedule_copy(event, context):
     replica = Replica[event[EventConstants.REPLICA]]
 
     scheduled = 0
-    for src_key, dst_key in get_manifest_files(dss_bucket, bundle_uuid, bundle_version, replica):
+    for src_key, dst_key in get_manifest_files(replica, dss_bucket, bundle_uuid, bundle_version):
         logger.info("Schedule copying a file %s to bucket %s", dst_key, dss_bucket)
-        parallel_copy(dss_bucket, src_key, dst_bucket, dst_key, replica)
+        parallel_copy(replica, dss_bucket, src_key, dst_bucket, dst_key)
         scheduled += 1
     return {_InternalEventConstants.SCHEDULED_FILES: scheduled,
             _InternalEventConstants.SCHEDULED_DST_LOCATION: get_dst_bundle_prefix(bundle_uuid, bundle_version),
@@ -62,9 +62,9 @@ def get_job_status(event, context):
 
     complete_count = 0
     total_count = 0
-    for src_key, dst_key in get_manifest_files(dss_bucket, bundle_uuid, bundle_version, replica):
+    for src_key, dst_key in get_manifest_files(replica, dss_bucket, bundle_uuid, bundle_version):
         total_count += 1
-        if validate_file_dst(get_dst_bucket(event), dst_key, replica):
+        if validate_file_dst(replica, get_dst_bucket(event), dst_key):
             complete_count += 1
 
     checkout_status = "SUCCESS" if complete_count == total_count else "IN_PROGRESS"
@@ -91,7 +91,7 @@ def pre_execution_check(event, context):
         "Pre-execution check job_id %s for bundle %s version %s replica %s",
         event[EventConstants.EXECUTION_NAME], bundle_uuid, bundle_version, replica)
 
-    checkout_status, cause = pre_exec_validate(dss_bucket, dst_bucket, replica, bundle_uuid, bundle_version)
+    checkout_status, cause = pre_exec_validate(replica, dss_bucket, dst_bucket, bundle_uuid, bundle_version)
     result = {_InternalEventConstants.VALIDATION_CHECKOUT_STATUS: checkout_status.name.upper()}
     if cause:
         result[_InternalEventConstants.VALIDATION_CAUSE] = cause
@@ -110,11 +110,12 @@ def notify_complete(event, context):
             replica)
     # record results of execution into S3
     CheckoutStatus.mark_bundle_checkout_successful(
-        event[EventConstants.STS_BUCKET],
         event[EventConstants.EXECUTION_NAME],
         replica,
+        event[EventConstants.STS_BUCKET],
         get_dst_bucket(event),
-        event[_InternalEventConstants.SCHEDULE][_InternalEventConstants.SCHEDULED_DST_LOCATION])
+        event[_InternalEventConstants.SCHEDULE][_InternalEventConstants.SCHEDULED_DST_LOCATION],
+    )
     logger.info("Checkout completed successfully jobId %s", event[EventConstants.EXECUTION_NAME])
     return {_InternalEventConstants.RESULT: result}
 
@@ -134,9 +135,9 @@ def notify_complete_failure(event, context):
         result = send_checkout_failure_email(dss.Config.get_notification_email(), event[EventConstants.EMAIL], cause)
     # record results of execution into S3
     CheckoutStatus.mark_bundle_checkout_failed(
-        event[EventConstants.STS_BUCKET],
         event[EventConstants.EXECUTION_NAME],
         Replica[event[EventConstants.REPLICA]],
+        event[EventConstants.STS_BUCKET],
         cause,
     )
     logger.info("Checkout failed jobId %s", event[EventConstants.EXECUTION_NAME])


### PR DESCRIPTION
For status methods, should be execution_id, replica, sts_bucket, etc.
For other methods, replica, bucket, etc.

Renamed some bundle_id instances to bundle_uuid.  Renamed some version instances to bundle_version.