### PR TITLE
[Easy] Don't mark job as failed when not releasing to integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,6 +106,7 @@ release_integration:
     url: https://dss.integration.data.humancellatlas.org
   only:
     - master
+  allow_failure: true
 
 force_release_integration:
   stage: release_integration


### PR DESCRIPTION
This allows pipelines that pass all tests and deploy succesfully to `dev` to be marked as passed even if they fail to release to the `integration` stage.

This:
<img width="593" alt="aaa" src="https://user-images.githubusercontent.com/32105697/44241043-4f183700-a176-11e8-8c8c-fc2243cc8688.png">

Will look more like this (note the orange shade):
<img width="523" alt="bbb" src="https://user-images.githubusercontent.com/32105697/44241048-55a6ae80-a176-11e8-80cb-b5a7e1156b18.png">

