### PR TITLE
Add missing 301 response to GET /v1/bundles/{uuid} swagger

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -984,6 +984,13 @@ paths:
             properties:
               bundle:
                 $ref: "#/definitions/bundle_version"
+        301:
+          description: Handle asynchronously, downstream users are expected to retry later.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users are expected to retry after the delay.
+              type: integer
+              format: int64
         400:
           description: Bad request
           schema:


### PR DESCRIPTION
Fixes https://github.com/HumanCellAtlas/data-store/issues/1263 (partially)

### Test plan

Verified in the UI and by the standard unit tests.

<img width="751" alt="screen shot 2018-07-10 at 5 24 46 pm" src="https://user-images.githubusercontent.com/538456/42544516-37751e1e-8467-11e8-8ce1-6bd1ee8a05c8.png">
<img width="746" alt="screen shot 2018-07-10 at 5 24 56 pm" src="https://user-images.githubusercontent.com/538456/42544519-3cd6b930-8467-11e8-949c-9ed5d10b6bd9.png">
