### PR TITLE
Switch  deployment to the build box

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,8 +41,8 @@ before_script:
 deploy_dev:
   stage: deploy_dev
   script:
-     - scripts/should_deploy.py --stage dev
-#    - make -C infra apply-all
-#    - make deploy
+    - scripts/should_deploy.py --stage dev
+    - make deploy-infra
+    - make deploy
   only:
     - schedules

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ stages:
 - name: integration_test
   if: env(TRAVIS_DSS_INTEGRATION_MODE) = 1
 - name: deploy
-  if: env(TRAVIS_DSS_INTEGRATION_MODE) != 1 AND branch IN (master, integration, staging) AND type != pull_request
+  if: env(TRAVIS_DSS_INTEGRATION_MODE) != 1 AND branch IN (integration, staging) AND type != pull_request
 
 jobs:
   include:


### PR DESCRIPTION
Use the build box for `dev` deployment:
1. Deployments attempted by Build Box on a schedule (configured for every 5 minutes at time of this  PR)
2. Target branch is configured on the Build Box

This has been tested on a separate DSS deployment.