### PR TITLE
Optimize get_bundle to only perform checkout when necessary

### DIFF
--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import json
 import typing
 
@@ -8,6 +9,7 @@ from dss.storage.identifiers import DSS_BUNDLE_KEY_REGEX, DSS_BUNDLE_TOMBSTONE_R
 from dss.storage.blobstore import test_object_exists
 
 
+@lru_cache(maxsize=32)
 def get_bundle_manifest(
         uuid: str,
         replica: Replica,

--- a/dss/storage/checkout/bundle.py
+++ b/dss/storage/checkout/bundle.py
@@ -1,11 +1,14 @@
 """
 This is the module for bundle checkouts.
 """
+import datetime
 import io
 import json
+import os
 import time
 import typing
 
+from cloud_blobstore import BlobMetadataField
 from dss import stepfunctions
 from dss.config import Replica, Config
 from dss.stepfunctions.checkout.constants import EventConstants, STATE_MACHINE_NAME_TEMPLATE
@@ -71,6 +74,21 @@ def verify_checkout(
         bundle_version: typing.Optional[str],
         token: typing.Optional[str]
 ) -> typing.Tuple[str, bool]:
+
+    handle = Config.get_blobstore_handle(replica)
+    prefix = get_dst_bundle_prefix(bundle_uuid, bundle_version)
+    bundle_metadata = get_bundle_manifest(bundle_uuid, replica, bundle_version)
+
+    expected_files = [prefix + '/' + file['name'] for file in bundle_metadata['files']]
+    blobs_in_checkout = list(handle.list_v2(replica.checkout_bucket, prefix))
+    stale_before_date = (datetime.datetime.now(datetime.timezone.utc) -
+                         datetime.timedelta(days=int(os.environ['DSS_BLOB_PUBLIC_TTL_DAYS'])))
+
+    if (all((key in expected_files) and
+            (blob[BlobMetadataField.LAST_MODIFIED] > stale_before_date) for key, blob in blobs_in_checkout) and
+            len(blobs_in_checkout) == len(expected_files)):
+        return "", True
+
     decoded_token: dict
     if token is None:
         execution_id = start_bundle_checkout(replica, bundle_uuid, bundle_version, dst_bucket=replica.checkout_bucket)


### PR DESCRIPTION
These changes update bundle GETs (`get_bundle`) to only perform a checkout in the following cases:
- if any file in the bundle has become [stale](https://github.com/HumanCellAtlas/data-store/pull/1516)
- if any file in the checkout bundle is not listed in the bundle manifest
- if the number of files in the checkout bundle does not match the number of files in the bundle manifest

### Test plan
- Manual testing on dev DSS
- Added integration test

### Release notes
Upgraded dependency: [`cloud-blobstore` >= 3.0.0](https://github.com/chanzuckerberg/cloud-blobstore/pull/21)

Should be merged after https://github.com/HumanCellAtlas/data-store/pull/1516
Fixes #1347 
