### PR TITLE
Allow TF to work with assumed roles

### DIFF
--- a/environment
+++ b/environment
@@ -113,6 +113,8 @@ DSS_GS_BUCKET_REGION=""
 DSS_GS_BUCKET_TEST_REGION="US-EAST1"
 DSS_GS_BUCKET_TEST_FIXTURES_REGION="US-EAST1"
 
+AWS_SDK_LOAD_CONFIG=1 # Needed for Terraform to correctly use AWS assumed roles
+
 set +a
 
 if [[ -f "${DSS_HOME}/environment.local" ]]; then

--- a/infra/build_deploy_config.py
+++ b/infra/build_deploy_config.py
@@ -21,6 +21,7 @@ terraform_backend_template = """terraform {{
     bucket = "{bucket}"
     key = "dss-{comp}-{stage}.tfstate"
     region = "{region}"
+    {profile_setting}
   }}
 }}
 """
@@ -83,12 +84,18 @@ for key in env_vars_to_infra:
     }
 
 with open(os.path.join(infra_root, args.component, "backend.tf"), "w") as fp:
-    info = boto3.client("sts").get_caller_identity()
+    caller_info = boto3.client("sts").get_caller_identity()
+    if os.environ.get('AWS_PROFILE'):
+        profile = os.environ['AWS_PROFILE']
+        profile_setting = f'profile = "{profile}"'
+    else:
+        profile_setting = ''
     fp.write(terraform_backend_template.format(
-        bucket=os.environ['DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE'].format(account_id=info['Account']),
+        bucket=os.environ['DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE'].format(account_id=caller_info['Account']),
         comp=args.component,
         stage=os.environ['DSS_DEPLOYMENT_STAGE'],
         region=os.environ['AWS_DEFAULT_REGION'],
+        profile_setting=profile_setting,
     ))
 
 with open(os.path.join(infra_root, args.component, "variables.tf"), "w") as fp:


### PR DESCRIPTION
This allows Terraform to deploy resources using an assumed role, such as `dcp-admin` from the `hca-id` account.