### PR TITLE
Fixed multipart upload

### DIFF
--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import re
 import time

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ chalice==1.1.0
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.1.4
+cloud-blobstore==2.1.5
 colorama==0.3.7
 connexion==1.1.15
 cookies==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cffi==1.11.2
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.1.4
+cloud-blobstore==2.1.5
 connexion==1.1.15
 cryptography==2.1.4
 docutils==0.14

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -2,7 +2,7 @@
 azure-storage >= 0.36.0
 boto3 >= 1.6.0
 botocore >= 1.10.16  # 1.9.x does not support AWS secretsmanager support
-cloud-blobstore >= 2.1.4
+cloud-blobstore >= 2.1.5
 connexion == 1.1.15 # pinned by akislyuk due to upstream breaking changes in auth middleware in connexion 1.2
 elasticsearch >= 5.4.0, < 6.0.0
 elasticsearch-dsl >= 5.3.0

--- a/tests/fixtures/cloud_uploader.py
+++ b/tests/fixtures/cloud_uploader.py
@@ -6,7 +6,7 @@ import boto3
 from boto3.s3.transfer import TransferConfig
 from google.cloud.storage import Client
 
-from dss.util.aws import get_s3_chunk_size
+from dss.util.aws import AWS_MIN_CHUNK_SIZE, get_s3_chunk_size
 from .checksumming_io.checksumming_io import ChecksummingSink
 
 
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class Uploader:
-    def __init__(self, local_root: str) -> None:
+    def __init__(self, local_root: str, *args, **kwargs) -> None:
         self.local_root = local_root
 
     def reset(self) -> None:
@@ -86,7 +86,7 @@ class S3Uploader(Uploader):
 
         chunk_sz = get_s3_chunk_size(sz)
         transfer_config = TransferConfig(
-            multipart_threshold=64 * 1024 * 1024,
+            multipart_threshold=AWS_MIN_CHUNK_SIZE + 1,
             multipart_chunksize=chunk_sz,
         )
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -15,10 +15,9 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss.api.files import RETRY_AFTER_INTERVAL
+from dss.api.files import ASYNC_COPY_THRESHOLD, RETRY_AFTER_INTERVAL
 from dss.config import BucketConfig, override_bucket_config, Replica
 from dss.util import UrlBuilder
-from dss.util.aws import AWS_MIN_CHUNK_SIZE
 from dss.util.version import datetime_to_version_format
 from tests import eventually
 from tests.fixtures.cloud_uploader import GSUploader, S3Uploader, Uploader
@@ -111,56 +110,74 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                           f"when uploading a file with without UUID {invalid_uuid}"):
             self.upload_file(source_url, '', expected_code=requests.codes.forbidden)
 
+    @staticmethod
+    def _upload_file_to_mock_ingest(
+            uploader_class: typing.Type[Uploader],
+            bucket: str,
+            key: str,
+            data: bytes) -> None:
+        tempdir = tempfile.gettempdir()
+        uploader = uploader_class(tempdir, bucket)
+        with tempfile.NamedTemporaryFile(delete=True) as fh:
+            fh.write(data)
+            fh.flush()
+
+            uploader.checksum_and_upload_file(fh.name, key, "text/plain")
+
+    @testmode.standalone
+    def test_file_put_large_sync(self):
+        """Test PUT /files with the largest file that is copied synchronously."""
+        test_data = os.urandom(ASYNC_COPY_THRESHOLD)
+        self._test_file_put_large(test_data[:-1])
+        self._test_file_put_large(test_data)
+
     @testmode.integration
-    def test_file_put_large(self):
+    def test_file_put_large_async(self):
+        """Test PUT /files with the smallest file that is copied asynchronously."""
+        test_data = os.urandom(ASYNC_COPY_THRESHOLD + 1)
+        self._test_file_put_large(test_data)
 
