### PR TITLE
GCP service account should not be managed from Integration, Staging

### DIFF
--- a/environment.integration
+++ b/environment.integration
@@ -8,6 +8,13 @@ DSS_S3_CHECKOUT_BUCKET=$DSS_S3_CHECKOUT_BUCKET_INTEGRATION
 DSS_GS_CHECKOUT_BUCKET=$DSS_GS_CHECKOUT_BUCKET_INTEGRATION
 DSS_ES_DOMAIN="dss-index-$DSS_DEPLOYMENT_STAGE"
 API_DOMAIN_NAME=dss.integration.data.humancellatlas.org
+
+# `dev`, `integration`, and `staging` share the same GCP service account. This account is
+# deployed and managed from `dev`, and the other stages should not attempt to manage a
+# shared resource from separate Terraform state files.
+# Setting `DSS_GCP_SERVICE_ACCOUNT_NAME` to a blank string will prevent duplicated management.
+DSS_GCP_SERVICE_ACCOUNT_NAME=""
+
 set +a
 
 if [[ -f "${DSS_HOME}/environment.integration.local" ]]; then

--- a/environment.staging
+++ b/environment.staging
@@ -6,11 +6,19 @@ DSS_S3_BUCKET=$DSS_S3_BUCKET_STAGING
 DSS_GS_BUCKET=$DSS_GS_BUCKET_STAGING
 DSS_S3_CHECKOUT_BUCKET=$DSS_S3_CHECKOUT_BUCKET_STAGING
 DSS_GS_CHECKOUT_BUCKET=$DSS_GS_CHECKOUT_BUCKET_STAGING
+API_DOMAIN_NAME=dss.staging.data.humancellatlas.org
+DSS_GS_BUCKET_REGION=US
+
 # `staging` currently shares the ES domain with `dev`
 DSS_ES_DOMAIN=dss-index-dev
-API_DOMAIN_NAME=dss.staging.data.humancellatlas.org
 
-DSS_GS_BUCKET_REGION=US
+
+# `dev`, `integration`, and `staging` share the same GCP service account. This account is
+# deployed and managed from `dev`, and the other stages should not attempt to manage a
+# shared resource from separate Terraform state files.
+# Setting `DSS_GCP_SERVICE_ACCOUNT_NAME` to a blank string will prevent duplicated management.
+DSS_GCP_SERVICE_ACCOUNT_NAME=""
+
 set +a
 
 if [[ -f "${DSS_HOME}/environment.staging.local" ]]; then

--- a/infra/gcp_service_account/main.tf
+++ b/infra/gcp_service_account/main.tf
@@ -1,6 +1,7 @@
 data "google_project" "project" {}
 
 resource "google_service_account" "dss" {
+  count = "${length(var.DSS_GCP_SERVICE_ACCOUNT_NAME) > 0 ? 1 : 0}"
   display_name = "${var.DSS_GCP_SERVICE_ACCOUNT_NAME}"
   account_id = "${var.DSS_GCP_SERVICE_ACCOUNT_NAME}"
 }
@@ -9,24 +10,28 @@ resource "google_service_account" "dss" {
 # `gcloud iam list-grantable-roles //cloudresourcemanager.googleapis.com/projects/{project-id}`
 
 resource "google_project_iam_member" "serviceaccountactor" {
+  count = "${length(var.DSS_GCP_SERVICE_ACCOUNT_NAME) > 0 ? 1 : 0}"
   project = "${data.google_project.project.project_id}"
   role    = "roles/iam.serviceAccountActor"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 resource "google_project_iam_member" "cloudruntimeconfiguratoradmin" {
+  count = "${length(var.DSS_GCP_SERVICE_ACCOUNT_NAME) > 0 ? 1 : 0}"
   project = "${data.google_project.project.project_id}"
   role    = "roles/runtimeconfig.admin"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 resource "google_project_iam_member" "storageadmin" {
+  count = "${length(var.DSS_GCP_SERVICE_ACCOUNT_NAME) > 0 ? 1 : 0}"
   project = "${data.google_project.project.project_id}"
   role    = "roles/storage.admin"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 resource "google_project_iam_member" "storageobjectadmin" {
+  count = "${length(var.DSS_GCP_SERVICE_ACCOUNT_NAME) > 0 ? 1 : 0}"
   project = "${data.google_project.project.project_id}"
   role    = "roles/storage.objectAdmin"
   member  = "serviceAccount:${google_service_account.dss.email}"


### PR DESCRIPTION
The GCP service account is shared across stages `dev`, `integration`, and `staging`. There is currently Terraform scripting in place to manage this account from the `dev` Terraform state file.

Since infrastructure should not be managed by multiple state files:
1. Tweak the TF scripting to not deploy the service account when `DSS_GCP_SERVICE_ACCOUNT_NAME == ""`
2. Set `DSS_GCP_SERVICE_ACCOUNT_NAME=""` for `integration` and `staging`