### PR TITLE
[Easy] Release to integration requires manual action.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,6 +106,7 @@ release_integration:
     url: https://dss.integration.data.humancellatlas.org
   only:
     - master
+  when: manual 
   allow_failure: true
 
 force_release_integration:


### PR DESCRIPTION
Since dcp-wide integration has been blocked for a long time, require manual action to integration. This can be turned on again when things stabilize.
