### PR TITLE
Improve error response documentation for PATCH /collections

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1053,6 +1053,57 @@ paths:
                     enum: [illegal_version]
                 required:
                   - code
+        403:
+          description: >
+            Returned when credentials presented do not grant access to this collection.
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+
+                      The code `Forbidden` indicates that the user does not have access to this collection.
+
+                      The code `OAuthResponseProblem` indicates that the OAuth credentials presented were not
+                      understood.
+                    enum: [Forbidden, OAuthResponseProblem]
+                required:
+                  - code
+        404:
+          description: >
+            Returned when the server could not find the collection to patch.
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [not_found]
+                required:
+                  - code
+        422:
+          description: >
+            Returned when the server could not find some of the files necessary to complete the operation or if the JSON
+            Pointer reference could not be resolved within the specified file.
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [invalid_link]
+                required:
+                  - code
         default:
           description: Unexpected error
           schema:
@@ -1064,13 +1115,7 @@ paths:
                     type: string
                     description: >
                       Machine-readable error code.  The types of return values should not be changed lightly.
-
-
-                      The code `invalid_link` indicates that an item listed in the collection contents field of the
-                      input could not be resolved (either because the file, bundle, or collection does not exist on the
-                      replica specified, or because the JSON Pointer reference could not be resolved within the
-                      specified file).
-                    enum: [unhandled_exception, Forbidden, OAuthResponseProblem, not_found, invalid_link]
+                    enum: [unhandled_exception, illegal_arguments]
                 required:
                   - code
     delete:

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -151,13 +151,18 @@ def get_json_metadata(entity_type: str, uuid: str, version: str, replica: Replic
         # TODO: verify that file is a metadata file
         size = blobstore_handle.get_size(replica.bucket, key)
         if size > MAX_METADATA_SIZE:
-            raise DSSException(422, "invalid_link",
-                               "The file UUID {} refers to a file that is too large to process".format(uuid))
+            raise DSSException(
+                requests.codes.unprocessable_entity,
+                "invalid_link",
+                "The file UUID {} refers to a file that is too large to process".format(uuid))
         return json.loads(blobstore_handle.get(
             replica.bucket,
             "{}s/{}.{}".format(entity_type, uuid, version)))
     except BlobNotFoundError as ex:
-        raise DSSException(404, "invalid_link", "Could not find file for UUID {}".format(uuid))
+        raise DSSException(
+            requests.codes.unprocessable_entity,
+            "invalid_link",
+            "Could not find file for UUID {}".format(uuid))
 
 def resolve_content_item(replica: Replica, blobstore_handle: BlobStore, item: dict):
     try:
@@ -177,7 +182,7 @@ def resolve_content_item(replica: Replica, blobstore_handle: BlobStore, item: di
         raise
     except Exception as e:
         raise DSSException(
-            422,
+            requests.codes.unprocessable_entity,
             "invalid_link",
             'Error while parsing the link "{}": {}: {}'.format(item, type(e).__name__, e)
         )


### PR DESCRIPTION
1. Explode all the various errors so they're tied to their own response codes.
2. Add illegal_arguments to the default error.  This is REQUIRED for every endpoint's default error handler, because when swagger validates the parameters and fails, it returns this code.
