### PR TITLE
Switch to the constants defined in dcplib

### DIFF
--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import iso8601
 import requests
 from cloud_blobstore import BlobAlreadyExistsError, BlobNotFoundError
+from dcplib.s3_multipart import AWS_MIN_CHUNK_SIZE
 from flask import jsonify, make_response, redirect, request
 
 from dss import DSSException, dss_handler, stepfunctions
@@ -18,7 +19,6 @@ from dss.storage.files import write_file_metadata
 from dss.storage.hcablobstore import FileMetadata, HCABlobStore, compose_blob_key
 from dss.stepfunctions import gscopyclient, s3copyclient
 from dss.util import tracing, UrlBuilder
-from dss.util.aws import AWS_MIN_CHUNK_SIZE
 from dss.util.version import datetime_to_version_format
 
 

--- a/dss/stepfunctions/s3copyclient/implementation.py
+++ b/dss/stepfunctions/s3copyclient/implementation.py
@@ -1,17 +1,16 @@
 import binascii
 import collections
-import concurrent.futures as futures
 
 import hashlib
 import typing
 
 import boto3
 from cloud_blobstore.s3 import S3BlobStore
+from dcplib.s3_multipart import get_s3_multipart_chunk_size
 
 from dss.stepfunctions.lambdaexecutor import TimedThread
 from dss.storage.files import write_file_metadata
 from dss.util import parallel_worker
-from dss.util.aws import get_s3_chunk_size
 
 
 # CONSTANTS
@@ -49,7 +48,7 @@ def setup_copy_task(event, lambda_context):
     blobinfo = s3_blobstore.get_all_metadata(source_bucket, source_key)
     source_etag = blobinfo['ETag'].strip("\"")  # the ETag is returned with an extra set of quotes.
     source_size = blobinfo['ContentLength']  # type: int
-    part_size = get_s3_chunk_size(source_size)
+    part_size = get_s3_multipart_chunk_size(source_size)
     part_count = source_size // part_size
     if part_count * part_size < source_size:
         part_count += 1

--- a/dss/util/aws/__init__.py
+++ b/dss/util/aws/__init__.py
@@ -3,12 +3,6 @@ import botocore
 from . import clients, resources, cloudwatch_logging
 
 
-AWS_MIN_CHUNK_SIZE = 64 * 1024 * 1024
-"""Files must be larger than this before we consider multipart uploads."""
-AWS_MAX_MULTIPART_COUNT = 10000
-"""Maximum number of parts allowed in a multipart upload.  This is a limitation imposed by S3."""
-
-
 class ARN:
     fields = "arn partition service region account_id resource".split()
     _default_region, _default_account_id, _default_iam_username = None, None, None
@@ -42,13 +36,3 @@ def send_sns_msg(topic_arn, message, attributes=None):
     if attributes is not None:
         args['MessageAttributes'] = attributes
     sns_topic.publish(**args)
