### PR TITLE
Timeout fixes for dss tests

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -50,10 +50,6 @@ This is how quickly API Gateway gives up on Lambda.  This allows us to terminate
 timeout than API Gateway.
 """
 
-OVERRIDE_EXECUTION_LIMIT_SECONDS = None
-"""
-This is how long we wait for a request, if set.  If the value is None, we try to use the lambda's timeout.
-"""
 DSS_VERSION = os.getenv('DSS_VERSION')
 """
 Tag describing the version of the currently deployed DSS codebase.  Generated during deployment in the form:
@@ -64,7 +60,7 @@ Tag describing the version of the currently deployed DSS codebase.  Generated du
 class DSSChaliceApp(chalice.Chalice):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._override_exptime_seconds = OVERRIDE_EXECUTION_LIMIT_SECONDS
+        self._override_exptime_seconds = None
 
 
 def timeout_response() -> chalice.Response:

--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -12,13 +12,15 @@ from dss.storage.checkout.bundle import get_bundle_checkout_status, start_bundle
 def post(uuid: str, json_request_body: dict, replica: str, version: str=None):
 
     assert replica is not None
+    _replica: Replica = Replica[replica]
+    dst_bucket = json_request_body.get('destination', _replica.checkout_bucket)
 
     try:
         execution_id = start_bundle_checkout(
-            Replica[replica],
+            _replica,
             uuid,
             version,
-            dst_bucket=json_request_body.get('destination', None),
+            dst_bucket=dst_bucket,
             email_address=json_request_body.get('email', None),
         )
     except BundleNotFoundError:

--- a/dss/index/indexer.py
+++ b/dss/index/indexer.py
@@ -6,7 +6,8 @@ from urllib.parse import unquote
 from abc import ABCMeta, abstractmethod
 
 from dss import Config, Replica
-from dss.storage.identifiers import BundleFQID, FileFQID, ObjectIdentifier, ObjectIdentifierError, BundleTombstoneID
+from dss.storage.identifiers import BundleFQID, FileFQID, ObjectIdentifier, ObjectIdentifierError, BundleTombstoneID, \
+    CollectionFQID, CollectionTombstoneID
 from dss.util.time import RemainingTime
 from .backend import IndexBackend
 from .bundle import Bundle, Tombstone
@@ -47,6 +48,9 @@ class Indexer(metaclass=ABCMeta):
         elif isinstance(identifier, FileFQID):
             logger.debug(f"Indexing of individual files is not supported. "
                          f"Ignoring file {identifier} in {self.replica.name}.")
+        elif isinstance(identifier, (CollectionFQID, CollectionTombstoneID)):
+            logger.debug(f"Indexing of collections is not supported. "
+                         f"Ignoring collection {identifier} in {self.replica.name}.")
         else:
             assert False, f"{identifier} is of unknown type"
 

