### PR TITLE
Bump to cloud-blobstore to 2.1.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ chalice==1.1.0
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.1.2
+cloud-blobstore==2.1.4
 colorama==0.3.7
 connexion==1.1.15
 cookies==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cffi==1.11.2
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.1.2
+cloud-blobstore==2.1.4
 connexion==1.1.15
 cryptography==2.1.4
 docutils==0.14

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -2,7 +2,7 @@
 azure-storage >= 0.36.0
 boto3 >= 1.6.0
 botocore >= 1.10.16  # 1.9.x does not support AWS secretsmanager support
-cloud-blobstore >= 2.1.2
+cloud-blobstore >= 2.1.4
 connexion == 1.1.15 # pinned by akislyuk due to upstream breaking changes in auth middleware in connexion 1.2
 elasticsearch >= 5.4.0, < 6.0.0
 elasticsearch-dsl >= 5.3.0


### PR DESCRIPTION
See https://github.com/chanzuckerberg/cloud-blobstore/commit/6fcd3d5a1eabc572615e17d8a6c7c2089938f4de for changelog.

This solves a race condition where `get_blob` returns a different dynamic instance of a blob, which is overwritten, and is not available when download_as_file is called.  It also reduces the # of API calls by 1.
