### PR TITLE
Optimize file checkout to always return immediately if available

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ chalice==1.6.0
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==3.0.0
+cloud-blobstore==3.1.0
 colorama==0.3.9
 connexion==1.5.2
 coverage==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cffi==1.11.5
 chardet==3.0.4
 click==6.7
 clickclick==1.2.2
-cloud-blobstore==3.0.0
+cloud-blobstore==3.1.0
 connexion==1.5.2
 crcmod==1.7
 cryptography==2.3.1

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -2,7 +2,7 @@
 azure-storage >= 0.36.0
 boto3 >= 1.6.0
 botocore >= 1.10.16  # 1.9.x does not support AWS secretsmanager support
-cloud-blobstore >= 3.0.0
+cloud-blobstore >= 3.1.0
 connexion >= 1.1.15
 dcplib>=1.3.2
 elasticsearch >= 5.4.0, < 6.0.0


### PR DESCRIPTION
These changes follow https://github.com/HumanCellAtlas/data-store/pull/1516 and further optimize `get_file` to initiate a checkout and return `302 Found` (instead of previously initiating a checkout and returning a `301 Redirect`) if the file is requested past its soft expiration date (`DSS_BLOB_PUBLIC_TTL_DAYS`), but 1 hour before its real expiration date (`DSS_BLOB_TTL_DAYS`). The second condition is to prevent returning a `302 Found` immediately before the file is deleted from the bucket.

### Test plan
- Added tests for both cases
- Tested both cases by hitting local API server

### Release notes
- `get_file` always optimistically returns `302 Found` when file is in checkout

Relates to #1367 