### PR TITLE
 Notification only sent on bundle modification

### DIFF
--- a/dss/index/backend.py
+++ b/dss/index/backend.py
@@ -14,7 +14,7 @@ class IndexBackend(metaclass=ABCMeta):
     purpose of indexing and querying metadata associated with bundles and the files contained in them.
     """
 
-    def __init__(self, dryrun: bool = False, notify: Optional[bool] = True, **kwargs) -> None:
+    def __init__(self, dryrun: bool = False, notify: Optional[bool] = None, **kwargs) -> None:
         """
         Create a new index backend.
 

--- a/tests/infra/storage_mixin.py
+++ b/tests/infra/storage_mixin.py
@@ -14,9 +14,10 @@ from dss.util.version import datetime_to_version_format
 
 
 class TestBundle:
-    def __init__(self, handle: BlobStore, path: str, bucket: str, replica: Replica = Replica.aws) -> None:
+    def __init__(self, handle: BlobStore, path: str, bucket: str, replica: Replica = Replica.aws,
+                 bundle_uuid: str = None) -> None:
         self.path = path
-        self.uuid = str(uuid.uuid4())
+        self.uuid = bundle_uuid if bundle_uuid else str(uuid.uuid4())
         self.version = datetime_to_version_format(datetime.datetime.utcnow())
         self.handle = handle
         self.bucket = bucket

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -117,12 +117,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
 
     def setUp(self):
         super().setUp()
-        remaining_time = SpecificRemainingTime(300)
-        backend = CompositeIndexBackend(executor=self.executor,
-                                        backends=DEFAULT_BACKENDS,
-                                        remaining_time=remaining_time,
-                                        notify_async=testmode.is_integration())
-        self.indexer = self.indexer_cls(backend, remaining_time)
+        self.set_indexer()
         self.dss_alias_name = dss.Config.get_es_alias_name(dss.ESIndexType.docs, self.replica)
         self.subscription_index_name = dss.Config.get_es_index_name(dss.ESIndexType.subscriptions, self.replica)
         if self.replica not in self.bundle_key_by_replica:
@@ -419,7 +414,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         subscription_id = self.subscribe_for_notification(es_query=self.smartseq2_paired_ends_query,
                                                           **endpoint.to_dict())
         sample_event = self.create_bundle_created_event(self.bundle_key)
-        with self.subTest("A notification is recieved when an indexing event for a new bundle version replica matching "
+        with self.subTest("A notification is received when an indexing event for a new bundle version replica matching "
                           "my subscription is received."):
             self.process_new_indexable_object(sample_event)
             prefix, _, bundle_fqid = self.bundle_key.partition("/")
@@ -429,7 +424,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             self.process_new_indexable_object(sample_event)
             received_request = self._get_received_notification_request()
             self.assertIsNone(received_request)
-        with self.subTest("A notification is recieved when an indexing event for a modified bundle version replica "
+        with self.subTest("A notification is received when an indexing event for a modified bundle version replica "
                           "matching my subscription is received."):
             bundle_uuid = self.bundle_key.split('/')[1].split('.')[0]
             bundle_key = self.load_test_data_bundle_for_path(
@@ -448,13 +443,9 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
 
     @testmode.always
     def test_subscription_notification_successful(self):
-        remaining_time = SpecificRemainingTime(300)
-        backend = CompositeIndexBackend(executor=self.executor,
-                                        backends=DEFAULT_BACKENDS,
-                                        remaining_time=remaining_time,
-                                        notify_async=testmode.is_integration(),
-                                        notify=True)
-        self.indexer = self.indexer_cls(backend, remaining_time)
+        self.set_indexer(notify=True)
+        # setting notify to true allows us create subscriptions and receive notification without uploading a new bundle
+        # for every test iteration.
 
         sample_event = self.create_bundle_created_event(self.bundle_key)
         self.process_new_indexable_object(sample_event)
@@ -497,13 +488,9 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
 
     @testmode.standalone
     def test_subscription_with_attachments(self):
-        remaining_time = SpecificRemainingTime(300)
-        backend = CompositeIndexBackend(executor=self.executor,
-                                        backends=DEFAULT_BACKENDS,
-                                        remaining_time=remaining_time,
-                                        notify_async=testmode.is_integration(),
-                                        notify=True)
-        self.indexer = self.indexer_cls(backend, remaining_time)
+        self.set_indexer(notify=True)
+        # setting notify to true allows us create subscriptions and receive notification without uploading a new bundle
+        # for every test iteration.
 
         def define(**definitions):
             return dict({k: dict(type='jmespath', expression=v) for k, v in definitions.items()})
@@ -1083,6 +1070,15 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                 return None
             else:
                 time.sleep(0.5)
+
+    def set_indexer(self, remaining_time: int=300, notify: bool=None):
+        _remaining_time = SpecificRemainingTime(remaining_time)
+        backend = CompositeIndexBackend(executor=self.executor,
+                                        backends=DEFAULT_BACKENDS,
+                                        remaining_time=_remaining_time,
+                                        notify_async=testmode.is_integration(),
+                                        notify=notify)
+        self.indexer = self.indexer_cls(backend, _remaining_time)
 
     def load_test_data_bundle_for_path(self, fixture_path: str, uuid=None):
         """Loads files into test bucket and returns bundle id"""

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1284,7 +1284,9 @@ class LocalNotificationRequestHandler(BaseHTTPRequestHandler):
 
     @classmethod
     def get_request(cls):
-        return cls._request
+        request = cls._request
+        cls._request = None
+        return request
 
     def log_request(self, code='-', size='-'):
         if Config.debug_level():


### PR DESCRIPTION

### Test plan
- modified indexer test cases to handle notification on modification.
- added test case to indexer when duplicate indexer events are sent.

### Deployment instructions & migrations
- None

### Release notes
-  Notification only sent on bundle modification
- connects to #1386