### PR TITLE
Adjusting async copy threshold to >= ASYNC_COPY_THRESHOLD

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -113,13 +113,10 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
     @testmode.integration
     def test_file_put_large(self):
-
-        file_sizes = [AWS_MIN_CHUNK_SIZE - 1,
-                      AWS_MIN_CHUNK_SIZE,
-                      AWS_MIN_CHUNK_SIZE + 1]
+        sizes = [-1, 0, 1]
         replicas = [(Replica.aws, S3Uploader, self.s3_test_bucket),
                     (Replica.gcp, GSUploader, self.gs_test_bucket)]
-        test_data = os.urandom(max(file_sizes))
+        test_data = os.urandom(AWS_MIN_CHUNK_SIZE + max(sizes))
 
         def upload_callable_creator(uploader_class: type) -> typing.Callable[[str, str, bytes], None]:
             def upload_callable(bucket: str, key: str, data: bytes) -> None:
@@ -132,35 +129,31 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                     uploader.checksum_and_upload_file(fh.name, key, "text/plain")
             return upload_callable
 
-        for file_size in file_sizes:
+        for size in sizes:
+            file_size = AWS_MIN_CHUNK_SIZE + size
             src_data = test_data[:file_size]
             for replica, uploader, bucket in replicas:
-                with self.subTest(f"{replica.name} {file_size}"):
-                    self._test_file_put_large(Replica.aws, bucket, upload_callable_creator(uploader), src_data)
-
-    def _test_file_put_large(self, replica: Replica,
-                             test_bucket: str,
-                             upload_func: typing.Callable[[str, str, bytes], None],
-                             src_data: bytes):
-        src_key = generate_test_key()
-        upload_func(test_bucket, src_key, src_data)
-
-        # We should be able to do this twice (i.e., same payload, different UUIDs).  First time should be asynchronous
-        # since it's new data.  Second time should be synchronous since the data is present, but because S3 does not
-        # make consistency guarantees, a second client might not see that the data is already there.  Therefore, we do
-        # not mandate that it is done synchronously.
-        for expect_async in [True, None]:
-            resp_obj = self.upload_file_wait(
-                f"{replica.storage_schema}://{test_bucket}/{src_key}",
-                replica,
-                expect_async=expect_async)
-            self.assertHeaders(
-                resp_obj.response,
-                {
-                    'content-type': "application/json",
-                }
-            )
-            self.assertIn('version', resp_obj.json)
+                src_key = generate_test_key()
+                upload_callable_creator(uploader)(bucket, src_key, src_data)
+                # We should be able to do this twice (i.e., same payload, different UUIDs).  First time should be
+                # asynchronous since it's new data.  Second time should be synchronous since the data is present,
+                # but because S3 does not make consistency guarantees, a second client might not see that the data
+                # is already there.  Therefore, we do not mandate that it is done synchronously.
+                async = [True, None] if file_size >= AWS_MIN_CHUNK_SIZE else [False, None]
+                for expect_async in async:
+                    with self.subTest(
+                            f"{replica.name}, AWS_MIN_CHUNK_SIZE + {size}, {expect_async}"):
+                        resp_obj = self.upload_file_wait(
+                            f"{replica.storage_schema}://{bucket}/{src_key}",
+                            replica,
+                            expect_async=expect_async)
+                        self.assertHeaders(
+                            resp_obj.response,
+                            {
+                                'content-type': "application/json",
+                            }
+                        )
+                        self.assertIn('version', resp_obj.json)
 
     # This is a test specific to AWS since it has separate notion of metadata and tags.
     @testmode.standalone


### PR DESCRIPTION
### Test plan
- Modified test cases to verify the upload of files with sizes +-1 of ASYNC_COPY_THRESHOLD.

### Release notes
- Relates to https://github.com/HumanCellAtlas/dcp-cli/issues/120