### PR TITLE
bump cryptography lib to 2.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ connexion==1.1.15
 cookies==2.2.1
 coverage==4.4.2
 crcmod==1.7
-cryptography==2.1.4
+cryptography==2.3
 dcplib==1.3.1
 dnspython==1.15.0
 docker==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ clickclick==1.2.2
 cloud-blobstore==2.1.5
 connexion==1.1.15
 crcmod==1.7
-cryptography==2.1.4
+cryptography==2.3
 dcplib==1.3.1
 docutils==0.14
 elasticsearch==5.5.1


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-10903

