### PR TITLE
Version mandatory for PUT Files and Bundles

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: HCA DCP DSS API
   description: Human Cell Atlas Data Coordination Platform Data Storage System API
-  version: "0.0.1"
+  version: "0.0.2"
 host: {{API_DOMAIN_NAME}}
 schemes:
   - https
@@ -291,7 +291,7 @@ paths:
         - name: version
           in: query
           description: Timestamp of file creation in RFC3339.  If this is not provided, the latest version is returned.
-          required: false
+          required: true
           type: string
           format: date-time
         - name: json_request_body
@@ -1056,7 +1056,7 @@ paths:
         - name: version
           in: query
           description: Timestamp of bundle creation in RFC3339.
-          required: false
+          required: true
           type: string
           format: date-time
         - name: replica

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -112,13 +112,10 @@ def post():
 
 
 @dss_handler
-def put(uuid: str, replica: str, json_request_body: dict, version: str = None):
+def put(uuid: str, replica: str, json_request_body: dict, version: str):
     uuid = uuid.lower()
-    if version is not None:
-        # convert it to date-time so we can format exactly as the system requires (with microsecond precision)
-        timestamp = iso8601.parse_date(version)
-    else:
-        timestamp = datetime.datetime.utcnow()
+    # convert it to date-time so we can format exactly as the system requires (with microsecond precision)
+    timestamp = iso8601.parse_date(version)
     version = datetime_to_version_format(timestamp)
 
     handle = Config.get_blobstore_handle(Replica[replica])

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -143,18 +143,16 @@ def _verify_checkout(
 
 
 @dss_handler
-def put(uuid: str, json_request_body: dict, version: str=None):
+def put(uuid: str, json_request_body: dict, version: str):
     class CopyMode(Enum):
         NO_COPY = auto()
         COPY_INLINE = auto()
         COPY_ASYNC = auto()
 
     uuid = uuid.lower()
-    if version is not None:
-        # convert it to date-time so we can format exactly as the system requires (with microsecond precision)
-        timestamp = iso8601.parse_date(version)
-    else:
-        timestamp = datetime.datetime.utcnow()
+
+    # convert it to date-time so we can format exactly as the system requires (with microsecond precision)
+    timestamp = iso8601.parse_date(version)
     version = datetime_to_version_format(timestamp)
 
     source_url = json_request_body['source_url']

--- a/tests/infra/storage_mixin.py
+++ b/tests/infra/storage_mixin.py
@@ -1,4 +1,6 @@
 import json
+
+import datetime
 import os
 import typing
 import uuid
@@ -8,13 +10,14 @@ from cloud_blobstore import BlobStore
 
 from dss import Config, Replica
 from dss.util import UrlBuilder
+from dss.util.version import datetime_to_version_format
 
 
 class TestBundle:
     def __init__(self, handle: BlobStore, path: str, bucket: str, replica: Replica = Replica.aws) -> None:
         self.path = path
         self.uuid = str(uuid.uuid4())
-        self.version = None
+        self.version = datetime_to_version_format(datetime.datetime.utcnow())
         self.handle = handle
         self.bucket = bucket
         self.files = self.enumerate_bundle_files(replica)
@@ -64,14 +67,13 @@ class DSSStorageMixin:
     def create_bundle(self: typing.Any, bundle: TestBundle, replica: Replica):
         response = self.assertPutResponse(
             str(UrlBuilder().set(path='/v1/bundles/' + bundle.uuid)
-                .add_query('replica', replica.name)),
+                .add_query('replica', replica.name).add_query('version', bundle.version)),
             requests.codes.created,
             json_request_body=self.put_bundle_payload(bundle)
         )
         response_data = json.loads(response[1])
         self.assertIs(type(response_data), dict)
         self.assertIn('version', response_data)
-        bundle.version = response_data['version']
 
     @staticmethod
     def put_bundle_payload(bundle: TestBundle):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -257,7 +257,7 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             requests.codes.conflict,
         )
 
-        print('should *NOT* be abke to this without bundle version.')
+        print('should *NOT* be able to do this without bundle version.')
         bundle_version = datetime_to_version_format(datetime.datetime.utcnow())
         self.put_bundle(
             replica,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -230,95 +230,95 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         )
         file_version = resp_obj.json['version']
 
