### PR TITLE
Optimize get_file to run synchronously when possible

### DIFF
--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -1,4 +1,7 @@
+import datetime
 import json
+import logging
+import os
 import re
 import time
 import typing
@@ -28,6 +31,8 @@ ASYNC_COPY_THRESHOLD = AWS_MIN_CHUNK_SIZE
 """The retry-after interval in seconds. Sets up downstream libraries / users to
 retry request after the specified interval."""
 RETRY_AFTER_INTERVAL = 10
+
+logger = logging.getLogger(__name__)
 
 
 @dss_handler
@@ -74,7 +79,6 @@ def get_helper(uuid: str, replica: Replica, version: str=None, token: str=None):
 
     if request.method == "GET":
         token, ready = _verify_checkout(replica, token, file_metadata, blob_path)
-
         if ready:
             response = redirect(handle.generate_presigned_GET_url(
                 replica.checkout_bucket,
@@ -108,6 +112,25 @@ def get_helper(uuid: str, replica: Replica, version: str=None, token: str=None):
 def _verify_checkout(
         replica: Replica, token: typing.Optional[str], file_metadata: dict, blob_path: str,
 ) -> typing.Tuple[str, bool]:
+    try:
+        cloud_handle = Config.get_blobstore_handle(replica)
+        hca_handle = Config.get_hcablobstore_handle(replica)
+        file_key = get_dst_key(blob_path)
+        last_modified = cloud_handle.get_last_modified_date(replica.checkout_bucket, file_key)
+        stale_before_date = (datetime.datetime.now(datetime.timezone.utc) -
+                             datetime.timedelta(days=int(os.environ['DSS_BLOB_PUBLIC_TTL_DAYS'])))
+
+        if last_modified > stale_before_date:
+            if hca_handle.verify_blob_checksum_from_dss_metadata(replica.checkout_bucket,
+                                                                 file_key,
+                                                                 file_metadata):
+                return "", True
+            else:
+                logger.error(
+                    f"Checksum verification failed for file {replica.checkout_bucket}/{file_key}")
+    except BlobNotFoundError:
+        pass
+
     decoded_token: dict
     if token is None:
         execution_id = start_file_checkout(replica, blob_path)
@@ -126,15 +149,7 @@ def _verify_checkout(
         except (KeyError, ValueError) as ex:
             raise DSSException(requests.codes.bad_request, "illegal_token", "Could not understand token", ex)
 
-    hcablobstore = Config.get_hcablobstore_handle(replica)
     encoded_token = json.dumps(decoded_token)
-    try:
-        if hcablobstore.verify_blob_checksum_from_dss_metadata(
-                replica.checkout_bucket, get_dst_key(blob_path), file_metadata):
-            return encoded_token, True
-    except BlobNotFoundError:
-        pass
-
     return encoded_token, False
 
 

--- a/dss/stepfunctions/visitation/index.py
+++ b/dss/stepfunctions/visitation/index.py
@@ -75,7 +75,7 @@ class IndexVisitation(Visitation):
                                               start_after_key=self.marker,
                                               token=self.token)
 
-            for key in blobs:
+            for key, metadata in blobs:
                 # Timing out while recording paging info could cause an inconsistent paging state, leading to repeats
                 # of large amounts of work. This can be avoided by checking for timeouts only during actual
                 # re-indexing. The indexer performs this check for every item.

--- a/dss/stepfunctions/visitation/integration_test.py
+++ b/dss/stepfunctions/visitation/integration_test.py
@@ -66,7 +66,7 @@ class IntegrationTest(Visitation):  # no coverage (this code *is* run by tests, 
             token=self.token  # type: ignore  # Cannot determine type of 'token'
         )
 
-        for key in blobs:
+        for key, metadata in blobs:
             if 250 < time() - start_time:
                 break
             self.process_item(key)

--- a/dss/stepfunctions/visitation/storage.py
+++ b/dss/stepfunctions/visitation/storage.py
@@ -78,7 +78,7 @@ class StorageVisitation(Visitation):
                                                start_after_key=key)
             columns.append(column)
 
-        diff = zipalign(columns=map(iter, columns), row=self.row)
+        diff = zipalign(columns=((key for key, metadata in column) for column in columns), row=self.row)
         while self.shutdown_time < self.remaining_runtime():
             try:
                 row = next(diff)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ chalice==1.6.0
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.1.5
+cloud-blobstore==3.0.0
 colorama==0.3.9
 connexion==1.5.2
 coverage==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cffi==1.11.5
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==2.1.5
+cloud-blobstore==3.0.0
 connexion==1.5.2
 crcmod==1.7
 cryptography==2.3.1

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -2,7 +2,7 @@
 azure-storage >= 0.36.0
 boto3 >= 1.6.0
 botocore >= 1.10.16  # 1.9.x does not support AWS secretsmanager support
-cloud-blobstore >= 2.1.5
+cloud-blobstore >= 3.0.0
 connexion >= 1.1.15
 dcplib>=1.3.2
 elasticsearch >= 5.4.0, < 6.0.0

--- a/tests/test_visitation.py
+++ b/tests/test_visitation.py
@@ -209,7 +209,7 @@ class FakeBlobStore:
         def __iter__(self):
             for key in self.keys:
                 self.start_after_key = key
-                yield self.start_after_key
+                yield (self.start_after_key, {})
 
     def list_v2(self, *args, **kwargs):
         return self.Iterator()
@@ -402,7 +402,7 @@ class TestConsistencyVisitation(unittest.TestCase):
                     # Once per listing, wait a little to trigger the walker timeout
                     if not self.resumed and i == len(resp) // 2:
                         time.sleep(test.timeout * 1.25)
-                    yield key
+                    yield (key, {})
 
             def get_next_token_from_response(self, resp):
                 return resp[-1] if resp else None


### PR DESCRIPTION
These changes enable `get_file` (file GETs) to immediately return the location of the file if it has already been checked out with the conditions:
- the file has not "expired"
- the checksum of the checkout file matches the original (existing logic)

Expiration is defined by `request_time - advertised_ttl` (i.e. earliest acceptable last modified date) such that we ensure the file we serve is preserved in checkout for the time that we advertise to the user.

### Test plan
Tested:
- manual testing via local DSS API server
- added integration test

Will test:
- Hit get_file unchecked-out files, checked-out files that are either stale or valid, and observe expected behaviors

Must be merged after https://github.com/HumanCellAtlas/data-store/pull/1515
Related to #1347