--- a/dss/storage/checkout/bundle.py
+++ b/dss/storage/checkout/bundle.py
@@ -19,19 +19,19 @@ def start_bundle_checkout(
         replica: Replica,
         bundle_uuid: str,
         bundle_version: typing.Optional[str],
-        dst_bucket: typing.Optional[str] = None,
-        email_address: typing.Optional[str] = None,
+        dst_bucket: str,
+        email_address: typing.Optional[str]=None,
         *,
-        sts_bucket: typing.Optional[str] = None,
+        sts_bucket: typing.Optional[str]=None,
 ) -> str:
     """
     Starts a bundle checkout.
 
     :param bundle_uuid: The UUID of the bundle to check out.
-    :param bundle_version: The version of the bundle to check out.
+    :param bundle_version: The version of the bundle to check out.  If this is not provided, the latest version of the
+                           bundle is checked out.
     :param replica: The replica to execute the checkout in.
-    :param dst_bucket: If provided, check out to this bucket.  If not provided, check out to the default checkout bucket
-                       for the replica.
+    :param dst_bucket: Check out to this bucket.
     :param email_address: If provided, send a message to this email address with the status of the checkout.
     :param sts_bucket: If provided, write the status of the checkout to this bucket.  If not provided, write the status
                        to the default checkout bucket for the replica.
@@ -68,12 +68,12 @@ def start_bundle_checkout(
 def verify_checkout(
         replica: Replica,
         bundle_uuid: str,
-        bundle_version: str,
+        bundle_version: typing.Optional[str],
         token: typing.Optional[str]
 ) -> typing.Tuple[str, bool]:
     decoded_token: dict
     if token is None:
-        execution_id = start_bundle_checkout(replica, bundle_uuid, bundle_version)
+        execution_id = start_bundle_checkout(replica, bundle_uuid, bundle_version, dst_bucket=replica.checkout_bucket)
 
         decoded_token = {
             CheckoutTokenKeys.EXECUTION_ID: execution_id,

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -44,7 +44,7 @@ class ThreadedLocalServer(threading.Thread):
         project_dir = os.path.join(os.path.dirname(__file__), "..", "..", "chalice")
         factory = CLIFactory(project_dir=project_dir)
         self._chalice_app = factory.load_chalice_app()
-        self._chalice_app._override_exptime_seconds = 86400  # something large.  sys.maxsize causes chalice to flip.
+        self._chalice_app._override_exptime_seconds = 30  # something large.  sys.maxsize causes chalice to flip.
 
         config = chalice.config.Config.create(lambda_timeout=self._chalice_app._override_exptime_seconds)
 
@@ -56,7 +56,7 @@ class ThreadedLocalServer(threading.Thread):
         return method(
             f"http://127.0.0.1:{self._port}{path}",
             allow_redirects=False,
-            timeout=(1.0, 30.0),
+            timeout=(1.0, 35.0),
             **kwargs)
 
     @classmethod

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -85,24 +85,26 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
     @testmode.integration
     def test_bundle_get_directaccess(self):
-        self._test_bundle_get_directaccess(Replica.aws)
-        self._test_bundle_get_directaccess(Replica.gcp)
+        self._test_bundle_get_directaccess(Replica.aws, True)
+        self._test_bundle_get_directaccess(Replica.aws, False)
+        self._test_bundle_get_directaccess(Replica.gcp, True)
+        self._test_bundle_get_directaccess(Replica.gcp, False)
 
-    def _test_bundle_get_directaccess(self, replica: Replica):
+    def _test_bundle_get_directaccess(self, replica: Replica, explicit_version: bool):
         schema = replica.storage_schema
 
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
 
-        url = str(UrlBuilder()
-                  .set(path="/v1/bundles/" + bundle_uuid)
-                  .add_query("replica", replica.name)
-                  .add_query("version", version)
-                  .add_query("directurls", "true"))
+        url = UrlBuilder().set(path="/v1/bundles/" + bundle_uuid)
+        url.add_query("replica", replica.name)
+        url.add_query("directurls", "true")
+        if explicit_version:
+            url.add_query("version", version)
 
         with override_bucket_config(BucketConfig.TEST_FIXTURE):
             resp_obj = self.assertGetResponse(
-                url,
+                str(url),
                 requests.codes.ok,
                 redirect_follow_retries=BUNDLE_GET_RETRY_COUNT,
                 min_retry_interval_header=RETRY_AFTER_INTERVAL,
@@ -126,22 +128,24 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
 
     @testmode.integration
     def test_bundle_get_presigned(self):
-        self._test_bundle_get_presigned(Replica.aws)
-        self._test_bundle_get_presigned(Replica.gcp)
+        self._test_bundle_get_presigned(Replica.aws, True)
+        self._test_bundle_get_presigned(Replica.aws, False)
+        self._test_bundle_get_presigned(Replica.gcp, True)
+        self._test_bundle_get_presigned(Replica.gcp, False)
 
-    def _test_bundle_get_presigned(self, replica: Replica):
+    def _test_bundle_get_presigned(self, replica: Replica, explicit_version: bool):
         bundle_uuid = "011c7340-9b3c-4d62-bf49-090d79daf198"
         version = "2017-06-20T214506.766634Z"
 
-        url = str(UrlBuilder()
-                  .set(path="/v1/bundles/" + bundle_uuid)
-                  .add_query("replica", replica.name)
-                  .add_query("version", version)
-                  .add_query("presignedurls", "true"))
+        url = UrlBuilder().set(path="/v1/bundles/" + bundle_uuid)
+        url.add_query("replica", replica.name)
+        url.add_query("presignedurls", "true")
+        if explicit_version:
+            url.add_query("version", version)
 
         with override_bucket_config(BucketConfig.TEST_FIXTURE):
             resp_obj = self.assertGetResponse(
-                url,
+                str(url),
                 requests.codes.ok,
                 redirect_follow_retries=BUNDLE_GET_RETRY_COUNT,
                 min_retry_interval_header=RETRY_AFTER_INTERVAL,


### PR DESCRIPTION
1. Remove the time_left hack for the missing file test.  This does cut about 30s from test time, but is not consistent with how it works in production.
2. Reduce the server time allowed by chalice to 30 sec to match production.
3. Change the time the client waits to 35 seconds (it must be longer than the server execution time).
4. Remove OVERRIDE_EXECUTION_LIMIT_SECONDS, which is not really doing much.