-        print('first bundle.')
-        bundle_version = datetime_to_version_format(datetime.datetime.utcnow())
-        self.put_bundle(
-            replica,
-            bundle_uuid,
-            [(file_uuid, file_version, "LICENSE")],
-            bundle_version,
-        )
-
-        print('should be able to do this twice (i.e., same payload, same UUIDs)')
-        self.put_bundle(
-            replica,
-            bundle_uuid,
-            [(file_uuid, file_version, "LICENSE")],
-            bundle_version,
-            requests.codes.ok,
-        )
-
-        print('should *NOT* be able to do this twice with different payload.')
-        self.put_bundle(
-            replica,
-            bundle_uuid,
-            [(file_uuid, file_version, "LICENSE1")],
-            bundle_version,
-            requests.codes.conflict,
-        )
-
-        print('should *NOT* be able to do this without bundle version.')
-        bundle_version = datetime_to_version_format(datetime.datetime.utcnow())
-        self.put_bundle(
-            replica,
-            bundle_uuid,
-            [(file_uuid, file_version, "LICENSE")],
-            expected_code=requests.codes.bad_request
-        )
-
-        print('should *NOT* be able to upload a bundle with a missing file, but we should get requests.codes.conflict.')
-        with nestedcontext.bind(time_left=lambda: 0):
-            bundle_version = datetime_to_version_format(datetime.datetime.utcnow())
-            resp_obj = self.put_bundle(
-                replica,
-                bundle_uuid,
-                [
-                    (file_uuid, file_version, "LICENSE0"),
-                    (missing_file_uuid, file_version, "LICENSE1"),
-                ],
-                bundle_version,
-                expected_code=requests.codes.conflict
-            )
-            self.assertEqual(resp_obj.json['code'], "file_missing")
-
-        print('uploads a file, but delete the file metadata. put it back after a delay.')
-        self.upload_file_wait(
-            f"{schema}://{fixtures_bucket}/test_good_source_data/0",
-            replica,
-            missing_file_uuid,
-            file_version,
-            bundle_uuid=bundle_uuid
-        )
-        handle = Config.get_blobstore_handle(replica)
-        bucket = replica.bucket
-        file_metadata = handle.get(bucket, f"files/{missing_file_uuid}.{file_version}")
-        handle.delete(bucket, f"files/{missing_file_uuid}.{file_version}")
-
-        class UploadThread(threading.Thread):
-            def run(innerself):
-                time.sleep(5)
-                data_fh = io.BytesIO(file_metadata)
-                handle.upload_file_handle(bucket, f"files/{missing_file_uuid}.{file_version}", data_fh)
-
-        print('start the upload (on a delay...)')
-        upload_thread = UploadThread()
-        upload_thread.start()
-
-        # this should at first fail to find one of the files, but the UploadThread will eventually upload the file
-        # metadata.  since we give the upload bundle process ample time to spin, it should eventually find the file
-        # metadata and succeed.
-        with nestedcontext.bind(time_left=lambda: sys.maxsize):
+        with self.subTest(f'{replica}: first bundle.'):
             bundle_version = datetime_to_version_format(datetime.datetime.utcnow())
             self.put_bundle(
                 replica,
                 bundle_uuid,
-                [
-                    (file_uuid, file_version, "LICENSE0"),
-                    (missing_file_uuid, file_version, "LICENSE1"),
-                ],
+                [(file_uuid, file_version, "LICENSE")],
                 bundle_version,
-                expected_code=requests.codes.created,
             )
