### PR TITLE
More GitLab CI release bugfixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@ before_script:
   - if not [[ CI_COMMIT_SHA == $(http GET ${GITHUB_API}/repos/HumanCellAtlas/data-store/commits sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
 # TODO: figure out how to get the gitlab-runner to not clone the repo as root - Brian H
   - cp -r /HumanCellAtlas/data-store ~/data-store && cd ~/data-store
+  - git reset --hard HEAD
   - virtualenv ~/venv
   - source ~/venv/bin/activate
   - pip install -r requirements-dev.txt
@@ -104,6 +105,7 @@ integration_test:
 release_integration:
   stage: release
   script:
+    - git remote set-url origin https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git
     - for i in $(seq 1 40); do
     -   status=$(scripts/status.sh HumanCellAtlas dcp integration)
     -   if [[ pending != "${status}" && running != "${status}" ]]; then break; fi
@@ -114,7 +116,7 @@ release_integration:
     -   echo "DCP Integration test returned status ${status}";
     -   exit 1
     - fi
-    - yes 1 | scripts/release.sh master integration --no-deploy
+    - scripts/release.sh master integration --no-deploy --skip-github-status --skip-account-verification
   only:
     - master
   when: manual
@@ -123,7 +125,8 @@ release_integration:
 force_release_integration:
   stage: release
   script:
-    - yes 1 | scripts/release.sh master integration --force --no-deploy
+    - git remote set-url origin https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git
+    - scripts/release.sh master integration --force --no-deploy --skip-github-status --skip-account-verification
   only:
     - master
   when: manual
@@ -131,6 +134,7 @@ force_release_integration:
 release_staging:
   stage: release
   script:
+    - git remote set-url origin https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git
     - for i in $(seq 1 40); do
     -   status=$(scripts/status.sh HumanCellAtlas dcp staging)
     -   if [[ pending != "${status}" && running != "${status}" ]]; then break; fi
@@ -141,7 +145,7 @@ release_staging:
     -   echo "DCP Integration test returned status ${status}";
     -   exit 1
     - fi
-    - yes 1 | scripts/release.sh integration staging --no-deploy
+    - scripts/release.sh integration staging --no-deploy --skip-github-status --skip-account-verification
   only:
     - integration
   when: manual 
@@ -149,7 +153,8 @@ release_staging:
 force_release_staging:
   stage: release
   script:
-    - yes 1 | scripts/release.sh integration staging --force --no-deploy
+    - git remote set-url origin https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git
+    - scripts/release.sh integration staging --force --no-deploy --skip-github-status --skip-account-verification
   only:
     - integration
   when: manual

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,12 +56,12 @@ if [[ $# != 2 ]]; then
     echo "If the --skip-account-verification flag is given, the user will not be asked to"
     echo "verify cloud account information."
     echo
-    echo "Usage: $(basename $0) source_branch dest_branch [--force] [--no-deploy]"
+    echo "Usage: $(basename $0) source_branch dest_branch [--force] [--no-deploy] [--skip-github-status] [--skip-account-verification]"
     echo "Example: $(basename $0) master staging"
     exit 1
 fi
 
-if ! [[ $SKIP_ACCOUNT_VERIFICATION == "--skip-account-verification" ]]; then
+if [[ $SKIP_ACCOUNT_VERIFICATION != "--skip-account-verification" ]]; then
     echo "Please review and confirm your active AWS account configuration:"
     aws configure list
     aws sts get-caller-identity
@@ -100,7 +100,7 @@ fi
 
 export PROMOTE_FROM_BRANCH=$1 PROMOTE_DEST_BRANCH=$2
 
-if ! [[ $SKIP_GITHUB_STATUS == "--skip-github-status" ]]; then
+if [[ $SKIP_GITHUB_STATUS != "--skip-github-status" ]]; then
     GH_API=https://api.github.com
     REPO=$(git remote get-url origin | perl -ne '/github\.com.(.+?)(\.git)?$/; print $1')
     STATUS=$(http GET ${GH_API}/repos/${REPO}/commits/${PROMOTE_FROM_BRANCH}/status Accept:application/vnd.github.full+json)


### PR DESCRIPTION
* Command number checks no needed anymore in `scripts/release.sh`
* Reset working tree before doing anything
* Add `--skip-account-verification` and `--skip-github-status` to `scripts/release.sh`, which is useful for the CI build since the `yes 1 | ...` was causing non-zero exit status for some reason

Testing:
Successfully released to integration