### PR TITLE
Test DestinationBucketNotFoundError and DestinationBucketNotWritableError

### DIFF
--- a/environment
+++ b/environment
@@ -45,6 +45,7 @@ DSS_S3_BUCKET_STAGING=org-humancellatlas-dss-staging
 DSS_S3_BUCKET_PROD=org-humancellatlas-dss-prod
 DSS_S3_CHECKOUT_BUCKET=org-humancellatlas-dss-checkout-dev
 DSS_S3_CHECKOUT_BUCKET_TEST=org-humancellatlas-dss-checkout-test
+DSS_S3_CHECKOUT_BUCKET_UNWRITABLE=org-humancellatlas-dss-checkout-unwritable
 DSS_S3_CHECKOUT_BUCKET_INTEGRATION=org-humancellatlas-dss-checkout-integration
 DSS_S3_CHECKOUT_BUCKET_STAGING=org-humancellatlas-dss-checkout-staging
 DSS_S3_CHECKOUT_BUCKET_PROD=org-humancellatlas-dss-checkout-prod

--- a/infra/buckets/s3_buckets.tf
+++ b/infra/buckets/s3_buckets.tf
@@ -46,3 +46,38 @@ resource aws_s3_bucket dss_s3_checkout_bucket_test {
     }
   }
 }
+
+resource aws_s3_bucket dss_s3_checkout_bucket_unwritable {
+  count = "${length(var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE) > 0 ? 1 : 0}"
+  bucket = "${var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE}"
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE}",
+        "arn:aws:s3:::${var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE}/*"
+      ],
+      "Principal": "*"
+    },
+    {
+      "Action": [
+        "s3:Put*"
+      ],
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:s3:::${var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE}",
+        "arn:aws:s3:::${var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE}/*"
+      ],
+      "Principal": "*"
+    }
+  ]
+}
+POLICY
+}


### PR DESCRIPTION
DestinationBucketNotWritableError is not practical to test with GCP because creating a bucket that we don't own is the only way to prevent write access, and that's not possible within the same account.

Depends on #1415 