### PR TITLE
Deploy dev on the  Build Box

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: python:3.6
+image: xbrianh/dss-build-box  # TODO: Move to humancellatlas docker account?
 
 cache:
   paths:
@@ -7,35 +7,62 @@ cache:
   - daemons/dss-index/.chalice/venv
 
 variables:
-  ES_VERSION: 5.4.2
-  ES_DOWNLOAD_URL: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
-  DSS_TEST_ES_PATH: ./elasticsearch-${ES_VERSION}/bin/elasticsearch
+  GIT_SUBMODULE_STRATEGY: normal
   DSS_ES_TIMEOUT: 30
   DSS_UNITTEST_OPTS: "-v"
   TERRAFORM_APPLY_ARGS: "-auto-approve"
+  GITHUB_API: "https://api.github.com"
 
 stages:
+  - test
+  - integration_test
   - deploy_dev
 
 before_script:
-  - apt-get update --quiet --assume-yes
-  - apt-get --assume-yes install jq moreutils gettext zip unzip
-  - python -V
-  - pip -V
-  - pip install virtualenv
+  - if not [[ CI_COMMIT_SHA == $(http GET ${GITHUB_API}/repos/HumanCellAtlas/data-store/commits sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
+# TODO: figure out how to get the gitlab-runner to not clone the repo as root - Brian H
+  - cp -r /HumanCellAtlas/data-store ~/data-store && cd ~/data-store
   - virtualenv venv
   - source venv/bin/activate
   - pip install -r requirements-dev.txt
-  - wget -q ${ES_DOWNLOAD_URL}
-  - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
-  - wget -q http://us-east-1.ec2.archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/make_4.1-6_amd64.deb
-  - mkdir make4
-  - dpkg -x make*.deb make4
-  - wget -q https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
-  - unzip terraform_0.11.7_linux_amd64.zip -d make4/usr/bin
-  - export PATH=$(pwd)/make4/usr/bin:$PATH
   - source environment
   - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then source "environment.$CI_COMMIT_REF_NAME"; fi
+
+unit_tests:
+  stage: test
+  script:
+    - whoami
+    - ls -alh /
+    - make -j4 parallel_test
+
+test_search:
+  stage: test
+  script:
+    - make -j1 tests/test_search.py
+
+test_aws_indexer:
+  stage: test
+  variables:
+    DSS_UNITTEST_OPTS: "-v TestAWSIndexer"
+  script:
+    - make -j1 tests/test_indexer.py
+
+test_gcp_indexer:
+  stage: test
+  variables:
+    DSS_UNITTEST_OPTS: "-v TestGCPIndexer"
+  script:
+    - make -j1 tests/test_indexer.py
+
+test_subscriptions:
+  stage: test
+  script:
+    - make -j1 tests/test_subscriptions.py
+
+integration_test:
+  stage: integration_test
+  script:
+    - make -j1 integration_test
 
 deploy_dev:
   stage: deploy_dev
@@ -46,4 +73,3 @@ deploy_dev:
     - make deploy
   only:
     - master
-    - triggers

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: xbrianh/dss-build-box  # TODO: Move to humancellatlas docker account?
+image: humancellatlas/dss-build-box
 
 cache:
   paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ stages:
 - name: integration_test
   if: env(TRAVIS_DSS_INTEGRATION_MODE) = 1
 - name: deploy
-  if: env(TRAVIS_DSS_INTEGRATION_MODE) != 1 AND branch IN (master, integration, staging) AND type != pull_request
+  if: env(TRAVIS_DSS_INTEGRATION_MODE) != 1 AND branch IN (integration, staging) AND type != pull_request
 
 jobs:
   include:

--- a/Dockerfile.allspark
+++ b/Dockerfile.allspark
@@ -1,3 +1,19 @@
+# This is the build image for the DSS, intended for use with the allspark GitLab server
+# It may be built and uploaded with the commands:
+#   `docker login
+#   `docker build -f Dockerfile.allspark -t {docker_username}/{tag_key}:{tag_value} .`
+#   `docker push {docker_username}/{tag_key}:{tag_value}`
+# Note that `{tag_value}` may be omitted:
+#   `docker login
+#   `docker build -f Dockerfile.allspark -t {docker_username}/{tag_key} .`
+#   `docker push {docker_username}/{tag_key}`
+#
+# Now reference the image in .gitlab-ci.yml with the line:
+#   `image: {docker_username}/{tag_key}:{tag_value}
+#
+# Please see Docker startup guide for additional info:
+#   https://docs.docker.com/get-started/ 
+
 FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile.allspark
+++ b/Dockerfile.allspark
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update --quiet \
     && apt-get install --assume-yes --no-install-recommends \
-		ca-certificates \
+        ca-certificates \
         build-essential \
         default-jre \
         gettext \

--- a/Dockerfile.allspark
+++ b/Dockerfile.allspark
@@ -1,0 +1,43 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update --quiet \
+    && apt-get install --assume-yes --no-install-recommends \
+		ca-certificates \
+        build-essential \
+        default-jre \
+        gettext \
+        git \
+        httpie \
+        jq \
+        make \
+        moreutils \
+        python3-pip \
+        python3.6-dev \
+        unzip \
+        wget \
+        zlib1g-dev
+
+RUN apt-get update --quiet
+
+RUN python3 -m pip install --upgrade pip==10.0.1 
+RUN python3 -m pip install virtualenv==16.0.0
+RUN ln -s /usr/bin/python3.6 /usr/bin/python
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
+
+RUN useradd -d /home/hca -ms /bin/bash -g root -G sudo hca
+RUN mkdir /HumanCellAtlas && chown hca /HumanCellAtlas
+USER hca
+WORKDIR /home/hca
+
+ENV PATH /home/hca/bin:${PATH}
+RUN mkdir -p /home/hca/bin
+
+ENV ES_VERSION 5.4.2
+ENV DSS_TEST_ES_PATH=/home/hca/elasticsearch-${ES_VERSION}/bin/elasticsearch
+RUN wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz \
+    && tar -xzf elasticsearch-${ES_VERSION}.tar.gz -C /home/hca
+
+RUN wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip \
+    && unzip terraform_0.11.7_linux_amd64.zip -d /home/hca/bin


### PR DESCRIPTION
* Run tests on GitLab, and deploy to `dev` if they pass.
* Create a custom Docker container to resolve Elasticsearch needing to run as a non-root user, and other permission issues.
* Turn off travis `dev` deployment