### PR TITLE
Give GCP service account read access.

### DIFF
--- a/infra/gcp_service_account/main.tf
+++ b/infra/gcp_service_account/main.tf
@@ -37,3 +37,9 @@ resource "google_project_iam_member" "cloudfunctionsdeveloper" {
   role    = "roles/cloudfunctions.developer"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
+
+resource "google_project_iam_member" "cloudfunctionsdeveloper" {
+  project = "${data.google_project.project.project_id}"
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.dss.email}"
+}

--- a/infra/gcp_service_account/main.tf
+++ b/infra/gcp_service_account/main.tf
@@ -38,7 +38,7 @@ resource "google_project_iam_member" "cloudfunctionsdeveloper" {
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
-resource "google_project_iam_member" "cloudfunctionsdeveloper" {
+resource "google_project_iam_member" "viewer" {
   project = "${data.google_project.project.project_id}"
   role    = "roles/viewer"
   member  = "serviceAccount:${google_service_account.dss.email}"


### PR DESCRIPTION
This is needed to for `terraform plan` to succeed on GCP infra.