-
-
-def get_s3_chunk_size(filesize: int) -> int:
-    if filesize <= AWS_MAX_MULTIPART_COUNT * AWS_MIN_CHUNK_SIZE:
-        return AWS_MIN_CHUNK_SIZE
-    else:
-        div = filesize // AWS_MAX_MULTIPART_COUNT
-        if div * AWS_MAX_MULTIPART_COUNT < filesize:
-            div += 1
-        return ((div + 1048575) // 1048576) * 1048576

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ cookies==2.2.1
 coverage==4.4.2
 crcmod==1.7
 cryptography==2.1.4
-dcplib==1.2.1
+dcplib==1.3.1
 dnspython==1.15.0
 docker==2.6.1
 docker-pycreds==0.2.1

--- a/requirements-dev.txt.in
+++ b/requirements-dev.txt.in
@@ -13,5 +13,4 @@ Faker >= 0.8.11
 rstr >=2.2.6
 click >= 5.7
 aegea >= 2.1.9
-dcplib
 -r requirements.txt.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,9 @@ click==6.7
 clickclick==1.2.2
 cloud-blobstore==2.1.5
 connexion==1.1.15
+crcmod==1.7
 cryptography==2.1.4
+dcplib==1.3.1
 docutils==0.14
 elasticsearch==5.5.1
 elasticsearch-dsl==5.3.0
@@ -43,6 +45,7 @@ monotonic==1.4
 nestedcontext==0.0.4
 oauth2client==4.1.2
 protobuf==3.5.0.post1
+puremagic==1.4
 pyasn1==0.4.2
 pyasn1-modules==0.2.1
 pycparser==2.18

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -4,6 +4,7 @@ boto3 >= 1.6.0
 botocore >= 1.10.16  # 1.9.x does not support AWS secretsmanager support
 cloud-blobstore >= 2.1.5
 connexion == 1.1.15 # pinned by akislyuk due to upstream breaking changes in auth middleware in connexion 1.2
+dcplib>=1.3.1
 elasticsearch >= 5.4.0, < 6.0.0
 elasticsearch-dsl >= 5.3.0
 google-cloud-storage >= 1.7.0

--- a/tests/fixtures/cloud_uploader.py
+++ b/tests/fixtures/cloud_uploader.py
@@ -6,7 +6,7 @@ import boto3
 from boto3.s3.transfer import TransferConfig
 from google.cloud.storage import Client
 
-from dss.util.aws import AWS_MIN_CHUNK_SIZE, get_s3_chunk_size
+from dcplib.s3_multipart import MULTIPART_THRESHOLD, get_s3_multipart_chunk_size
 from dcplib.checksumming_io import ChecksummingSink
 
 
@@ -84,9 +84,9 @@ class S3Uploader(Uploader):
         fp = os.path.join(self.local_root, local_path)
         sz = os.stat(fp).st_size
 
-        chunk_sz = get_s3_chunk_size(sz)
+        chunk_sz = get_s3_multipart_chunk_size(sz)
         transfer_config = TransferConfig(
-            multipart_threshold=AWS_MIN_CHUNK_SIZE + 1,
+            multipart_threshold=MULTIPART_THRESHOLD,
             multipart_chunksize=chunk_sz,
         )
 

--- a/tests/test_s3parallelcopy.py
+++ b/tests/test_s3parallelcopy.py
@@ -10,6 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import boto3
 import botocore
+from dcplib.s3_multipart import AWS_MIN_CHUNK_SIZE
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
@@ -17,7 +18,6 @@ sys.path.insert(0, pkg_root)  # noqa
 from dss import Config, Replica, stepfunctions
 from dss.stepfunctions import s3copyclient
 from dss.stepfunctions.s3copyclient.implementation import LAMBDA_PARALLELIZATION_FACTOR
-from dss.util.aws import AWS_MIN_CHUNK_SIZE
 from tests import eventually, infra
 from tests.infra import testmode
 
@@ -32,7 +32,7 @@ class TestS3ParallelCopy(unittest.TestCase):
             UploadId=upload_id,
             PartNumber=part_id,
             ContentLength=AWS_MIN_CHUNK_SIZE,
-            Body=chr(part_id % 256) * (AWS_MIN_CHUNK_SIZE))['ETag']
+            Body=chr(part_id % 256) * AWS_MIN_CHUNK_SIZE)['ETag']
         return part_id, etag
 
     @eventually(30 * 60, 5.0, {AssertionError, botocore.exceptions.ClientError})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from dss.logging import configure_test_logging
 from dss.util import UrlBuilder
-from dss.util.aws import ARN, get_s3_chunk_size
+from dss.util.aws import ARN
 from tests.infra import testmode
 
 
@@ -24,15 +24,6 @@ class TestAwsUtils(unittest.TestCase):
         arn.get_region()
         arn.get_account_id()
         str(arn)
-
-    @testmode.standalone
-    def test_s3_chunk_size(self):
-        self.assertEqual(get_s3_chunk_size(10000 * 64 * 1024 * 1024 - 1), 64 * 1024 * 1024)
-        self.assertEqual(get_s3_chunk_size(10000 * 64 * 1024 * 1024 + 0), 64 * 1024 * 1024)
-        self.assertEqual(get_s3_chunk_size(10000 * 64 * 1024 * 1024 + 1), 65 * 1024 * 1024)
-        self.assertEqual(get_s3_chunk_size(10000 * 65 * 1024 * 1024 - 1), 65 * 1024 * 1024)
-        self.assertEqual(get_s3_chunk_size(10000 * 65 * 1024 * 1024 + 0), 65 * 1024 * 1024)
-        self.assertEqual(get_s3_chunk_size(10000 * 65 * 1024 * 1024 + 1), 66 * 1024 * 1024)
 
 
 class TestUrlBuilder(unittest.TestCase):


### PR DESCRIPTION
https://github.com/HumanCellAtlas/dcplib/commit/d446e4d79a93f1e4ccc17d9d002c13717a495c04 replicates the constants defined in dss/util/aws/__init__.py, and should be used throughout the HCA DCP.
