### PR TITLE
Include SFN execution name in visitation state

### DIFF
--- a/dss/stepfunctions/visitation/__init__.py
+++ b/dss/stepfunctions/visitation/__init__.py
@@ -49,6 +49,7 @@ class Visitation:
         _visitation_class_name=str,
         _status=WalkerStatus.init.name,
         _number_of_workers=int,
+        execution_name=str,
         work_ids=list,
         work_id=str,
         work_result=None
@@ -105,6 +106,7 @@ class Visitation:
             **kwargs,
             '_visitation_class_name': cls.__name__,
             '_number_of_workers': number_of_workers,
+            'execution_name': name
         }
         # Invoke directly without reaper/retry
         execution = _step_functions_start_execution('dss-visitation-{stage}', name, json.dumps(execution_input))

--- a/dss/stepfunctions/visitation/integration_test.py
+++ b/dss/stepfunctions/visitation/integration_test.py
@@ -46,7 +46,8 @@ class IntegrationTest(Visitation):  # no coverage (this code *is* run by tests, 
         listed_keys = handle.list(self.bucket, prefix=self.prefix)
         k_listed = sum(1 for _ in listed_keys)
         assert self.work_result == k_listed, f'Integration test failed: {self.work_result} != {k_listed}'
-        logger.info(f"Integration test passed for {self.replica} with {k_listed} key(s) listed")
+        logger.info(f"Integration test execution {self.execution_name}"
+                    f"passed for {self.replica} with {k_listed} key(s) listed")
 
     def _walk(self) -> None:
         """


### PR DESCRIPTION
Make the execution name available in the `Visitation` sfn state, which is useful as a correlation id.