+
+        with self.subTest(f'{replica}: should be able to do this twice (i.e. same payload, same UUIDs)'):
+            self.put_bundle(
+                replica,
+                bundle_uuid,
+                [(file_uuid, file_version, "LICENSE")],
+                bundle_version,
+                requests.codes.ok,
+            )
+
+        with self.subTest(f'{replica}: should *NOT* be able to do this twice with different payload.'):
+            self.put_bundle(
+                replica,
+                bundle_uuid,
+                [(file_uuid, file_version, "LICENSE1")],
+                bundle_version,
+                requests.codes.conflict,
+            )
+
+        with self.subTest(f'{replica}: should *NOT* be able to do this without bundle version.'):
+            self.put_bundle(
+                replica,
+                bundle_uuid,
+                [(file_uuid, file_version, "LICENSE")],
+                expected_code=requests.codes.bad_request
+            )
+
+        with self.subTest(f'{replica}: should *NOT* be able to upload a bundle with a missing file, but we should get '
+                          'requests.codes.conflict.'):
+            with nestedcontext.bind(time_left=lambda: 0):
+                bundle_version = datetime_to_version_format(datetime.datetime.utcnow())
+                resp_obj = self.put_bundle(
+                    replica,
+                    bundle_uuid,
+                    [
+                        (file_uuid, file_version, "LICENSE0"),
+                        (missing_file_uuid, file_version, "LICENSE1"),
+                    ],
+                    bundle_version,
+                    expected_code=requests.codes.conflict
+                )
+                self.assertEqual(resp_obj.json['code'], "file_missing")
+
+        with self.subTest(f'{replica}: uploads a file, but delete the file metadata. put it back after a delay.'):
+            self.upload_file_wait(
+                f"{schema}://{fixtures_bucket}/test_good_source_data/0",
+                replica,
+                missing_file_uuid,
+                file_version,
+                bundle_uuid=bundle_uuid
+            )
+            handle = Config.get_blobstore_handle(replica)
+            bucket = replica.bucket
+            file_metadata = handle.get(bucket, f"files/{missing_file_uuid}.{file_version}")
+            handle.delete(bucket, f"files/{missing_file_uuid}.{file_version}")
+
+            class UploadThread(threading.Thread):
+                def run(innerself):
+                    time.sleep(5)
+                    data_fh = io.BytesIO(file_metadata)
+                    handle.upload_file_handle(bucket, f"files/{missing_file_uuid}.{file_version}", data_fh)
+
+            # start the upload (on a delay...)
+            upload_thread = UploadThread()
+            upload_thread.start()
+
+            # this should at first fail to find one of the files, but the UploadThread will eventually upload the file
+            # metadata.  since we give the upload bundle process ample time to spin, it should eventually find the file
+            # metadata and succeed.
+            with nestedcontext.bind(time_left=lambda: sys.maxsize):
+                bundle_version = datetime_to_version_format(datetime.datetime.utcnow())
+                self.put_bundle(
+                    replica,
+                    bundle_uuid,
+                    [
+                        (file_uuid, file_version, "LICENSE0"),
+                        (missing_file_uuid, file_version, "LICENSE1"),
+                    ],
+                    bundle_version,
+                    expected_code=requests.codes.created,
+                )
 
     @testmode.standalone
     def test_bundle_delete(self):

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -266,7 +266,7 @@ class TestCheckoutApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         for replica in Replica:
             valid, cause = pre_exec_validate(replica, replica.bucket, replica.checkout_bucket, nonexistent_bundle_uuid,
                                              nonexistent_bundle_version)
-            self.assertIs(valid, ValidationEnum.WRONG_BUNDLE_KEY)
+            self.assertIs(valid, ValidationEnum.WRONG_BUNDLE_KEY, msg=f"cause: {cause}")
 
     @testmode.standalone
     def test_validate(self):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -79,6 +79,12 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         # should be able to do this twice (i.e., different payload, same UUIDs)
         self.upload_file(source_url, file_uuid, version=version, expected_code=requests.codes.ok)
 
+        # should fail validation when invalid version is provided.
+        self.upload_file(source_url, file_uuid, version='', expected_code=requests.codes.bad)
+
+        # should fail validation when version is not provided
+        self.upload_file(source_url, file_uuid, version='missing', expected_code=requests.codes.bad)
+
     @testmode.integration
     def test_file_put_large(self):
 
@@ -415,7 +421,8 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             version = timestamp.strftime("%Y-%m-%dT%H%M%S.%fZ")
 
         urlbuilder = UrlBuilder().set(path='/v1/files/' + file_uuid)
-        urlbuilder.add_query("version", version)
+        if version is not 'missing':
+            urlbuilder.add_query("version", version)
 
         resp_obj = self.assertPutResponse(
             str(urlbuilder),


### PR DESCRIPTION
### Test plan
- Updated test cases to always include version
- Added test cases to test when no version is present

### Deployment instructions & migrations
- the HCA-CLI will need to be updated to handles these changes.

### Release notes
- updated the swagger paths for bundles/put to require version
- updated the swagger paths for files/put to require version


