### PR TITLE
Explicitly catch a malformed version error for PATCH /collections

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1037,6 +1037,22 @@ paths:
             required:
               - uuid
               - version
+        400:
+          description: >
+            Returned when the server could not process the request due to incorrect inputs.  Examine the code for more
+            details.
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      The code `illegal_version` is returned when version is not a RFC3339-compliant timestamp.
+                    enum: [illegal_version]
+                required:
+                  - code
         default:
           description: Unexpected error
           schema:

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -84,6 +84,14 @@ class hashabledict(dict):
 
 @dss_handler
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
+    try:
+        iso8601.parse_date(version)
+    except iso8601.ParseError:
+        raise DSSException(
+            requests.codes.bad_request,
+            "illegal_version",
+            f"version should be an rfc3339-compliant timestamp")
+
     authenticated_user_email = request.token_info['email']
 
     uuid = uuid.lower()

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -165,7 +165,8 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                           dict(version=self.version),
                           dict(),
                           dict(replica="", version=self.version),
-                          dict(replica="aws", version='')
+                          dict(replica="aws", version=""),
+                          dict(replica="aws", version="GIBBERISH"),
                           ]
         for params in missing_params:
             with self.subTest(params):


### PR DESCRIPTION
This is required to unpin dependencies, as validation has changed for empty strings.  This is a generally good change to have though, since we were not previously testing for versions that are not timestamps but not an empty string. 