### PR TITLE
No-op fixes

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -50,10 +50,6 @@ This is how quickly API Gateway gives up on Lambda.  This allows us to terminate
 timeout than API Gateway.
 """
 
-OVERRIDE_EXECUTION_LIMIT_SECONDS = None
-"""
-This is how long we wait for a request, if set.  If the value is None, we try to use the lambda's timeout.
-"""
 DSS_VERSION = os.getenv('DSS_VERSION')
 """
 Tag describing the version of the currently deployed DSS codebase.  Generated during deployment in the form:
@@ -64,7 +60,7 @@ Tag describing the version of the currently deployed DSS codebase.  Generated du
 class DSSChaliceApp(chalice.Chalice):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._override_exptime_seconds = OVERRIDE_EXECUTION_LIMIT_SECONDS
+        self._override_exptime_seconds = None
 
 
 def timeout_response() -> chalice.Response:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -115,8 +115,8 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                     override_retry_interval=1,
                 )
 
-            url = resp_obj.json['bundle']['files'][0]['url']
-            splitted = urllib.parse.urlparse(url)  # type: ignore
+            directaccess_url = resp_obj.json['bundle']['files'][0]['url']
+            splitted = urllib.parse.urlparse(directaccess_url)
             self.assertEqual(splitted.scheme, schema)
             bucket = splitted.netloc
             key = splitted.path[1:]  # ignore the / part of the path.
@@ -156,8 +156,8 @@ class TestBundleApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                     override_retry_interval=1,
                 )
 
-            url = resp_obj.json['bundle']['files'][0]['url']
-            resp = requests.get(str(url))
+            presigned_url = resp_obj.json['bundle']['files'][0]['url']
+            resp = requests.get(presigned_url)
             contents = resp.content
 
             hasher = hashlib.sha1()


### PR DESCRIPTION
1. Remove OVERRIDE_EXECUTION_LIMIT_SECONDS, which is not really doing much.
2. mypy fixes for `url`.  url is defined above, and mypy retains the typing of the first instance of a variable.

This is split out of #1552, which was more controversial than expected.

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. Uncomment below:
### Test plan -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
