### PR TITLE
[Easy] Grab credentials before release it gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,8 @@ release_integration:
     -   echo "DCP Integration test did not succeed";
     -   exit 1
     - fi
+    - aws secretsmanager get-secret-value --secret-id ${DSS_SECRETS_STORE}/${DSS_DEPLOYMENT_STAGE}/gcp-credentials.json | jq -r .SecretString > gcp-credentials.json
+    - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
     - make plan-infra
     - yes 1 | scripts/release.sh master integration
   environment:


### PR DESCRIPTION
Grab the GCP credentials in gitlab-ci.yml after git clean