### PR TITLE
Adding additional retry errors to visitation

### DIFF
--- a/dss/stepfunctions/visitation/implementation.py
+++ b/dss/stepfunctions/visitation/implementation.py
@@ -107,7 +107,9 @@ _retry = [
         "BackoffRate": 1
     },
     {
-        "ErrorEquals": ["States.Timeout"],
+        "ErrorEquals": ["States.Timeout",
+                        "States.TaskFailed",
+                        "Lambda.SdkClientException"],
         "IntervalSeconds": 5,
         "MaxAttempts": 3,
         "BackoffRate": 1.5

--- a/dss/stepfunctions/visitation/implementation.py
+++ b/dss/stepfunctions/visitation/implementation.py
@@ -108,8 +108,9 @@ _retry = [
     },
     {
         "ErrorEquals": ["States.Timeout",
-                        "States.TaskFailed",
-                        "Lambda.SdkClientException"],
+                        "Lambda.AWSLambdaException",
+                        "Lambda.SdkClientException",
+                        "Lambda.ServiceException"],
         "IntervalSeconds": 5,
         "MaxAttempts": 3,
         "BackoffRate": 1.5


### PR DESCRIPTION
- Adding `Lambda.SdkClientException` and `State.TaskFailed` to visitation retry conditions
- Fixes #1401
- Fixes #1391
 
### Test plan
We will need to run this against integration for a few days to ensure this fix works
@xbrianh any ideas how to unittest?

### Deployment instructions & migrations
- none

### Release notes
- Visitation workers will retry if the lambda fails to be invoked this includes reindexing and verify.