### PR TITLE
GS event relay: Get all available GRTC env vars in one go

### DIFF
--- a/daemons/dss-gs-event-relay/main.py
+++ b/daemons/dss-gs-event-relay/main.py
@@ -67,7 +67,9 @@ class GRTCClient(GCPAPIClient):
         if variable not in self.cache:
             config_ns = f"projects/{self.get_project()}/configs"
             var_ns = f"{config_ns}/{os.environ['ENTRY_POINT']}/variables"
-            self.cache[variable] = base64.b64decode(self.get(f"{var_ns}/{variable}")["value"]).decode()
+            res = self.get(var_ns, params=dict(returnValues=True))
+            for var in res["variables"]:
+                self.cache[os.path.basename(var["name"])] = base64.b64decode(var["value"]).decode()
         return self.cache[variable]
 
 grtc_client = GRTCClient()


### PR DESCRIPTION
The GET variables method in GRTC allows us to get all the values in
one go. This reduces the number of GRTC API calls, so we're less
likely to exceed our quota (crashing the function).

https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest/v1beta1/projects.configs.variables/list

<!-- Please make sure to provide a meaningful title for your PR. Do not keep the default title. -->
<!-- Use the following GitHub keyword if your PR completely resolves an issue: "Fixes #123" -->

<!-- Describe how you tested this PR, and how you will test the feature after it is merged. Uncomment below:
### Test plan -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

<!-- Add notes to highlight the feature when it's released/demoed. Uncomment the headings below:
### Release notes -->

<!-- Do you want your PR to be merged by the reviewer using squash or rebase merging? If so, mention it here. -->
