### PR TITLE
Rename most things to execution_id

### DIFF
--- a/dss/stepfunctions/checkout/checkout_states.py
+++ b/dss/stepfunctions/checkout/checkout_states.py
@@ -71,7 +71,7 @@ def get_job_status(event, context):
     check_count += 1
     logger.info(
         "Check copy status for checkout jobId %s , check  count %d , status %s",
-        event[EventConstants.EXECUTION_NAME], check_count, checkout_status)
+        event[EventConstants.EXECUTION_ID], check_count, checkout_status)
     return {
         EventConstants.STATUS_COMPLETE_COUNT: complete_count,
         EventConstants.STATUS_TOTAL_COUNT: total_count,
@@ -89,7 +89,7 @@ def pre_execution_check(event, context):
 
     logger.info(
         "Pre-execution check job_id %s for bundle %s version %s replica %s",
-        event[EventConstants.EXECUTION_NAME], bundle_uuid, bundle_version, replica)
+        event[EventConstants.EXECUTION_ID], bundle_uuid, bundle_version, replica)
 
     checkout_status, cause = pre_exec_validate(replica, dss_bucket, dst_bucket, bundle_uuid, bundle_version)
     result = {_InternalEventConstants.VALIDATION_CHECKOUT_STATUS: checkout_status.name.upper()}
@@ -110,13 +110,13 @@ def notify_complete(event, context):
             replica)
     # record results of execution into S3
     CheckoutStatus.mark_bundle_checkout_successful(
-        event[EventConstants.EXECUTION_NAME],
+        event[EventConstants.EXECUTION_ID],
         replica,
         event[EventConstants.STATUS_BUCKET],
         get_dst_bucket(event),
         event[_InternalEventConstants.SCHEDULE][_InternalEventConstants.SCHEDULED_DST_LOCATION],
     )
-    logger.info("Checkout completed successfully jobId %s", event[EventConstants.EXECUTION_NAME])
+    logger.info("Checkout completed successfully jobId %s", event[EventConstants.EXECUTION_ID])
     return {_InternalEventConstants.RESULT: result}
 
 
@@ -135,12 +135,12 @@ def notify_complete_failure(event, context):
         result = send_checkout_failure_email(dss.Config.get_notification_email(), event[EventConstants.EMAIL], cause)
     # record results of execution into S3
     CheckoutStatus.mark_bundle_checkout_failed(
-        event[EventConstants.EXECUTION_NAME],
+        event[EventConstants.EXECUTION_ID],
         Replica[event[EventConstants.REPLICA]],
         event[EventConstants.STATUS_BUCKET],
         cause,
     )
-    logger.info("Checkout failed jobId %s", event[EventConstants.EXECUTION_NAME])
+    logger.info("Checkout failed jobId %s", event[EventConstants.EXECUTION_ID])
     return {_InternalEventConstants.RESULT: result}
 
 

--- a/dss/stepfunctions/checkout/constants.py
+++ b/dss/stepfunctions/checkout/constants.py
@@ -1,7 +1,7 @@
 class EventConstants:
     """Externally visible constants used in the SFN messages."""
 
-    EXECUTION_NAME = "execution_name"
+    EXECUTION_ID = "execution_id"
     BUNDLE_UUID = "bundle"
     BUNDLE_VERSION = "version"
     DSS_BUCKET = "dss_bucket"

--- a/dss/storage/checkout.py
+++ b/dss/storage/checkout.py
@@ -95,7 +95,7 @@ def start_bundle_checkout(
         EventConstants.BUNDLE_UUID: bundle_uuid,
         EventConstants.BUNDLE_VERSION: bundle[BundleMetadata.VERSION],
         EventConstants.REPLICA: replica.name,
-        EventConstants.EXECUTION_NAME: execution_id
+        EventConstants.EXECUTION_ID: execution_id
     }
     if dst_bucket is not None:
         sfn_input[EventConstants.DST_BUCKET] = dst_bucket
@@ -182,9 +182,9 @@ def parallel_copy(
     else:
         raise ValueError("Unsupported replica")
 
-    execution_name = get_execution_id()
-    stepfunctions.step_functions_invoke(state_machine_name_template, execution_name, state)
-    return execution_name
+    execution_id = get_execution_id()
+    stepfunctions.step_functions_invoke(state_machine_name_template, execution_id, state)
+    return execution_id
 
 
 def get_dst_bundle_prefix(bundle_id: str, bundle_version: str) -> str:

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -152,18 +152,18 @@ class TestCheckoutApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             requests.codes.ok,
             request_body
         )
-        execution_arn = resp_obj.json["checkout_job_id"]
-        self.assertIsNotNone(execution_arn)
+        execution_id = resp_obj.json["checkout_job_id"]
+        self.assertIsNotNone(execution_id)
 
-        return execution_arn
+        return execution_id
 
     @testmode.integration
     def test_status_success(self):
         for replica in Replica:
-            exec_arn = self.launch_checkout(replica.checkout_bucket, replica)
-            CheckoutStatus.mark_bundle_checkout_started(exec_arn, replica, replica.checkout_bucket)
+            execution_id = self.launch_checkout(replica.checkout_bucket, replica)
+            CheckoutStatus.mark_bundle_checkout_started(execution_id, replica, replica.checkout_bucket)
 
-            url = str(UrlBuilder().set(path="/v1/bundles/checkout/" + exec_arn).add_query("replica", replica.name))
+            url = str(UrlBuilder().set(path="/v1/bundles/checkout/" + execution_id).add_query("replica", replica.name))
 
             @eventually(timeout=120, interval=1)
             def check_status():
@@ -182,10 +182,10 @@ class TestCheckoutApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
     def test_status_fail(self):
         nonexistent_bucket_name = str(uuid.uuid4())
         for replica in Replica:
-            exec_arn = self.launch_checkout(nonexistent_bucket_name, replica)
-            CheckoutStatus.mark_bundle_checkout_started(exec_arn, replica, replica.checkout_bucket)
+            execution_id = self.launch_checkout(nonexistent_bucket_name, replica)
+            CheckoutStatus.mark_bundle_checkout_started(execution_id, replica, replica.checkout_bucket)
 
-            url = str(UrlBuilder().set(path="/v1/bundles/checkout/" + exec_arn).add_query("replica", replica.name))
+            url = str(UrlBuilder().set(path="/v1/bundles/checkout/" + execution_id).add_query("replica", replica.name))
 
             @eventually(timeout=120, interval=1)
             def check_status():


### PR DESCRIPTION
The only thing I didn't change is the _value_ of EventConstants.EXECUTION_ID.  The rationale was to preserve existing sfn runs, but maybe we don't care and we can blow away backwards compatibility. :)

Test plan: `DSS_TEST_MODE="standalone integration" make -j tests/test_checkout.py`

Addresses comment https://github.com/HumanCellAtlas/data-store/pull/1373#pullrequestreview-132235939