### PR TITLE
Reintroduce aws us-east-1 provider for non-us-east-1 deployments

### DIFF
--- a/infra/build_deploy_config.py
+++ b/infra/build_deploy_config.py
@@ -31,6 +31,15 @@ provider aws {{
   region = "{aws_region}"
 }}
 
+# To use an ACM Certificate with Amazon CloudFront, you must request or import the certificate
+# in the US East (N. Virginia) region:
+# https://docs.aws.amazon.com/acm/latest/userguide/acm-regions.html
+# - Brian Hannafious, 07/04/2018
+provider aws {{
+  region = "us-east-1"
+  alias = "us-east-1"
+}}
+
 provider google {{
   project = "{gcp_project_id}"
 }}

--- a/infra/domain/domain.tf
+++ b/infra/domain/domain.tf
@@ -6,6 +6,7 @@ data aws_route53_zone dss_route53_zone {
 
 data aws_acm_certificate dss_domain_cert {
   domain = "${var.DSS_CERTIFICATE_DOMAIN}"
+  provider = "aws.us-east-1"
 }
 
 # TODO: Configure regional domain name with Terraform


### PR DESCRIPTION
Some certificates must live in us-east-1 regardless of deployment region:
https://docs.aws.amazon.com/acm/latest/userguide/acm-regions.html