-        file_sizes = [AWS_MIN_CHUNK_SIZE - 1,
-                      AWS_MIN_CHUNK_SIZE,
-                      AWS_MIN_CHUNK_SIZE + 1]
-        replicas = [(Replica.aws, S3Uploader, self.s3_test_bucket),
-                    (Replica.gcp, GSUploader, self.gs_test_bucket)]
-        test_data = os.urandom(max(file_sizes))
-
-        def upload_callable_creator(uploader_class: type) -> typing.Callable[[str, str, bytes], None]:
-            def upload_callable(bucket: str, key: str, data: bytes) -> None:
-                tempdir = tempfile.gettempdir()
-                uploader = uploader_class(tempdir, bucket)
-                with tempfile.NamedTemporaryFile(delete=True) as fh:
-                    fh.write(data)
-                    fh.flush()
-
-                    uploader.checksum_and_upload_file(fh.name, key, "text/plain")
-            return upload_callable
-
-        for file_size in file_sizes:
-            src_data = test_data[:file_size]
-            for replica, uploader, bucket in replicas:
-                with self.subTest(f"{replica.name} {file_size}"):
-                    self._test_file_put_large(Replica.aws, bucket, upload_callable_creator(uploader), src_data)
-
-    def _test_file_put_large(self, replica: Replica,
-                             test_bucket: str,
-                             upload_func: typing.Callable[[str, str, bytes], None],
-                             src_data: bytes):
+    def _test_file_put_large(self, src_data: bytes) -> None:
+        replicas: typing.Sequence[typing.Tuple[Replica, typing.Type[Uploader], str]] = [
+            (Replica.aws, S3Uploader, self.s3_test_bucket),
+            (Replica.gcp, GSUploader, self.gs_test_bucket)
+        ]
         src_key = generate_test_key()
-        upload_func(test_bucket, src_key, src_data)
+        for replica, uploader_class, bucket in replicas:
+            self._upload_file_to_mock_ingest(uploader_class, bucket, src_key, src_data)
 
-        # We should be able to do this twice (i.e., same payload, different UUIDs).  First time should be asynchronous
-        # since it's new data.  Second time should be synchronous since the data is present, but because S3 does not
-        # make consistency guarantees, a second client might not see that the data is already there.  Therefore, we do
-        # not mandate that it is done synchronously.
-        for expect_async in [True, None]:
-            resp_obj = self.upload_file_wait(
-                f"{replica.storage_schema}://{test_bucket}/{src_key}",
-                replica,
-                expect_async=expect_async)
-            self.assertHeaders(
-                resp_obj.response,
-                {
-                    'content-type': "application/json",
-                }
-            )
-            self.assertIn('version', resp_obj.json)
+            expect_async_results: typing.Tuple[typing.Optional[bool], ...]
+            if len(src_data) > ASYNC_COPY_THRESHOLD:
+                if Replica == Replica.aws:
+                    # We should be able to do this twice (i.e., same payload, different UUIDs).
+                    # First time should be asynchronous since it's new data.  Second time should be
+                    # synchronous since the data is present, but because S3 does not make
+                    # consistency guarantees, a second client might not see that the data is already
+                    # there.  Therefore, we do not mandate that it is done synchronously.
+                    expect_async_results = (True, None)
+                else:
+                    # We should be able to do this twice (i.e., same payload, different UUIDs).
+                    # First time should be asynchronous since it's new data.  Second time should be
+                    # synchronous since the data is present.
+                    expect_async_results = (True, False)
+            else:
+                # We should be able to do this twice (i.e., same payload, different UUIDs).  Neither
+                # time should be asynchronous.
+                expect_async_results = (False, False)
+
+            for ix, expect_async in enumerate(expect_async_results):
+                with self.subTest(f"replica: {replica.name} size: {len(src_data)} round: {ix}"):
+                    resp_obj = self.upload_file_wait(
+                        f"{replica.storage_schema}://{bucket}/{src_key}",
+                        replica,
+                        expect_async=expect_async)
+                    self.assertHeaders(
+                        resp_obj.response,
+                        {
+                            'content-type': "application/json",
+                        }
+                    )
+                    self.assertIn('version', resp_obj.json)
 
     # This is a test specific to AWS since it has separate notion of metadata and tags.
     @testmode.standalone


### PR DESCRIPTION
1. Bumped to cloud-blobstore 2.1.5 to pick up https://github.com/chanzuckerberg/cloud-blobstore/commit/749d4ef7d9c7cff1d9de662a5fe5919d446a2ef5.
2. Changed the multipart threshold to 64MB+1 for the test uploader class.  This ensures that we don't switch to multipart uploads for 64MB objects.
3. Refactored the tests so that synchronous requests (i.e., <= 64MB) tests can run standalone.
4. Clarified expectations for the three classes of requests: aws multipart, gs multipart, and synchronous requests.

Test plan: Ran `DSS_TEST_MODE="standalone integration" make tests/test_file.py`

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. Uncomment below:
### Test plan -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
