### PR TITLE
directaccess and presignedurl should go to the checkout bucket

### DIFF
--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -12,13 +12,15 @@ from dss.storage.checkout.bundle import get_bundle_checkout_status, start_bundle
 def post(uuid: str, json_request_body: dict, replica: str, version: str=None):
 
     assert replica is not None
+    _replica: Replica = Replica[replica]
+    dst_bucket = json_request_body.get('destination', _replica.checkout_bucket)
 
     try:
         execution_id = start_bundle_checkout(
-            Replica[replica],
+            _replica,
             uuid,
             version,
-            dst_bucket=json_request_body.get('destination', None),
+            dst_bucket=dst_bucket,
             email_address=json_request_body.get('email', None),
         )
     except BundleNotFoundError:

--- a/dss/storage/checkout/bundle.py
+++ b/dss/storage/checkout/bundle.py
@@ -19,19 +19,19 @@ def start_bundle_checkout(
         replica: Replica,
         bundle_uuid: str,
         bundle_version: typing.Optional[str],
-        dst_bucket: typing.Optional[str] = None,
-        email_address: typing.Optional[str] = None,
+        dst_bucket: str,
+        email_address: typing.Optional[str]=None,
         *,
-        sts_bucket: typing.Optional[str] = None,
+        sts_bucket: typing.Optional[str]=None,
 ) -> str:
     """
     Starts a bundle checkout.
 
     :param bundle_uuid: The UUID of the bundle to check out.
-    :param bundle_version: The version of the bundle to check out.
+    :param bundle_version: The version of the bundle to check out.  If this is not provided, the latest version of the
+                           bundle is checked out.
     :param replica: The replica to execute the checkout in.
-    :param dst_bucket: If provided, check out to this bucket.  If not provided, check out to the default checkout bucket
-                       for the replica.
+    :param dst_bucket: Check out to this bucket.
     :param email_address: If provided, send a message to this email address with the status of the checkout.
     :param sts_bucket: If provided, write the status of the checkout to this bucket.  If not provided, write the status
                        to the default checkout bucket for the replica.
@@ -68,12 +68,12 @@ def start_bundle_checkout(
 def verify_checkout(
         replica: Replica,
         bundle_uuid: str,
-        bundle_version: str,
+        bundle_version: typing.Optional[str],
         token: typing.Optional[str]
 ) -> typing.Tuple[str, bool]:
     decoded_token: dict
     if token is None:
-        execution_id = start_bundle_checkout(replica, bundle_uuid, bundle_version)
+        execution_id = start_bundle_checkout(replica, bundle_uuid, bundle_version, dst_bucket=replica.checkout_bucket)
 
         decoded_token = {
             CheckoutTokenKeys.EXECUTION_ID: execution_id,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -85,24 +85,26 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
     @testmode.integration
     def test_bundle_get_directaccess(self):
-        self._test_bundle_get_directaccess(Replica.aws)
-        self._test_bundle_get_directaccess(Replica.gcp)
+        self._test_bundle_get_directaccess(Replica.aws, True)
+        self._test_bundle_get_directaccess(Replica.aws, False)
+        self._test_bundle_get_directaccess(Replica.gcp, True)
+        self._test_bundle_get_directaccess(Replica.gcp, False)
 
-    def _test_bundle_get_directaccess(self, replica: Replica):
+    def _test_bundle_get_directaccess(self, replica: Replica, explicit_version: bool):
         schema = replica.storage_schema
 
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
 
-        url = str(UrlBuilder()
-                  .set(path="/v1/bundles/" + bundle_uuid)
-                  .add_query("replica", replica.name)
-                  .add_query("version", version)
-                  .add_query("directurls", "true"))
+        url = UrlBuilder().set(path="/v1/bundles/" + bundle_uuid)
+        url.add_query("replica", replica.name)
+        url.add_query("directurls", "true")
+        if explicit_version:
+            url.add_query("version", version)
 
         with override_bucket_config(BucketConfig.TEST_FIXTURE):
             resp_obj = self.assertGetResponse(
-                url,
+                str(url),
                 requests.codes.ok,
                 redirect_follow_retries=BUNDLE_GET_RETRY_COUNT,
                 min_retry_interval_header=RETRY_AFTER_INTERVAL,
@@ -126,22 +128,24 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
     @testmode.integration
     def test_bundle_get_presigned(self):
-        self._test_bundle_get_presigned(Replica.aws)
-        self._test_bundle_get_presigned(Replica.gcp)
+        self._test_bundle_get_presigned(Replica.aws, True)
+        self._test_bundle_get_presigned(Replica.aws, False)
+        self._test_bundle_get_presigned(Replica.gcp, True)
+        self._test_bundle_get_presigned(Replica.gcp, False)
 
-    def _test_bundle_get_presigned(self, replica: Replica):
+    def _test_bundle_get_presigned(self, replica: Replica, explicit_version: bool):
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
 
-        url = str(UrlBuilder()
-                  .set(path="/v1/bundles/" + bundle_uuid)
-                  .add_query("replica", replica.name)
-                  .add_query("version", version)
-                  .add_query("presignedurls", "true"))
+        url = UrlBuilder().set(path="/v1/bundles/" + bundle_uuid)
+        url.add_query("replica", replica.name)
+        url.add_query("presignedurls", "true")
+        if explicit_version:
+            url.add_query("version", version)
 
         with override_bucket_config(BucketConfig.TEST_FIXTURE):
             resp_obj = self.assertGetResponse(
-                url,
+                str(url),
                 requests.codes.ok,
                 redirect_follow_retries=BUNDLE_GET_RETRY_COUNT,
                 min_retry_interval_header=RETRY_AFTER_INTERVAL,


### PR DESCRIPTION
1. `dss/api/bundles/__init__.py`: changes to which bucket we point to after the checkout succeeds.  Note that the keys are different.
2. Make the dst replica explicit.  Right now, the state machine is not aware of overrides done in tests.
3. Small change #1 that I'm sneaking in: `bundle_version` is actually possibly None.
4. Small change #2 that I'm sneaking in: fix styling around default parameter values.

Test plan: `DSS_TEST_MODE="standalone integration" make -j tests/test_checkout.py tests/test_file.py tests/test_bundle.py tests/test_api.py`