### PR TITLE
Use the HCA DCP common Terraform backend bucket

### DIFF
--- a/environment
+++ b/environment
@@ -102,7 +102,7 @@ DSS_DEBUG=0
 
 # `{account_id}`, if present, will be replaced with the account ID associated with the AWS credentials used for
 # deployment. It can be safely omitted.
-DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE="org-humancellatlas-dss-config-{account_id}"
+DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE="org-humancellatlas-{account_id}-terraform"
 
 # Configure the delays between notification attempts. The first attempt is immediate. The second attempt is one
 # minute later. Then ten minutes, one hour, and six hours in between. Then 24 hours minus all previous delays and

--- a/infra/build_deploy_config.py
+++ b/infra/build_deploy_config.py
@@ -27,7 +27,7 @@ terraform_backend_template = """# Auto-generated during infra build process.
 terraform {{
   backend "s3" {{
     bucket = "{bucket}"
-    key = "dss-{comp}-{stage}.tfstate"
+    key = "dss/{comp}-{stage}.tfstate"
     region = "{region}"
     {profile_setting}
   }}


### PR DESCRIPTION
* Move TF state bucket to common HCA DCP bucket
* Put state files int s3://{bucket}/dss/{component}.state instead of s3://{bucket}/dss-{component}.state
* Make bucket account-id parameterization explicit