### PR TITLE
Update fixture for tests/test_api.py

### DIFF
--- a/tests/fixtures/populate_lib.py
+++ b/tests/fixtures/populate_lib.py
@@ -101,13 +101,6 @@ def upload(uploader: Uploader):
         "testList/delimiter/test"
     )
 
-    for fname in ["assay.json", "cell.json", "manifest.json", "project.json", "sample.json"]:
-        uploader.checksum_and_upload_file(
-            f"test_api/{fname}",
-            f"fixtures/test_api/bundle/{fname}",
-            "application/json",
-        )
-
     # Create sample stored bundles with tombstones to test the filtering of deleted bundles
     source_path = "tombstones"
     for fname in [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,7 +37,7 @@ class TestApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin, DSSStorageMixin
         self.blobstore = dss.Config.get_blobstore_handle(self.replica)
         self.bucket = self.replica.bucket
 
-    BUNDLE_FIXTURE = 'fixtures/test_api/bundle'
+    BUNDLE_FIXTURE = "fixtures/indexing/bundles/vx/smartseq2/paired_ends"
 
     @testmode.standalone
     def test_creation_and_retrieval_of_files_and_bundle(self):


### PR DESCRIPTION
tests/test_api.py doesn't need  it's own (old) fixture.