### PR TITLE
Checkout from GitHub with token for releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,8 +85,8 @@ integration_test:
 release_integration:
   stage: release_integration
   script:
-    - git clean -df
-    - git reset --hard
+    - git clone https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git ~/release && cd ~/release
+    - git checkout integration
     - for i in $(seq 1 40); do
     -   status=$(scripts/status.sh HumanCellAtlas dcp integration)
     -   if [[ pending != "${status}" && running != "${status}" ]]; then break; fi
@@ -110,8 +110,8 @@ release_integration:
 force_release_integration:
   stage: release_integration
   script:
-    - git clean -df
-    - git reset --hard
+    - git clone https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git ~/release && cd ~/release
+    - git checkout integration
     - scripts/fetch_secret.sh gcp-credentials.json > gcp-credentials.json
     - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
     - make plan-infra
@@ -126,8 +126,8 @@ force_release_integration:
 release_staging:
   stage: release_staging
   script:
-    - git clean -df
-    - git reset --hard
+    - git clone https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git ~/release && cd ~/release
+    - git checkout staging
     - for i in $(seq 1 40); do
     -   status=$(scripts/status.sh HumanCellAtlas dcp integration)
     -   if [[ pending != "${status}" && running != "${status}" ]]; then break; fi
@@ -152,8 +152,8 @@ release_staging:
 force_release_staging:
   stage: release_staging
   script:
-    - git clean -df
-    - git reset --hard
+    - git clone https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git ~/release && cd ~/release
+    - git checkout staging
     - scripts/fetch_secret.sh gcp-credentials.json > gcp-credentials.json
     - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
     - make plan-infra


### PR DESCRIPTION
For release builds, explicitly clone the repo from GitHub using an access token.

This fixes a bug where release pushes were attempted on the cloned repo in the build box, which failed.

Tested by successfully pushing a test tag to GitHub.