### PR TITLE
Add /version endpoint to DSS API

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -54,6 +54,11 @@ OVERRIDE_EXECUTION_LIMIT_SECONDS = None
 """
 This is how long we wait for a request, if set.  If the value is None, we try to use the lambda's timeout.
 """
+DSS_VERSION = os.getenv('DSS_VERSION')
+"""
+Tag describing the version of the currently deployed DSS codebase.  Generated during deployment in the form:
+[<latest-release-tag>-<commits-since-tag>-]<SHA>
+"""
 
 
 class DSSChaliceApp(chalice.Chalice):
@@ -204,6 +209,21 @@ def get_chalice_app(flask_app) -> DSSChaliceApp:
         return chalice.Response(status_code=200,
                                 headers={"Content-Type": "text/html"},
                                 body=swagger_ui_html)
+
+    @app.route("/version")
+    @time_limited(app)
+    def version():
+        data = {
+            'version_info': {
+                'version': DSS_VERSION
+            }
+        }
+
+        return chalice.Response(
+            status_code=requests.codes.ok,
+            headers={'Content-Type': "application/json"},
+            body=data
+        )
 
     @app.route("/internal/health")
     @time_limited(app)

--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -22,8 +22,9 @@ if ! aws es describe-elasticsearch-domain --domain-name $dss_es_domain; then
     echo "Please create AWS elasticsearch domain $dss_es_domain or set DSS_ES_DOMAIN to an existing domain and try again"
     exit 1
 fi
+export DSS_VERSION=$(git describe --tags --always)
 export DSS_ES_ENDPOINT=$(aws es describe-elasticsearch-domain --domain-name "$dss_es_domain" | jq -r .DomainStatus.Endpoint)
-export EXPORT_ENV_VARS_TO_LAMBDA="$EXPORT_ENV_VARS_TO_LAMBDA DSS_ES_ENDPOINT"
+export EXPORT_ENV_VARS_TO_LAMBDA="$EXPORT_ENV_VARS_TO_LAMBDA DSS_ES_ENDPOINT DSS_VERSION"
 
 cat "$config_json" | jq ".stages.$stage.api_gateway_stage=env.stage" | sponge "$config_json"
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,8 @@ import os
 import sys
 import unittest
 
+import requests
+
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
@@ -21,6 +23,7 @@ from tests.infra.server import ThreadedLocalServer
 class TestApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin, DSSStorageMixin):
     @classmethod
     def setUpClass(cls):
+        os.environ['DSS_VERSION'] = "test_version"
         cls.app = ThreadedLocalServer()
         cls.app.start()
 
@@ -54,6 +57,14 @@ class TestApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin, DSSStorageMixin
         bundle = TestBundle(self.blobstore, self.BUNDLE_FIXTURE, self.bucket, self.replica)
         self.upload_files_and_create_bundle(bundle, self.replica)
         self.get_bundle_and_check_files(bundle, self.replica)
+
+    @testmode.standalone
+    def test_get_version(self):
+        """
+        Test /version endpoint and configuration
+        """
+        res = self.assertGetResponse("/version", requests.codes.ok)
+        self.assertEquals(res.json['version_info']['version'], os.environ['DSS_VERSION'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Connected to https://github.com/HumanCellAtlas/dcp-cli/issues/113 (cross repo)

The new `/version` endpoint on the DSS API will serve the version of the DSS generated by `git describe --tags --apply` at the time of deployment. This change is part of a larger solution to expose service version(s) describing each DCP service, and ultimately, to consolidate these endpoints in the DCP CLI as a single command that lists the versions of all DCP services.

The version value for DSS is set via environment variable and is injected into the Lambda environment. The return value of the endpoint is a named dictionary, `version_info`, and contains relevant <service/component, version> pair(s) in order to support multiple subcomponents/versions (see [Green Box's /version endpoint](https://github.com/HumanCellAtlas/dcp-cli/issues/113) under _Notes_ for an example with subcomponents).

### Test plan
The new `/version` endpoint was tested on a local instance of the DSS API and a unit test was added in `tests/test_api.py` to test configuration. When deployed, this will be tested by hitting the endpoint and verifying that the version matches the output of `$git describe --tags --always` run in the appropriate branch/commit.

### Release notes
- Added /version endpoint to DSS API
