### PR TITLE
Add `--no-deploy` flag to scripts/release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,32 @@ source "$(dirname $0)/../environment"
 
 set -euo pipefail
 
-if [[ $# != 2 ]] && [[ $# != 3 ]]; then
+# This block discovers the command line flags `--force` and  `--no-deploy`,
+# and passes on positional arguments as $1, $2, etc.
+FORCE=
+NO_DEPLOY=
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --force)
+    FORCE="--force"
+    shift
+    ;;
+    --no-deploy)
+    NO_DEPLOY="--no-deploy"
+    shift
+    ;;
+    *)
+    POSITIONAL+=("$1")
+    shift
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [[ $# != 2 ]]; then
     echo "Given a source (pre-release) branch and a destination (release) branch,"
     echo "this script checks the continuous integration status of the source branch,"
     echo "creates a Git tag, resets the head of the destination branch to the head"
@@ -15,7 +40,9 @@ if [[ $# != 2 ]] && [[ $# != 3 ]]; then
     echo
     echo "If the --force flag is given, deployment will proceed even if CI checks fail."
     echo
-    echo "Usage: $(basename $0) source_branch dest_branch [--force]"
+    echo "If the --no-deploy flag is given, the deployment step will be skipped."
+    echo
+    echo "Usage: $(basename $0) source_branch dest_branch [--force] [--no-deploy]"
     echo "Example: $(basename $0) master staging"
     exit 1
 fi
@@ -30,7 +57,7 @@ select result in Yes No; do
 done
 
 if ! git diff-index --quiet HEAD --; then
-    if [[ $# == 3 ]] && [[ $3 == "--force" ]]; then
+    if [[ $# == 3 ]] && [[ $FORCE == "--force" ]]; then
         echo "You have uncommitted files in your Git repository. Forcing deployment anyway."
     else
         echo "You have uncommitted files in your Git repository. Please commit or stash them, or run $0 with --force."
@@ -46,7 +73,7 @@ if ! [[ -e "$DSS_HOME/application_secrets.json" ]]; then
 fi
 
 if ! diff <(pip freeze) <(tail -n +2 "$DSS_HOME/requirements-dev.txt"); then
-    if [[ $# == 3 ]] && [[ $3 == "--force" ]]; then
+    if [[ $# == 3 ]] && [[ $FORCE == "--force" ]]; then
         echo "Your installed Python packages differ from requirements-dev.txt. Forcing deployment anyway."
     else
         echo "Your installed Python packages differ from requirements-dev.txt. Please update your virtualenv."
@@ -67,7 +94,7 @@ if [[ "hca_cicd" != $(whoami) ]]; then
     
     # TODO: (akislyuk) some CI builds no longer deploy or run a subset of tests. Find the last build that ran a deployment.
     if [[ "$STATE" != success ]]; then
-        if [[ $# == 3 ]] && [[ $3 == "--force" ]]; then
+        if [[ $# == 3 ]] && [[ $FORCE == "--force" ]]; then
             echo "Status checks failed on branch $PROMOTE_FROM_BRANCH. Forcing promotion and deployment anyway."
         else
             echo "Status checks failed on branch $PROMOTE_FROM_BRANCH."
@@ -82,7 +109,7 @@ RELEASE_TAG=${PROMOTE_DEST_BRANCH}-$(date -u +"%Y-%m-%d-%H-%M-%S").release
 if [[ "$(git --no-pager log --graph --abbrev-commit --pretty=oneline --no-merges $PROMOTE_DEST_BRANCH ^$PROMOTE_FROM_BRANCH)" != "" ]]; then
     echo "Warning: The following commits are present on $PROMOTE_DEST_BRANCH but not on $PROMOTE_FROM_BRANCH"
     git --no-pager log --graph --abbrev-commit --pretty=oneline --no-merges $PROMOTE_DEST_BRANCH ^$PROMOTE_FROM_BRANCH
-    if [[ $# == 3 ]] && [[ $3 == "--force" ]]; then
+    if [[ $# == 3 ]] && [[ $FORCE == "--force" ]]; then
         echo -e "\nThey will be overwritten on $PROMOTE_DEST_BRANCH and discarded."
     else
         echo -e "\nRun with --force to overwrite and discard these commits from $PROMOTE_DEST_BRANCH."
@@ -102,7 +129,9 @@ git tag $RELEASE_TAG
 git push --force origin $PROMOTE_DEST_BRANCH
 git push --tags
 
-if yq -e '.stages[]
+if [[ $NO_DEPLOY == "--no-deploy" ]]; then
+    echo "The --no-deploy flag is set. Skipping deployment."
+elif yq -e '.stages[]
           | select(.name == "deploy")
           | .if
           | splits("\\s+AND\\s+")


### PR DESCRIPTION
When running `scripts/release.sh`, skip deployment  step if `--no-deploy` flag is set.

Connects to #692