### PR TITLE
Update infra to reflect current state

### DIFF
--- a/environment.integration
+++ b/environment.integration
@@ -9,6 +9,10 @@ DSS_GS_CHECKOUT_BUCKET=$DSS_GS_CHECKOUT_BUCKET_INTEGRATION
 DSS_ES_DOMAIN="dss-index-$DSS_DEPLOYMENT_STAGE"
 API_DOMAIN_NAME=dss.integration.data.humancellatlas.org
 DSS_GCP_SERVICE_ACCOUNT_NAME="org-humancellatlas-integration"
+DSS_CERTIFICATE_DOMAIN="*.integration.data.humancellatlas.org"
+DSS_CERTIFICATE_ADDITIONAL_NAMES=""
+DSS_CERTIFICATE_VALIDATION="DNS"
+DSS_ZONE_NAME="integration.data.humancellatlas.org."
 set +a
 
 if [[ -f "${DSS_HOME}/environment.integration.local" ]]; then

--- a/infra/buckets/gs_buckets.tf
+++ b/infra/buckets/gs_buckets.tf
@@ -1,14 +1,14 @@
 resource google_storage_bucket dss_gs_bucket {
-  count = "${length(var.DSS_GS_BUCKET) > 0 ? 1 : 0}"
   name = "${var.DSS_GS_BUCKET}"
   provider = "google"
   location = "${length(var.DSS_GS_BUCKET_REGION) > 0 ?
     "${var.DSS_GS_BUCKET_REGION}" : "${var.GCP_DEFAULT_REGION}"}"
   storage_class = "REGIONAL"
+  storage_class = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? "REGIONAL" : "STANDARD"}"
 }
 
 resource google_storage_bucket dss_gs_bucket_test {
-  count = "${length(var.DSS_GS_BUCKET_TEST) > 0 ? 1 : 0}"
+  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   name = "${var.DSS_GS_BUCKET_TEST}"
   provider = "google"
   location = "${length(var.DSS_GS_BUCKET_TEST_REGION) > 0 ?
@@ -26,7 +26,7 @@ resource google_storage_bucket dss_gs_bucket_test {
 }
 
 resource google_storage_bucket dss_gs_bucket_test_fixtures {
-  count = "${length(var.DSS_GS_BUCKET_TEST_FIXTURES) > 0 ? 1 : 0}"
+  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   name = "${var.DSS_GS_BUCKET_TEST_FIXTURES}"
   provider = "google"
   location = "${length(var.DSS_GS_BUCKET_TEST_FIXTURES_REGION) > 0 ?
@@ -52,7 +52,7 @@ resource google_storage_bucket dss_gs_checkout_bucket {
 }
 
 resource google_storage_bucket dss_gs_checkout_bucket_test {
-  count = "${length(var.DSS_GS_CHECKOUT_BUCKET_TEST) > 0 ? 1 : 0}"
+  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   name = "${var.DSS_GS_CHECKOUT_BUCKET_TEST}"
   provider = "google"
   location = "${var.GCP_DEFAULT_REGION}"

--- a/infra/buckets/s3_buckets.tf
+++ b/infra/buckets/s3_buckets.tf
@@ -4,7 +4,7 @@ resource aws_s3_bucket dss_s3_bucket {
 }
 
 resource aws_s3_bucket dss_s3_bucket_test {
-  count = "${length(var.DSS_S3_BUCKET_TEST) > 0 ? 1 : 0}"
+  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_BUCKET_TEST}"
   lifecycle_rule {
     id      = "prune old things"
@@ -17,7 +17,7 @@ resource aws_s3_bucket dss_s3_bucket_test {
 }
 
 resource aws_s3_bucket dss_s3_bucket_test_fixtures {
-  count = "${length(var.DSS_S3_BUCKET_TEST_FIXTURES) > 0 ? 1 : 0}"
+  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_BUCKET_TEST_FIXTURES}"
 }
 
@@ -35,7 +35,7 @@ resource aws_s3_bucket dss_s3_checkout_bucket {
 }
 
 resource aws_s3_bucket dss_s3_checkout_bucket_test {
-  count = "${length(var.DSS_S3_CHECKOUT_BUCKET_TEST) > 0 ? 1 : 0}"
+  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_CHECKOUT_BUCKET_TEST}"
   lifecycle_rule {
     id      = "dss_checkout_expiration"
@@ -48,7 +48,7 @@ resource aws_s3_bucket dss_s3_checkout_bucket_test {
 }
 
 resource aws_s3_bucket dss_s3_checkout_bucket_unwritable {
-  count = "${length(var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE) > 0 ? 1 : 0}"
+  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE}"
   policy = <<POLICY
 {

--- a/infra/domain/main.tf
+++ b/infra/domain/main.tf
@@ -16,7 +16,7 @@ resource "aws_route53_record" "cert_validation" {
   type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
   zone_id = "${data.aws_route53_zone.selected.zone_id}"
   records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
-  ttl     = 60
+  ttl     = 300
 }
 
 resource "aws_acm_certificate_validation" "cert_dns" {

--- a/infra/elasticsearch/elasticsearch.tf
+++ b/infra/elasticsearch/elasticsearch.tf
@@ -101,5 +101,9 @@ resource aws_elasticsearch_domain elasticsearch {
     automated_snapshot_start_hour = 23
   }
 
+  tags {
+    Domain = "${var.DSS_ES_DOMAIN}"
+  }
+
   access_policies = "${data.aws_iam_policy_document.dss_es_access_policy_documennt.json}"
 }


### PR DESCRIPTION
* Accommodate, and bring up-to-date, infrastructure for `integration`.
* With this PR, `make deploy-infra` passes without changes on `dev` and `integration`.