### PR TITLE
adding 422 when metadata checksums are missing for put_file

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -502,6 +502,22 @@ paths:
                     enum: [file_already_exists]
                 required:
                   - code
+        422:
+          description: Returned when a request cannot be processed due to invalid values in a supplied entity.
+          schema:
+            allOf:
+            - $ref: '#/definitions/Error'
+            - type: object
+              properties:
+                code:
+                  type: string
+                  description: Machine-readable error code.  The types of return values should not be changed lightly.
+
+                  The code `missing_checksum` is returned when the file uploaded is missing a required checksum.
+
+                  enum: [missing_checksum]
+              required:
+              - code
         default:
           description: Unexpected error
           schema:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -506,18 +506,18 @@ paths:
           description: Returned when a request cannot be processed due to invalid values in a supplied entity.
           schema:
             allOf:
-            - $ref: '#/definitions/Error'
-            - type: object
-              properties:
-                code:
-                  type: string
-                  description: Machine-readable error code.  The types of return values should not be changed lightly.
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: Machine-readable error code.  The types of return values should not be changed lightly.
 
-                  The code `missing_checksum` is returned when the file uploaded is missing a required checksum.
+                      The code `missing_checksum` is returned when the file uploaded is missing a required checksum.
 
-                  enum: [missing_checksum]
-              required:
-              - code
+                    enum: [missing_checksum]
+                required:
+                - code
         default:
           description: Unexpected error
           schema:

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -205,11 +205,17 @@ def put(uuid: str, json_request_body: dict, version: str):
     size = handle.get_size(src_bucket, src_key)
     content_type = handle.get_content_type(src_bucket, src_key)
 
-    # format all the checksums so they're lower-case.
-    for metadata_spec in HCABlobStore.MANDATORY_STAGING_METADATA.values():
-        if metadata_spec['downcase']:
-            keyname = typing.cast(str, metadata_spec['keyname'])
-            metadata[keyname] = metadata[keyname].lower()
+    try:
+        # format all the checksums so they're lower-case.
+        for metadata_spec in HCABlobStore.MANDATORY_STAGING_METADATA.values():
+            if metadata_spec['downcase']:
+                keyname = typing.cast(str, metadata_spec['keyname'])
+                metadata[keyname] = metadata[keyname].lower()
+    except KeyError:
+        raise DSSException(
+            requests.codes.unprocessable,
+            "missing_checksum",
+            f"mssing {keyname}")
 
     # what's the target object name for the actual data?
     dst_key = ("blobs/" + ".".join(


### PR DESCRIPTION
### Test plan
- need to add a test case.

### Release notes
- A 422 is returned when the file metadata is missing checksums.

