### PR TITLE
Custom email claim fix and tests

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -238,8 +238,7 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str):
 @dss_handler
 @security.authorized_group_required(['hca'])
 def delete(uuid: str, replica: str, json_request_body: dict, version: str=None):
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    email = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+    email = security.get_token_email(request.token_info)
 
     if email not in ADMIN_USER_EMAILS:
         raise DSSForbiddenException("You can't delete bundles with these credentials!")

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -51,8 +51,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 @dss_handler
 @security.authorized_group_required(['hca'])
 def get(uuid: str, replica: str, version: str = None):
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    authenticated_user_email = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+    authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)
     if collection_body["owner"] != authenticated_user_email:
         raise DSSException(requests.codes.forbidden, "forbidden", f"Collection access denied")
@@ -61,8 +60,7 @@ def get(uuid: str, replica: str, version: str = None):
 @dss_handler
 @security.authorized_group_required(['hca'])
 def put(json_request_body: dict, replica: str, uuid: str, version: str):
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    authenticated_user_email = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+    authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = dict(json_request_body, owner=authenticated_user_email)
     uuid = uuid.lower()
     handle = Config.get_blobstore_handle(Replica[replica])
@@ -98,8 +96,7 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
             "illegal_version",
             f"version should be an rfc3339-compliant timestamp")
 
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    authenticated_user_email = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+    authenticated_user_email = security.get_token_email(request.token_info)
 
     uuid = uuid.lower()
     owner = get_impl(uuid=uuid, replica=replica)["owner"]
@@ -129,8 +126,7 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
 @dss_handler
 @security.authorized_group_required(['hca'])
 def delete(uuid: str, replica: str):
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    authenticated_user_email = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+    authenticated_user_email = security.get_token_email(request.token_info)
 
     uuid = uuid.lower()
     tombstone_key = CollectionTombstoneID(uuid, version=None).to_key()

--- a/dss/api/subscriptions.py
+++ b/dss/api/subscriptions.py
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
 @dss_handler
 @security.authorized_group_required(['hca'])
 def get(uuid: str, replica: str):
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    owner = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+    owner = security.get_token_email(request.token_info)
 
     es_client = ElasticsearchClient.get()
 
@@ -48,8 +47,7 @@ def get(uuid: str, replica: str):
 @dss_handler
 @security.authorized_group_required(['hca'])
 def find(replica: str):
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    owner = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+    owner = security.get_token_email(request.token_info)
     es_client = ElasticsearchClient.get()
 
     search_obj = Search(using=es_client,
@@ -73,8 +71,8 @@ def find(replica: str):
 def put(json_request_body: dict, replica: str):
     uuid = str(uuid4())
     es_query = json_request_body['es_query']
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    owner = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+
+    owner = security.get_token_email(request.token_info)
 
     attachment.validate(json_request_body.get('attachments', {}))
 
@@ -151,8 +149,7 @@ def put(json_request_body: dict, replica: str):
 @dss_handler
 @security.authorized_group_required(['hca'])
 def delete(uuid: str, replica: str):
-    # TODO remove request.token_info['email'] once HCA-CLI is updated to support custom claim
-    owner = request.token_info.get(Config.get_OIDC_email_claim()) or request.token_info['email']
+    owner = security.get_token_email(request.token_info)
 
     es_client = ElasticsearchClient.get()
 

--- a/dss/config.py
+++ b/dss/config.py
@@ -373,7 +373,7 @@ class Config:
 
     @staticmethod
     def get_OIDC_email_claim():
-        return os.environ.get("OIDC_EMAIL_CLAIM", None)
+        return os.environ.get("OIDC_EMAIL_CLAIM", 'email')
 
     @staticmethod
     def _get_required_envvar(envvar: str) -> str:

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -67,6 +67,14 @@ def verify_jwt(token: str) -> typing.Optional[typing.Mapping]:
     return verified_tok
 
 
+def get_token_email(token_info: typing.Mapping[str, typing.Any]) -> str:
+    try:
+        email_claim = Config.get_OIDC_email_claim()
+        return token_info.get(email_claim) or token_info['email']
+    except KeyError as ex:
+        raise DSSException(401, 'Unauthorized', 'Authorization token is missing email claims.')
+
+
 def assert_authorized_issuer(token: typing.Mapping[str, typing.Any]) -> None:
     """
     Must be either `Config.get_openid_provider()` or in `Config.get_trusted_google_projects()`

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -92,6 +92,11 @@ class TestSubscriptionsBase(ElasticsearchTestCase, DSSAssertMixin):
         with self.subTest("unauthorized group"):
             self.assertGetResponse(url, requests.codes.forbidden, headers=get_auth_header(group='public'))
 
+        with self.subTest("no email claims"):
+            self.assertGetResponse(url,
+                                   500,
+                                   headers=get_auth_header(email=False, email_claim=False))
+
     def test_put(self):
         uuid_ = self._put_subscription()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -180,8 +180,10 @@ class TestSecurity(unittest.TestCase):
                 self.assertEqual(security.get_token_email(param), result)
 
         with self.subTest("missing claim"):
-            with self.assertRaises(DSSException):
+            with self.assertRaises(DSSException) as ex:
                 security.get_token_email({})
+            self.assertEqual(ex.exception.status, 401)
+            self.assertEqual(ex.exception.message, 'Authorization token is missing email claims.')
 
     @staticmethod
     def restore_email_claims(old):


### PR DESCRIPTION
* Fixes an error that prevent users from making authorized request with user credentials. Does not affect service credentials.
* Moved common logic for retrieving user email to a function in security. 
* Added tests to confirm the behavior of that function. 

### Test plan
added specific test cases for custom email claims.

### Deployment instructions & migrations
None