### PR TITLE
Admin repair's default is to not send notifications

### DIFF
--- a/daemons/dss-admin/app.py
+++ b/daemons/dss-admin/app.py
@@ -40,7 +40,7 @@ class IndexTarget(Target):
         self.prefix = prefix or ''
 
     def repair(self, workers: int) -> JSON:
-        return self._start(workers, dryrun=False, notify=None)
+        return self._start(workers, dryrun=False, notify=False)
 
     def verify(self, workers: int) -> JSON:
         return self._start(workers, dryrun=True, notify=False)


### PR DESCRIPTION
### Release notes
By default admin repair will **not** send notification when new objects are discovered during the repair process. This can be changes by overriding the default values for repair.
