### PR TITLE
Use folded block YAML style for docs in swagger

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: HCA DCP DSS API
-  description: |
+  description: >
     Human Cell Atlas Data Coordination Platform Data Storage System API
 
     # HTTP semantics
@@ -9,24 +9,29 @@ info:
     The DSS API requires clients to follow certain HTTP protocol semantics that may require extra configuration in your
     HTTP client. The reference CLI and SDK (https://hca.readthedocs.io/) is pre-configured to do this. If writing your own
     client, please note the following:
-    
+
+
     **301 redirects**: Some DSS API routes may return one or more HTTP 301 redirects, including potentially redirects to
     themselves (combined with the **Retry-After** delay described below). The client must follow these redirects to obtain
     the resource requested.
 
+
     **Retry-After header**: Some DSS API routes may use the **Retry-After** header in combination with HTTP 301 or 500
     series response codes. The client must follow the HTTP specification and wait the designated time period before
     continuing with the next request.
+
 
     **General retry logic**: If you are building an application that will issue high numbers of API requests, you should be
     prepared for the possibility that a small fraction of requests fails due to network or server errors. In these
     situations, the HTTP client should follow best practice HTTP retry semantics. For example, clients may be configured
     to retry 5 times while waiting for an exponential number of seconds (1, 2, 4, 8, 16 seconds) upon encountering any 500
     series response code, connect or read timeout.
-    
+
+
     The following Python code demonstrates an example configuration of the popular Requests library per the above guidance:
     
     ```
+
     import requests, requests.packages.urllib3.util.retry
 
     class RetryPolicy(requests.packages.urllib3.util.retry.Retry):
@@ -40,6 +45,7 @@ info:
     s.mount('https://', a)
 
     print(s.get("https://dss.data.humancellatlas.org").content)
+
     ```
 
   version: "0.0.2"
@@ -60,20 +66,38 @@ securityDefinitions:
 paths:
   /search:
     post:
-      description: |
+      description: >
         Accepts Elasticsearch JSON query and returns matching bundle identifiers
 
         # Pagination
 
-        The DSS API supports pagination in a manner consistent with the [GitHub API](https://developer.github.com/v3/guides/traversing-with-pagination/), which is based on [RFC 5988](https://tools.ietf.org/html/rfc5988). When the results of an API call exceed the page size specified, the HTTP response will contain a `Link` header of the following form: `Link: <https://dss.data.humancellatlas.org/v1/search?replica=aws&per_page=100&search_after=123>; rel="next"`. The URL in the header refers to the next page of the results to be fetched; if no `Link rel="next"` URL is included, then all results have been fetched. The client should recognize and parse the `Link` header appropriately according to RFC 5988, and retrieve the next page if requested by the user, or if all results are being retrieved.
+        The DSS API supports pagination in a manner consistent with the
+        [GitHub API](https://developer.github.com/v3/guides/traversing-with-pagination/),
+        which is based on [RFC 5988](https://tools.ietf.org/html/rfc5988). When the results of an API call exceed the
+        page size specified, the HTTP response will contain a `Link` header of the following form:
+        `Link: <https://dss.data.humancellatlas.org/v1/search?replica=aws&per_page=100&search_after=123>; rel="next"`.
+        The URL in the header refers to the next page of the results to be fetched; if no `Link rel="next"` URL is
+        included, then all results have been fetched. The client should recognize and parse the `Link` header
+        appropriately according to RFC 5988, and retrieve the next page if requested by the user, or if all results
+        are being retrieved.
 
         # Index design
 
-        The metadata seach index is implemented as a [document-oriented database](https://en.wikipedia.org/wiki/Document-oriented_database) using [Elasticsearch](https://www.elastic.co/). The index stores all information relevant to a bundle within each bundle document, largely eliminating the need for [object-relational mapping](https://en.wikipedia.org/wiki/Object-relational_mapping). This design is optimized for queries that filter the data.
+        The metadata seach index is implemented as a
+        [document-oriented database](https://en.wikipedia.org/wiki/Document-oriented_database)
+        using [Elasticsearch](https://www.elastic.co/). The index stores all information relevant to a bundle within
+        each bundle document, largely eliminating the need for
+        [object-relational mapping](https://en.wikipedia.org/wiki/Object-relational_mapping). This design is optimized
+        for queries that filter the data.
 
-        To illustrate this concept, say our index stored information on three entities, `foo`, `bar`, and `baz`. A foo can have many bars and bars can have many bazes. If we were to index bazes in a document-oriented design, the information on the foo a bar comes from and the bazes it contains are combined into a single document. A example sketch of this is shown below in [JSON-schema](https://en.wikipedia.org/wiki/JSON#JSON_Schema).
+
+        To illustrate this concept, say our index stored information on three entities, `foo`, `bar`, and `baz`. A foo
+        can have many bars and bars can have many bazes. If we were to index bazes in a document-oriented design, the
+        information on the foo a bar comes from and the bazes it contains are combined into a single document. A
+        example sketch of this is shown below in [JSON-schema](https://en.wikipedia.org/wiki/JSON#JSON_Schema).
 
         ```
+
         {
           "definitions": {
             "bar": {
@@ -105,19 +129,26 @@ paths:
             }
           }
         }
+
         ```
 
-        This closely resembles the structure of DSS bundle documents: projects have many bundles and bundles have many files. Each bundle document is a concatenation of the metadata on the project it belongs to and the files it contains.
+        This closely resembles the structure of DSS bundle documents: projects have many bundles and bundles have many
+        files. Each bundle document is a concatenation of the metadata on the project it belongs to and the files it
+        contains.
 
         # Limitations to index design
 
         There are limitations to the design of DSS's metadata search index. A few important ones are listed below.
 
         * [Joins](https://en.wikipedia.org/wiki/Join_(SQL)) between bundle metadata must be conducted client-side
-        * Querying is schema-specific; fields or values changed between schema version will break queries that use those fields and values
+
+        * Querying is schema-specific; fields or values changed between schema version will break queries that use
+        those fields and values
+
         * A new search index must be built for each schema version
+
         * A lot of metadata is duplicated between documents
-      summary: |
+      summary: >
         Find bundles by searching their metadata with an Elasticsearch query
       parameters:
         - name: json_request_body
@@ -133,7 +164,7 @@ paths:
               - es_query
         - name: output_format
           in: query
-          description: |
+          description: >
             Specifies the output format. The default format, `summary`, is a list of UUIDs for bundles that match
             the query. Set this parameter to `raw` to get the verbatim JSON metadata for bundles that match the query.
           required: false
@@ -157,7 +188,7 @@ paths:
           default: 100
         - name: search_after
           in: query
-          description: |
+          description: >
             **Search-After-Context**.
             An internal state pointer parameter for use with pagination. This parameter is referenced by the `Link`
             header as described in the "Pagination" section. The API client should not need to set this parameter
@@ -184,7 +215,7 @@ paths:
   /files/{uuid}:
     head:
       summary: Retrieve a file's metadata given an UUID and optionally a version.
-      description: |
+      description: >
         Given a file UUID, return the metadata for the latest version of that file.  If the version is provided, that
         version's metadata is returned instead.  The metadata is returned in the headers.
       parameters:
@@ -243,7 +274,7 @@ paths:
               pattern: "^[a-z0-9]{64}$"
     get:
       summary: Retrieve a file given a UUID and optionally a version.
-      description: |
+      description: >
         Given a file UUID, return the latest version of that file.  If the version is provided, that version of the file
         is returned instead.
 
@@ -326,7 +357,7 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: |
+                    description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
 
                       The code `illegal_token` is returned when the token parameter cannot be understood.
@@ -348,7 +379,7 @@ paths:
                   - code
     put:
       summary: Create a new version of a file
-      description: |
+      description: >
         Create a new version of a file with a given UUID. The contents of the file are provided by the client by
         reference using a cloud object storage URL. The file on the cloud object storage service must have metadata set
         listing the file checksums and content-type.
@@ -488,7 +519,7 @@ paths:
                   - code
     put:
       summary: Create a event subscription.
-      description: |
+      description: >
         Register an HTTP endpoint that is to be notified when a given event occurs.
       security:
         - googAuth:
@@ -507,12 +538,12 @@ paths:
             type: object
             properties:
               es_query:
-                description: |
+                description: >
                   An Elasticsearch query for restricting the set of bundles for which the subscriber is notified. The
                   subscriber will only be notified for newly indexed bundles that match the given query.
                 type: object
               callback_url:
-                description: |
+                description: >
                   The subscriber's URL. An HTTP request is made to the specified URL for every attempt to deliver
                   a notification to the subscriber. If the HTTP response code is 2XX, the delivery attempt is
                   considered successful and no more attemtpts will be made. Otherwise, more attempts will be made with
@@ -537,12 +568,13 @@ paths:
                   - multipart/form-data
                 default: application/json
               form_fields:
-                description: |
+                description: >
                   A collection of static form fields to be supplied in the request body, alongside the actual
                   notification payload. The value of each field must be a string. For example, if the subscriptions has
                   this property set to `{"foo" : "bar"}`, the corresponding notification HTTP request body will be
 
                   ```
+
                   --2769baffc4f24cbc83ced26aa0c2f712
                   Content-Disposition: form-data; name="foo"
 
@@ -551,6 +583,7 @@ paths:
 
                   {"transaction_id": "301c9079-3b20-4311-a131-bcda9b7f08ba", "subscription_id": ...
                   --2769baffc4f24cbc83ced26aa0c2f712--
+
                   ```
 
                   Since the type of this property is `object`, multi-valued fields are not supported. This property is
@@ -560,7 +593,7 @@ paths:
                 additionalProperties:
                   type: string
               payload_form_field:
-                description: |
+                description: >
                   The name of the form field that will hold the notification payload when the request is made. If the
                   default name of the payload field collides with that of a field in `form_fields`, this porperty can be
                   used to rename the payload and avoid the collision. This property is ignored unless `encoding` is
@@ -568,17 +601,17 @@ paths:
                 type: string
                 default: payload
               hmac_secret_key:
-                description: |
+                description: >
                   The key for signing requests to the subscriber's URL. The signature will be constructed according to
                   https://tools.ietf.org/html/draft-cavage-http-signatures and transmitted in the HTTP `Authorization`
                   header.
                 type: string
               hmac_key_id:
-                description: |
+                description: >
                   An optional key ID to use with `hmac_secret_key`.
                 type: string
               attachments:
-                description: |
+                description: >
                   The set of bundle metadata items to be included in the payload of a notification request to a
                   subscription endpoint. Each property in this object represents an attachment to the notification
                   payload. Each attachment will be a child property of the `attachments` property of the payload. The
@@ -587,6 +620,7 @@ paths:
                   For example, if the subscription is
 
                   ```
+
                   {
                     "attachments": {
                       "taxon": {
@@ -595,14 +629,17 @@ paths:
                       }
                     }
                   }
+
                   ```
 
                   the corresponding notification payload will contain the following entry
 
                   ```
+
                   "attachments": {
                     "taxon": [9606, 9606]
                   }
+
                   ```
 
                   If a general error occurs during the processing of attachments, the notification will be sent with
@@ -612,12 +649,14 @@ paths:
                   an object with one property for each failed attachment. For example,
 
                   ```
+
                   "attachments": {
                     "taxon": [9606, 9606]
                     "_errors" {
                       "biomaterial": "Some error occurred"
                     }
                   }
+
                   ```
 
                   The value of the `attachments` property must be less than or equal to 128 KiB in size when serialized
@@ -634,7 +673,7 @@ paths:
                       description: The type of the attachment. Currently only the `jmespath` type is supported.
                       enum: [jmespath]
                     expression:
-                      description: |
+                      description: >
                         The JMESpath expression to evaluate against the bundle metadata JSON document. That document is
                         of the same structure as those returned by `POST /search` with `output_format: raw`.
                       type: string
@@ -679,7 +718,7 @@ paths:
   /subscriptions/{uuid}:
     get:
       summary: Retrieve an event subscription given a UUID.
-      description: |
+      description: >
         Given a subscription UUID, return the associated subscription.
       security:
         - googAuth:
@@ -720,7 +759,7 @@ paths:
                   - code
     delete:
       summary: Delete an event subscription.
-      description: |
+      description: >
         Delete a registered event subscription. The associated query will no longer trigger a callback
         if a matching document is added to the system.
       security:
@@ -767,15 +806,18 @@ paths:
   /collections:
     put:
       summary: Create a collection.
-      description: |
+      description: >
         Create a new collection.
+
 
         Collections are sets of links to files, bundles, other collections, or fragments of JSON metadata files. Each
         entry in the input set of links is checked for referential integrity (the link target must exist in the replica
         referenced). Up to 1000 items can be referenced in a new collection, or added or removed using
         `PATCH /collections`. New collections are private to the authenticated user.
 
+
         Collection items are de-duplicated (if an identical item is given multiple times, it will only be added once).
+
 
         Collections are replicated across storage replicas similarly to files and bundles.
       security:
@@ -796,7 +838,7 @@ paths:
           pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: version
           in: query
-          description: |
+          description: >
             Timestamp of collection creation in RFC3339 format. If this is not provided, the version is automatically
             generated.
           required: true
@@ -828,8 +870,9 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: |
+                    description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
+
 
                       The code `invalid_link` indicates that an item listed in the collection contents field of the
                       input could not be resolved (either because the file, bundle, or collection does not exist on the
@@ -841,7 +884,7 @@ paths:
   /collections/{uuid}:
     get:
       summary: Retrieve a collection given a UUID.
-      description: |
+      description: >
         Given a collection UUID, return the associated collection object.
       security:
         - googAuth:
@@ -861,7 +904,7 @@ paths:
           enum: [aws, gcp, azure]
         - name: version
           in: query
-          description: |
+          description: >
             Timestamp of collection creation in RFC3339.  If this is not provided, the latest version is returned.
           required: false
           type: string
@@ -889,7 +932,7 @@ paths:
                   - code
     patch:
       summary: Update a collection.
-      description: |
+      description: >
         Add or remove items from a collection. A specific version of the collection to update must be provided, and a
         new version will be written.
       security:
@@ -910,7 +953,7 @@ paths:
           enum: [aws, gcp, azure]
         - name: version
           in: query
-          description: |
+          description: >
             Timestamp of the collection to update in RFC3339 format (required).
           required: true
           type: string
@@ -923,7 +966,7 @@ paths:
             properties:
               add_contents:
                 type: array
-                description: |
+                description: >
                   List of new items to add to the collection. Items are de-duplicated (if an identical item is already
                   present in the collection or given multiple times, it will only be added once).
                 items:
@@ -931,7 +974,7 @@ paths:
                 maxItems: 1000
               remove_contents:
                 type: array
-                description: |
+                description: >
                   List of items to remove from the collection. Items must match exactly to be removed. Items not found
                   in the collection are ignored.
                 items:
@@ -971,8 +1014,9 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: |
+                    description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
+
 
                       The code `invalid_link` indicates that an item listed in the collection contents field of the
                       input could not be resolved (either because the file, bundle, or collection does not exist on the
@@ -983,7 +1027,7 @@ paths:
                   - code
     delete:
       summary: Delete a collection.
-      description: |
+      description: >
         Delete a collection.
       security:
         - googAuth:
@@ -1020,7 +1064,7 @@ paths:
   /bundles/{uuid}:
     get:
       summary: Retrieve a bundle given a UUID and optionally a version.
-      description: |
+      description: >
         Given a bundle UUID, return the latest version of that bundle.  If the version is provided, that version of the
         bundle is returned instead.
       parameters:
@@ -1044,13 +1088,13 @@ paths:
           enum: [aws, gcp, azure]
         - name: directurls
           in: query
-          description: |
+          description: >
             Include direct-access URLs in the response.  This is mutually exclusive with the presignedurls parameter.
           required: false
           type: boolean
         - name: presignedurls
           in: query
-          description: |
+          description: >
             Include presigned URLs in the response.  This is mutually exclusive with the directurls parameter.
           required: false
           type: boolean
@@ -1083,13 +1127,16 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: |
+                    description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
+
 
                       The code `illegal_arguments` is returned when required parameters are missing or parameters do not
                       match the requirements in the specification.
 
+
                       The code `illegal_token` is returned when the token parameter cannot be understood.
+
 
                       The code `only_one_urltype` is returned when more than one url type (`directurls` and
                       `presignedurls`) is requested.
@@ -1105,10 +1152,12 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: |
+                    description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
 
+
                       The code `unhandled_exception` is returned when an unexpected exception is encountered.
+
 
                       The code `checkout_error` is returned when the checkout fails.
                     enum: [unhandled_exception, checkout_error]
@@ -1123,8 +1172,9 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: |
+                    description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
+
 
                       The code `service_unavailable` is returned when service is unavailable because of unusually high
                       load/latency
@@ -1133,7 +1183,7 @@ paths:
                   - code
     put:
       summary: Create a bundle
-      description: |
+      description: >
         Create a new version of a bundle with a given UUID.  The list of file UUID+versions to be included must be
         provided.
       parameters:
@@ -1225,11 +1275,13 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: |
+                    description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
+
 
                       The code `bundle_already_exists` indicates that the bundle+version already exists, and has
                       different contents than this request would generate.
+
 
                       The code `file_missing` indicates that one of the files does not exist on the cloud provider.
                       Because the storage backend only guarantees eventual consistency, it may be desirable to retry
@@ -1252,7 +1304,7 @@ paths:
                   - code
     delete:
       summary: Delete a bundle or a specific bundle version
-      description: |
+      description: >
         Delete the bundle with the given UUID. This deletion is applied across replicas.
       security:
         - googAuth:
@@ -1334,7 +1386,7 @@ paths:
   /bundles/{uuid}/checkout:
     post:
       summary: Check out a bundle to DSS-managed or user-managed cloud object storage destination
-      description: |
+      description: >
         Initiate asynchronous checkout of a bundle. The response JSON contains a field, `checkout_job_id`, that can be
         used to query the status of the checkout via the `GET /bundles/checkout/{checkout_job_id}` API method.
         FIXME: document the error code returned when the bundle or specified version does not exist.
@@ -1402,7 +1454,7 @@ paths:
   /bundles/checkout/{checkout_job_id}:
     get:
       summary: Check the status of a checkout request.
-      description: |
+      description: >
         Use this route with the `checkout_job_id` identifier returned by `POST /bundles/{uuid}/checkout`.
       operationId: dss.api.bundles.checkout.get
       parameters:
@@ -1442,8 +1494,9 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: |
+                    description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
+
 
                       The code `not_found` is returned when there is no record of the checkout being referenced.
                     enum: [not_found]
@@ -1568,7 +1621,7 @@ definitions:
         description: Uniquely identifies this subscription.
         pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
       replica:
-        description: |
+        description: >
           The DSS replica to subscribe. When a new bundle is indexed in a particular replica, only subscriptions for
           that same replica are notified.
         type: string
@@ -1578,12 +1631,12 @@ definitions:
         format: email
         description: The email of the user who created this subscription.
       es_query:
-        description: |
+        description: >
           An Elasticsearch query for restricting the set of bundles for which the subscriber is notified. The
           subscriber will only be notified for newly indexed bundles that match the given query.
         type: object
       callback_url:
-        description: |
+        description: >
           The subscriber\'s URL. An HTTP request is made to the specified URL for every attempt to deliver
           a notification to the subscriber. If the HTTP response code is 2XX, the delivery attempt is
           considered successful and no more attemtpts will be made. Otherwise, more attempts will be made with
@@ -1608,12 +1661,13 @@ definitions:
           - multipart/form-data
         default: application/json
       form_fields:
-        description: |
+        description: >
           A collection of static form fields to be supplied in the request body, alongside the actual
           notification payload. The value of each field must be a string. For example, if the subscriptions has
           this property set to `{"foo" : "bar"}`, the corresponding notification HTTP request body will be
 
           ```
+
           --2769baffc4f24cbc83ced26aa0c2f712
           Content-Disposition: form-data; name="foo"
 
@@ -1622,6 +1676,7 @@ definitions:
 
           {"transaction_id": "301c9079-3b20-4311-a131-bcda9b7f08ba", "subscription_id": ...
           --2769baffc4f24cbc83ced26aa0c2f712--
+
           ```
 
           Since the type of this property is `object`, multi-valued fields are not supported. This property is
@@ -1631,7 +1686,7 @@ definitions:
         additionalProperties:
           type: string
       payload_form_field:
-        description: |
+        description: >
           The name of the form field that will hold the notification payload when the request is made. If the
           default name of the payload field collides with that of a field in `form_fields`, this porperty can be
           used to rename the payload and avoid the collision. This property is ignored unless `encoding` is
@@ -1639,7 +1694,7 @@ definitions:
         type: string
         default: payload
       attachments:
-        description: |
+        description: >
           The set of bundle metadata items to be included in the payload of a notification request to a
           subscription endpoint. Each property in this object represents an attachment to the notification
           payload. Each attachment will be a child property of the `attachments` property of the payload. The
@@ -1648,6 +1703,7 @@ definitions:
           For example, if the subscription is
 
           ```
+
           {
             "attachments": {
               "taxon": {
@@ -1656,14 +1712,17 @@ definitions:
               }
             }
           }
+
           ```
 
           the corresponding notification payload will contain the following entry
 
           ```
+
           "attachments": {
             "taxon": [9606, 9606]
           }
+
           ```
 
           If a general error occurs during the processing of attachments, the notification will be sent with
@@ -1673,20 +1732,26 @@ definitions:
           an object with one property for each failed attachment. For example,
 
           ```
+
           "attachments": {
             "taxon": [9606, 9606]
             "_errors" {
               "biomaterial": "Some error occurred"
             }
           }
+
           ```
 
           The value of the `attachments` property must be less than or equal to 128 KiB in size when serialized
           to JSON and encoded as UTF-8. If it is not, the notification will be sent with
 
+          ```
+
           "attachments": {
             "_errors": "Attachments too large (131073 bytes)"
           }
+
+          ```
         type: object
         additionalProperties:
           type: object
@@ -1695,7 +1760,7 @@ definitions:
               description: The type of the attachment. Currently only the `jmespath` type is supported.
               enum: [jmespath]
             expression:
-              description: |
+              description: >
                 The JMESpath expression to evaluate against the bundle metadata JSON document. That document is
                 of the same structure as those returned by `POST /search` with `output_format: raw`.
               type: string
@@ -1752,7 +1817,7 @@ definitions:
         description: Supplementary JSON metadata for the collection.
         type: object
       contents:
-        description: |
+        description: >
           A list of objects describing links to files, bundles, other collections, and metadata fragments that are
           part of the collection.
         type: array
@@ -1779,7 +1844,7 @@ definitions:
         description: RFC3339 timestamp of the file, bundle, collection, or file containing a metadata fragment.
       path:
         type: string
-        description: |
+        description: >
           JSON Pointer indexing into the JSON conents of the file containing a metadata fragment.
           Required for links of type other than file, bundle, or collection. Ignored otherwise.
     required:
@@ -1795,7 +1860,7 @@ definitions:
         description: HTTP error code.
       code:
         type: string
-        description: |
+        description: >
           Machine-readable error code.  The types of return values should not be changed lightly.  Individual endpoints
           should list an enumeration of possible return codes.  All endpoints should expect the possibility of the
           return code `unhandled_exception` and `illegal_arguments`.


### PR DESCRIPTION
Follow up from https://github.com/HumanCellAtlas/data-store/pull/1461

# Need

The swagger doc currently uses [literal block style](http://yaml.org/spec/1.2/spec.html#id2795688). This causes text in the swagger doc to not format properly. See example below

![before](https://user-images.githubusercontent.com/538456/43610584-59970c90-965b-11e8-8993-63019c5e4640.gif)

This makes the documentation harder to read for users.

# Approach

To fix this, this PR switches the swagger docs to [folded block style](http://yaml.org/spec/1.2/spec.html#id2796251) as suggested by @hannes-ucsc. See an example of the result below.

![after](https://user-images.githubusercontent.com/538456/43610650-931aa7ba-965b-11e8-9f32-78a09cf3fc27.gif)
