### PR TITLE
Optimize get bundle to serve existing checkout bundles whenever possible

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -49,6 +49,8 @@ def get(
     bundle_metadata = get_bundle_manifest(uuid, _replica, version)
     if bundle_metadata is None:
         raise DSSException(404, "not_found", "Cannot find bundle!")
+    if version is None:
+        version = bundle_metadata[BundleMetadata.VERSION]
 
     if directurls or presignedurls:
         try:


### PR DESCRIPTION
These changes follow https://github.com/HumanCellAtlas/data-store/pull/1522. With these changes, if a [stale](https://github.com/HumanCellAtlas/data-store/pull/1516) bundle is accessed, a checkout job will be kicked off but the existing checkout bundle will be returned immediately such that the client does not have to wait for the checkout job to complete, and the bundle's TTL will be refreshed.

### Test plan
- Added integration tests for new stale bundle behavior
- Manual testing against local DSS API server


### Deployment instructions & migrations
- Upgraded `cloud-blobstore` to 3.1.0

### Release notes
- Optimized GET bundle to return existing checkout bundles when possible

Fixed #1367 