### PR TITLE
Multiplex GS events between indexer and sync daemons using SNS-SQS

### DIFF
--- a/daemons/dss-gs-event-relay/main.py
+++ b/daemons/dss-gs-event-relay/main.py
@@ -82,10 +82,10 @@ def dss_gs_event_relay(data, context):
         print("Ignoring multipart object upload event")
     else:
         print("Relaying message:", data)
-        for config_var in "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION", "sqs_queue_url":
+        for config_var in "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION", "sns_topic_arn":
             os.environ[config_var] = grtc_client.get_config_var(config_var)
-        sqs = boto3.resource("sqs")
-        queue = sqs.Queue(os.environ["sqs_queue_url"])
-        print(json.dumps(queue.send_message(MessageBody=json.dumps(data))))
+        sns = boto3.resource("sns")
+        topic = sns.Topic(os.environ["sns_topic_arn"])
+        print(json.dumps(topic.publish(Message=json.dumps(data))))
 
 globals()[os.environ.get("ENTRY_POINT")] = dss_gs_event_relay

--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -42,8 +42,7 @@ def dispatch_gs_indexer_event(event, context):
     This handler receives GS events via the Google Cloud Function deployed from daemons/dss-gs-event-relay.
     """
     gs_event = json.loads(event['Records'][0]['Sns']['Message'])
-    event = gs_event['data']
-    _handle_event(Replica.gcp, event, context)
+    _handle_event(Replica.gcp, gs_event, context)
 
 
 def _handle_event(replica, event, context):

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -54,12 +54,12 @@ def launch_from_s3_event(event, context):
                 executions[exec_name] = app.state_machine.start_execution(**exec_input)["executionArn"]
     return executions
 
-# This entry point is for external events forwarded by dss-gs-event-relay (or other event sources) through SQS.
+# This entry point is for external events forwarded by dss-gs-event-relay (or other event sources) through SNS-SQS.
 @app.sqs_queue_subscriber("dss-sync-" + os.environ["DSS_DEPLOYMENT_STAGE"])
 def launch_from_forwarded_event(event, context):
     executions = {}
     for event_record in event["Records"]:
-        message = json.loads(event_record["body"])
+        message = json.loads(json.loads(event_record["body"])["Message"])
         if message["selfLink"].startswith("https://www.googleapis.com/storage"):
             source_replica = Replica.gcp
             source_key = message["name"]


### PR DESCRIPTION
My initial design had the same issue with GS events as it did with S3 events: SQS can't be used to send events to multiple destinations at once.

Fixup for 1cf7717