### PR TITLE
Upgrade to dcplib 1.3.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ cookies==2.2.1
 coverage==4.4.2
 crcmod==1.7
 cryptography==2.3
-dcplib==1.3.1
+dcplib==1.3.2
 dnspython==1.15.0
 docker==2.6.1
 docker-pycreds==0.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ cloud-blobstore==2.1.5
 connexion==1.1.15
 crcmod==1.7
 cryptography==2.3
-dcplib==1.3.1
+dcplib==1.3.2
 docutils==0.14
 elasticsearch==5.5.1
 elasticsearch-dsl==5.3.0

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -4,7 +4,7 @@ boto3 >= 1.6.0
 botocore >= 1.10.16  # 1.9.x does not support AWS secretsmanager support
 cloud-blobstore >= 2.1.5
 connexion == 1.1.15 # pinned by akislyuk due to upstream breaking changes in auth middleware in connexion 1.2
-dcplib>=1.3.1
+dcplib>=1.3.2
 elasticsearch >= 5.4.0, < 6.0.0
 elasticsearch-dsl >= 5.3.0
 google-cloud-storage >= 1.7.0

--- a/tests/fixtures/cloud_uploader.py
+++ b/tests/fixtures/cloud_uploader.py
@@ -42,7 +42,10 @@ class Uploader:
         if metadata is None:
             metadata = dict()
 
-        with ChecksummingSink() as sink, open(os.path.join(self.local_root, local_path), "rb") as fh:
+        fpath = os.path.join(self.local_root, local_path)
+        size = os.path.getsize(fpath)
+        chunk_size = get_s3_multipart_chunk_size(size)
+        with ChecksummingSink(write_chunk_size=chunk_size) as sink, open(fpath, "rb") as fh:
             data = fh.read()
             sink.write(data)
 


### PR DESCRIPTION
ChecksummingSink now has a required parameter write_chunk_size, which allows it to calculate correct HCA checksums.

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

### Test plan

Waiting for travis....

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
