### PR TITLE
Add roles/cloudfunctions.developer to gcp service account

### DIFF
--- a/infra/gcp_service_account/main.tf
+++ b/infra/gcp_service_account/main.tf
@@ -31,3 +31,9 @@ resource "google_project_iam_member" "storageobjectadmin" {
   role    = "roles/storage.objectAdmin"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
+
+resource "google_project_iam_member" "cloudfunctionsdeveloper" {
+  project = "${data.google_project.project.project_id}"
+  role    = "roles/cloudfunctions.developer"
+  member  = "serviceAccount:${google_service_account.dss.email}"
+}


### PR DESCRIPTION
`roles/cloudfunctions.developer` is needed to successfully execute `scripts/deploy_gcf.py` during deployment of `daemons/dss-gs-event-relay`.