### PR TITLE
Admin repair will never send notifications

### DIFF
--- a/daemons/dss-admin/app.py
+++ b/daemons/dss-admin/app.py
@@ -40,7 +40,7 @@ class IndexTarget(Target):
         self.prefix = prefix or ''
 
     def repair(self, workers: int) -> JSON:
-        return self._start(workers, dryrun=False, notify=None)
+        return self._start(workers, dryrun=False, notify=False)
 
     def verify(self, workers: int) -> JSON:
         return self._start(workers, dryrun=True, notify=False)


### PR DESCRIPTION
Changing admin reindex to never send notification during a repair operations.

connects to #1386