### PR TITLE
Fix sync daemon tests and logic error when copying tombstones

### DIFF
--- a/dss/events/handlers/sync.py
+++ b/dss/events/handlers/sync.py
@@ -16,7 +16,8 @@ from dss import Config, Replica
 from dss.api.collections import get_json_metadata, verify_collection
 from dss.util.aws import resources, clients
 from dss.util.streaming import get_pool_manager, S3SigningChunker
-from dss.storage.identifiers import FILE_PREFIX, BUNDLE_PREFIX, COLLECTION_PREFIX, FileFQID, BundleFQID, CollectionFQID
+from dss.storage.identifiers import (FILE_PREFIX, BUNDLE_PREFIX, COLLECTION_PREFIX, TOMBSTONE_SUFFIX,
+                                     FileFQID, BundleFQID, CollectionFQID)
 from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, compose_blob_key
 
 
@@ -219,7 +220,9 @@ def dependencies_exist(source_replica: Replica, dest_replica: Replica, key: str)
     """
     source_handle = Config.get_blobstore_handle(source_replica)
     dest_handle = Config.get_blobstore_handle(dest_replica)
-    if key.startswith(FILE_PREFIX):
+    if key.endswith(TOMBSTONE_SUFFIX):
+        return True
+    elif key.startswith(FILE_PREFIX):
         file_id = FileFQID.from_key(key)
         file_manifest = get_json_metadata(entity_type="file",
                                           uuid=file_id.uuid,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -231,7 +231,7 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
 @testmode.integration
 class TestSyncDaemon(unittest.TestCase, DSSSyncMixin):
     def setUp(self):
-        dss.Config.set_config(dss.BucketConfig.TEST)
+        dss.Config.set_config(dss.BucketConfig.NORMAL)
         self.gs_bucket_name, self.s3_bucket_name = dss.Config.get_gs_bucket(), dss.Config.get_s3_bucket()
         self.logger = logging.getLogger(__name__)
         self.gs = Config.get_native_handle(Replica.gcp)


### PR DESCRIPTION
- Sync daemon needs to use the "normal" bucket since that is what events are configured on.
- For now, let's have the sync daemon copy tombstones without checking for their dependencies. It's not clear if there are situations where we need to hold back dependent tombstone copying for referential integrity.