### PR TITLE
Move errcodes out of the catch-all default error handler.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -463,6 +463,32 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - version
+        400:
+          description: Returned when the source_url of the file has an unsupported schema.
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [unknown_source_schema]
+                required:
+                  - code
+        409:
+          description: Returned when a file with the same UUID and version already exists
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [file_already_exists]
+                required:
+                  - code
         default:
           description: Unexpected error
           schema:
@@ -473,7 +499,7 @@ paths:
                   code:
                     type: string
                     description: Machine-readable error code.  The types of return values should not be changed lightly.
-                    enum: [unhandled_exception, illegal_arguments, unknown_source_schema, file_already_exists]
+                    enum: [unhandled_exception, illegal_arguments]
                 required:
                   - code
   /subscriptions:
@@ -1266,8 +1292,8 @@ paths:
                 format: date-time
             required:
               - version
-        409:
-          description: Unexpected error
+        400:
+          description: Returned when the server could not process the request.  Examine the code for more details.
           schema:
             allOf:
               - $ref: '#/definitions/Error'
@@ -1278,15 +1304,24 @@ paths:
                     description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
 
+                      The code `duplicate_filename` is returned when the bundle contains two files of the same name.
 
-                      The code `bundle_already_exists` indicates that the bundle+version already exists, and has
-                      different contents than this request would generate.
-
-
-                      The code `file_missing` indicates that one of the files does not exist on the cloud provider.
-                      Because the storage backend only guarantees eventual consistency, it may be desirable to retry
-                      requests that return this error code.
-                    enum: [bundle_already_exists, file_missing]
+                      The code `file_missing` is returned when the server cannot find one of the files requested to be
+                      included in the bundle.
+                    enum: [duplicate_filename, file_missing]
+                required:
+                  - code
+        409:
+          description: Returned when a bundle with the same UUID and version already exists
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [bundle_already_exists]
                 required:
                   - code
         default:
@@ -1299,7 +1334,7 @@ paths:
                   code:
                     type: string
                     description: Machine-readable error code.  The types of return values should not be changed lightly.
-                    enum: [unhandled_exception, illegal_arguments, bundle_already_exists, duplicate_filename]
+                    enum: [unhandled_exception, illegal_arguments]
                 required:
                   - code
     delete:

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -169,7 +169,7 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str):
             continue
 
         raise DSSException(
-            requests.codes.conflict,
+            requests.codes.bad_request,
             "file_missing",
             f"Could not find file {missing_file_user_metadata['uuid']}/{missing_file_user_metadata['version']}."
         )

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -307,7 +307,7 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             )
 
         with self.subTest(f'{replica}: should *NOT* be able to upload a bundle with a missing file, but we should get '
-                          'requests.codes.conflict.'):
+                          'requests.codes.bad.'):
             with nestedcontext.bind(time_left=lambda: 0):
                 bundle_version = datetime_to_version_format(datetime.datetime.utcnow())
                 resp_obj = self.put_bundle(
@@ -318,7 +318,7 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                         (missing_file_uuid, file_version, "LICENSE1"),
                     ],
                     bundle_version,
-                    expected_code=requests.codes.conflict
+                    expected_code=requests.codes.bad
                 )
                 self.assertEqual(resp_obj.json['code'], "file_missing")
 


### PR DESCRIPTION
They belong on each of their own groups.

Also changed missing file in a bundle to a 400 not a 409.
