### PR TITLE
Setting ES timeout for all hosts

### DIFF
--- a/dss/index/es/__init__.py
+++ b/dss/index/es/__init__.py
@@ -85,6 +85,7 @@ class ElasticsearchClient:
                                    http_auth=es_auth)
         else:
             client = Elasticsearch(hosts=[dict(host=host, port=port)],
+                                   timeout=timeout,
                                    use_ssl=False)
         return client
 


### PR DESCRIPTION
This sets the timeout for all elasticsearch instances despite the host. This will help prevent timeout errors in elastic search unit tests.

Fixes #1370