### PR TITLE
Move cleanup of the permissions test to a finally clause.

### DIFF
--- a/dss/storage/checkout.py
+++ b/dss/storage/checkout.py
@@ -262,10 +262,14 @@ def touch_test_file(replica: Replica, dst_bucket: str) -> bool:
             dst_bucket,
             test_object,
             io.BytesIO(b""))
-        Config.get_blobstore_handle(replica).delete(dst_bucket, test_object)
         return True
     except Exception:
         return False
+    finally:
+        try:
+            Config.get_blobstore_handle(replica).delete(dst_bucket, test_object)
+        except Exception:
+            pass
 
 
 class CheckoutStatus:


### PR DESCRIPTION
This avoids the problem where the delete throws an exception, causes a spurious permission test failure.

Connects to #1398
