### PR TITLE
Change illegal version to a 400.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -464,7 +464,7 @@ paths:
             required:
               - version
         400:
-          description: Returned when the source_url of the file has an unsupported schema.
+          description: Returned when the server could not process the request.  Examine the code for more details.
           schema:
             allOf:
               - $ref: '#/definitions/Error'
@@ -472,8 +472,14 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: Machine-readable error code.  The types of return values should not be changed lightly.
-                    enum: [unknown_source_schema]
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+
+                      The code `unknown_source_schema` is returned when the source_url of the file has an unsupported
+                      schema.
+
+                      The code `illegal_version` is returned when version is not a RFC3339-compliant timestamp.
+                    enum: [unknown_source_schema, illegal_version]
                 required:
                   - code
         409:
@@ -1308,7 +1314,9 @@ paths:
 
                       The code `file_missing` is returned when the server cannot find one of the files requested to be
                       included in the bundle.
-                    enum: [duplicate_filename, file_missing]
+
+                      The code `illegal_version` is returned when version is not a RFC3339-compliant timestamp.
+                    enum: [duplicate_filename, file_missing, illegal_version]
                 required:
                   - code
         409:

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -115,7 +115,13 @@ def post():
 def put(uuid: str, replica: str, json_request_body: dict, version: str):
     uuid = uuid.lower()
     # convert it to date-time so we can format exactly as the system requires (with microsecond precision)
-    timestamp = iso8601.parse_date(version)
+    try:
+        timestamp = iso8601.parse_date(version)
+    except iso8601.ParseError:
+        raise DSSException(
+            requests.codes.bad_request,
+            "illegal_version",
+            f"version should be an rfc3339-compliant timestamp")
     version = datetime_to_version_format(timestamp)
 
     handle = Config.get_blobstore_handle(Replica[replica])

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -152,7 +152,14 @@ def put(uuid: str, json_request_body: dict, version: str):
     uuid = uuid.lower()
 
     # convert it to date-time so we can format exactly as the system requires (with microsecond precision)
-    timestamp = iso8601.parse_date(version)
+    try:
+        timestamp = iso8601.parse_date(version)
+    except iso8601.ParseError:
+        raise DSSException(
+            requests.codes.bad_request,
+            "illegal_version",
+            f"version should be an rfc3339-compliant timestamp")
+
     version = datetime_to_version_format(timestamp)
 
     source_url = json_request_body['source_url']

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -303,7 +303,7 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                 bundle_uuid,
                 [(file_uuid, file_version, "LICENSE")],
                 "ABCD",
-                expected_code=requests.codes.internal_server_error
+                expected_code=requests.codes.bad_request
             )
 
         with self.subTest(f'{replica}: should *NOT* be able to upload a bundle with a missing file, but we should get '

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -90,21 +90,21 @@ class TestFileApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             self.upload_file(source_url_temp, file_uuid, version=version, expected_code=requests.codes.conflict)
 
         with self.subTest(f"{replica}: Bad returned when uploading a file with an invalid version"):
-            self.upload_file(source_url, file_uuid, version='', expected_code=requests.codes.bad)
+            self.upload_file(source_url, file_uuid, version='', expected_code=requests.codes.bad_request)
 
         invalid_version = 'ABCD'
-        with self.subTest(f"{replica}: server_error returned "
+        with self.subTest(f"{replica}: bad_request returned "
                           f"when uploading a file with invalid version {invalid_version}"):
-            self.upload_file(source_url, file_uuid, version=invalid_version, expected_code=requests.codes.server_error)
+            self.upload_file(source_url, file_uuid, version=invalid_version, expected_code=requests.codes.bad_request)
 
         with self.subTest(f"{replica}: Bad returned when uploading a file without a version"):
-            self.upload_file(source_url, file_uuid, version='missing', expected_code=requests.codes.bad)
+            self.upload_file(source_url, file_uuid, version='missing', expected_code=requests.codes.bad_request)
 
         invalid_uuids = ['ABCD', '1234']
         for invalid_uuid in invalid_uuids:
             with self.subTest(f"{replica}: Bad returned "
                               f"when uploading a file with invalid UUID {invalid_uuid}"):
-                self.upload_file(source_url, invalid_uuid, expected_code=requests.codes.bad)
+                self.upload_file(source_url, invalid_uuid, expected_code=requests.codes.bad_request)
 
         with self.subTest(f"{replica}: forbidden returned "
                           f"when uploading a file with without UUID {invalid_uuid}"):


### PR DESCRIPTION
This should _not_ be a 500.  This is a case we should handle, and return the proper error message.  In general, we should never expect a 500 in a test.
