### PR TITLE
adding uuid to touch.txt to prevent GCP rate limit errors

### DIFF
--- a/dss/storage/checkout/__init__.py
+++ b/dss/storage/checkout/__init__.py
@@ -1,5 +1,6 @@
 import io
 from enum import Enum, auto
+import uuid
 
 from cloud_blobstore import BlobNotFoundError, BlobStoreUnknownError
 from dss.config import Config, Replica
@@ -57,7 +58,7 @@ def touch_test_file(replica: Replica, dst_bucket: str) -> bool:
     :param replica: the replica to execute the checkout in.
     :return: True if able to write, if not raise DestinationBucketNotWritableError.
     """
-    test_object = "touch.txt"
+    test_object = f"touch_{uuid.uuid1()}.txt"
     handle = Config.get_blobstore_handle(replica)
 
     try:

--- a/dss/storage/checkout/__init__.py
+++ b/dss/storage/checkout/__init__.py
@@ -1,6 +1,7 @@
 import io
+import random
 from enum import Enum, auto
-import uuid
+from string import hexdigits
 
 from cloud_blobstore import BlobNotFoundError, BlobStoreUnknownError
 from dss.config import Config, Replica
@@ -58,7 +59,7 @@ def touch_test_file(replica: Replica, dst_bucket: str) -> bool:
     :param replica: the replica to execute the checkout in.
     :return: True if able to write, if not raise DestinationBucketNotWritableError.
     """
-    test_object = f"touch_{uuid.uuid1()}.txt"
+    test_object = f"touch_{''.join(random.choices(hexdigits, k=4))}.txt"
     handle = Config.get_blobstore_handle(replica)
 
     try:

--- a/dss/storage/checkout/__init__.py
+++ b/dss/storage/checkout/__init__.py
@@ -59,7 +59,7 @@ def touch_test_file(replica: Replica, dst_bucket: str) -> bool:
     :param replica: the replica to execute the checkout in.
     :return: True if able to write, if not raise DestinationBucketNotWritableError.
     """
-    test_object = f"touch_{''.join(random.choices(hexdigits, k=4))}.txt"
+    test_object = f"touch/{''.join(random.choices(hexdigits, k=4))}.txt"
     handle = Config.get_blobstore_handle(replica)
 
     try:


### PR DESCRIPTION
Fixes #1440 

### Test plan
Run test over several days to see if any GCP request rate limits errors are triggered.

### Deployment instructions & migrations
None

### Release notes
A touch_*.txt file will be created for every checkout process. These files will eventually be deleted based on the buckets data lifecycle rules. We should also suggest that creators of checkout buckets set a shorter data lifecycle rule for files starting with `touch_`. 
