### PR TITLE
Use exceptions to signal failures in pre-exec checks

### DIFF
--- a/dss/storage/checkout/__init__.py
+++ b/dss/storage/checkout/__init__.py
@@ -1,12 +1,17 @@
 import io
-import typing
 from enum import Enum, auto
 
 from cloud_blobstore import BlobNotFoundError, BlobStoreUnknownError
 from dss.config import Config, Replica
 from dss.storage.bundles import get_bundle_manifest
 from .common import CheckoutTokenKeys, parallel_copy
-from .error import BundleNotFoundError, TokenError, CheckoutError
+from .error import (
+    BundleNotFoundError,
+    CheckoutError,
+    DestinationBucketNotFoundError,
+    DestinationBucketNotWritableError,
+    TokenError,
+)
 
 
 class ValidationEnum(Enum):
@@ -25,28 +30,24 @@ def validate_file_dst(replica: Replica, dst_bucket: str, dst_key: str):
         return False
 
 
-def pre_exec_validate(replica: Replica, dss_bucket: str, dst_bucket: str, bundle_uuid: str, bundle_version: str):
-    validation_code, cause = validate_dst_bucket(replica, dst_bucket)
-    if validation_code == ValidationEnum.PASSED:
-        validation_code, cause = validate_bundle_exists(replica, dss_bucket, bundle_uuid, bundle_version)
-    return validation_code, cause
+def pre_exec_validate(
+        replica: Replica, dss_bucket: str, dst_bucket: str, bundle_uuid: str, bundle_version: str) -> bool:
+    validate_dst_bucket(replica, dst_bucket)
+    validate_bundle_exists(replica, dss_bucket, bundle_uuid, bundle_version)
+    return True
 
 
-def validate_dst_bucket(replica: Replica, dst_bucket: str) -> typing.Tuple[ValidationEnum, str]:
+def validate_dst_bucket(replica: Replica, dst_bucket: str) -> bool:
     if not Config.get_blobstore_handle(replica).check_bucket_exists(dst_bucket):
-        return ValidationEnum.WRONG_DST_BUCKET, f"Bucket {dst_bucket} doesn't exist"
-    if not touch_test_file(replica, dst_bucket):
-        return ValidationEnum.WRONG_PERMISSIONS_DST_BUCKET, f"Insufficient permissions on bucket {dst_bucket}"
-
-    return ValidationEnum.PASSED, None
+        raise DestinationBucketNotFoundError(f"Bucket {dst_bucket} doesn't exist")
+    return touch_test_file(replica, dst_bucket)
 
 
-def validate_bundle_exists(replica: Replica, dss_bucket: str, bundle_uuid: str, bundle_version: str):
+def validate_bundle_exists(replica: Replica, dss_bucket: str, bundle_uuid: str, bundle_version: str) -> bool:
     bundle_manifest = get_bundle_manifest(bundle_uuid, replica, bundle_version, bucket=dss_bucket)
     if bundle_manifest is None:
-        return ValidationEnum.WRONG_BUNDLE_KEY, "Bundle with specified key does not exist"
-    else:
-        return ValidationEnum.PASSED, None
+        raise BundleNotFoundError(f"Bundle {bundle_uuid}/{bundle_version} does not exist")
+    return True
 
 
 def touch_test_file(replica: Replica, dst_bucket: str) -> bool:
@@ -54,7 +55,7 @@ def touch_test_file(replica: Replica, dst_bucket: str) -> bool:
     Write a test file into the specified bucket.
     :param dst_bucket: the bucket to be checked.
     :param replica: the replica to execute the checkout in.
-    :return: True if able to write, if not also returns error message as a cause
+    :return: True if able to write, if not raise DestinationBucketNotWritableError.
     """
     test_object = "touch.txt"
     handle = Config.get_blobstore_handle(replica)
@@ -65,8 +66,8 @@ def touch_test_file(replica: Replica, dst_bucket: str) -> bool:
             test_object,
             io.BytesIO(b""))
         return True
-    except Exception:
-        return False
+    except Exception as ex:
+        raise DestinationBucketNotWritableError(ex)
     finally:
         try:
             Config.get_blobstore_handle(replica).delete(dst_bucket, test_object)

--- a/dss/storage/checkout/error.py
+++ b/dss/storage/checkout/error.py
@@ -1,8 +1,3 @@
-class BundleNotFoundError(Exception):
-    """Raised when we attempt to check out a non-existent bundle."""
-    pass
-
-
 class TokenError(Exception):
     """Raised when we can't parse the token or it is missing fields."""
     pass
@@ -10,4 +5,24 @@ class TokenError(Exception):
 
 class CheckoutError(Exception):
     """Raised when the checkout fails."""
+    pass
+
+
+class PreExecCheckoutError(CheckoutError):
+    """Raised when one of the quick checks before we start the checkout fails."""
+    pass
+
+
+class BundleNotFoundError(PreExecCheckoutError):
+    """Raised when we attempt to check out a non-existent bundle."""
+    pass
+
+
+class DestinationBucketNotFoundError(PreExecCheckoutError):
+    """Raised when we attempt to check out to a non-existent bucket."""
+    pass
+
+
+class DestinationBucketNotWritableError(PreExecCheckoutError):
+    """Raised when we attempt to check out to a bucket that we can't write to."""
     pass


### PR DESCRIPTION
This allows us to bubble up the root cause of errors.

Test plan: deployed and `DSS_TEST_MODE="standalone integration" make -j tests/test_checkout.py tests/test_file.py tests/test_bundle.py`

Depends on #1409 