### PR TITLE
[Easy] Include missing infra env var

### DIFF
--- a/infra/build_deploy_config.py
+++ b/infra/build_deploy_config.py
@@ -77,6 +77,7 @@ env_vars_to_infra = [
     "DSS_CERTIFICATE_ADDITIONAL_NAMES",
     "DSS_CERTIFICATE_VALIDATION",
     "DSS_ZONE_NAME",
+    "DSS_S3_CHECKOUT_BUCKET_UNWRITABLE",
 ]
 
 terraform_variable_info = {'variable': dict()}


### PR DESCRIPTION
env vars to TF need to be included in `infra/build_deploy_config.py`