### PR TITLE
Add Index Design and search limitations documentation

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -4,7 +4,7 @@ info:
   description: |
     Human Cell Atlas Data Coordination Platform Data Storage System API
 
-    **HTTP semantics**
+    # HTTP semantics
 
     The DSS API requires clients to follow certain HTTP protocol semantics that may require extra configuration in your
     HTTP client. The reference CLI and SDK (https://hca.readthedocs.io/) is pre-configured to do this. If writing your own
@@ -66,6 +66,57 @@ paths:
         # Pagination
 
         The DSS API supports pagination in a manner consistent with the [GitHub API](https://developer.github.com/v3/guides/traversing-with-pagination/), which is based on [RFC 5988](https://tools.ietf.org/html/rfc5988). When the results of an API call exceed the page size specified, the HTTP response will contain a `Link` header of the following form: `Link: <https://dss.data.humancellatlas.org/v1/search?replica=aws&per_page=100&search_after=123>; rel="next"`. The URL in the header refers to the next page of the results to be fetched; if no `Link rel="next"` URL is included, then all results have been fetched. The client should recognize and parse the `Link` header appropriately according to RFC 5988, and retrieve the next page if requested by the user, or if all results are being retrieved.
+
+        # Index design
+
+        The metadata seach index is implemented as a [document-oriented database](https://en.wikipedia.org/wiki/Document-oriented_database) using [Elasticsearch](https://www.elastic.co/). The index stores all information relevant to a bundle within each bundle document, largely eliminating the need for [object-relational mapping](https://en.wikipedia.org/wiki/Object-relational_mapping). This design is optimized for queries that filter the data.
+
+        To illustrate this concept, say our index stored information on three entities, `foo`, `bar`, and `baz`. A foo can have many bars and bars can have many bazes. If we were to index bazes in a document-oriented design, the information on the foo a bar comes from and the bazes it contains are combined into a single document. A example sketch of this is shown below in [JSON-schema](https://en.wikipedia.org/wiki/JSON#JSON_Schema).
+
+        ```
+        {
+          "definitions": {
+            "bar": {
+              "type": "object",
+              "properties": {
+                "uuid": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "foo": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    ...
+                  }
+                },
+                "bazes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                ...
+              }
+            }
+          }
+        }
+        ```
+
+        This closely resembles the structure of DSS bundle documents: projects have many bundles and bundles have many files. Each bundle document is a concatenation of the metadata on the project it belongs to and the files it contains.
+
+        # Limitations to index design
+
+        There are limitations to the design of DSS's metadata search index. A few important ones are listed below.
+
+        * [Joins](https://en.wikipedia.org/wiki/Join_(SQL)) between bundle metadata must be conducted client-side
+        * Querying is schema-specific; fields or values changed between schema version will break queries that use those fields and values
+        * A new search index must be built for each schema version
+        * A lot of metadata is duplicated between documents
       summary: |
         Find bundles by searching their metadata with an Elasticsearch query
       parameters:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -63,17 +63,9 @@ paths:
       description: |
         Accepts Elasticsearch JSON query and returns matching bundle identifiers
 
-        **Pagination**
+        # Pagination
 
-        The DSS API supports pagination in a manner consistent with the
-        [GitHub API](https://developer.github.com/v3/guides/traversing-with-pagination/), which is based on
-        [RFC 5988](https://tools.ietf.org/html/rfc5988). When the results of an API call exceed the page size
-        specified, the HTTP response will contain a `Link` header of the following form:
-        `Link: <https://dss.data.humancellatlas.org/v1/search?replica=aws&per_page=100&search_after=123>; rel="next"`.
-        The URL in the header refers to the next page of the results to be fetched; if no `Link rel="next"` URL is
-        included, then all results have been fetched. The client should recognize and parse the `Link` header
-        appropriately according to RFC 5988, and retrieve the next page if requested by the user, or if all results
-        are being retrieved.
+        The DSS API supports pagination in a manner consistent with the [GitHub API](https://developer.github.com/v3/guides/traversing-with-pagination/), which is based on [RFC 5988](https://tools.ietf.org/html/rfc5988). When the results of an API call exceed the page size specified, the HTTP response will contain a `Link` header of the following form: `Link: <https://dss.data.humancellatlas.org/v1/search?replica=aws&per_page=100&search_after=123>; rel="next"`. The URL in the header refers to the next page of the results to be fetched; if no `Link rel="next"` URL is included, then all results have been fetched. The client should recognize and parse the `Link` header appropriately according to RFC 5988, and retrieve the next page if requested by the user, or if all results are being retrieved.
       summary: |
         Find bundles by searching their metadata with an Elasticsearch query
       parameters:


### PR DESCRIPTION
Fixes https://github.com/HumanCellAtlas/data-store/issues/1084

# Need
This documentation addresses the following user story
* As a user of the DSS `POST /search` API
* I want to understand the design and limitations of DSS's search index
* so that I can quickly develop efficient queries against DSS's Elasticsearch index.