### PR TITLE
Organize README into sections

### DIFF
--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -1,0 +1,71 @@
+Environment Variable | Description
+--- | ---
+`EXPORT_ENV_VARS_TO_LAMBDA` | Environment variables that will be exported to daemons on deploy. See `build_deploy_config.sh`.
+`DSS_DEPLOYMENT_STAGE` | The name of the DSS deployment. This value should be appended to all bucket and step function names. The Human Cell Atlas project maintains for deployment stages: `dev`, `integration`, `staging` and `prod`. 
+`AWS_DEFAULT_OUTPUT` | The default output format for AWS CLI commands.
+`AWS_DEFAULT_REGION` | The default region that the AWS CLI and boto3 will use.
+`GCP_DEFAULT_REGION` | The default region that `gcloud` and `google-cloud-python` will use.
+`DSS_S3_BUCKET` | The name of the DSS' main bucket in S3. This bucket stores file contents in `blobs/`, file metadata in ` files/` and bundle manifests in `bundles/`. The bucket name should be suffixed with `DSS_DEPLOYMENT_STAGE`.
+`DSS_S3_BUCKET_TEST` | The name of the DSS' test bucket in S3. This bucket replaces `DSS_S3_BUCKET` during unit and integration tests. The bucket name should be suffixed with `DSS_DEPLOYMENT_STAGE`.
+`DSS_S3_BUCKET_TEST_FIXTURES` | The name of the DSS' test fixtures bucket in S3. This bucket stores static test data such as bundles and files that are required to run unit and integration tests. Test fixture buckets can be populated by running the script: `tests/fixtures/populate.py --s3-bucket $DSS_S3_BUCKET_TEST_FIXTURES --gs-bucket $DSS_GS_BUCKET_TEST_FIXTURES`.
+`DSS_S3_BUCKET_INTEGRATION` | The name of the HCA DSS' main bucket in S3 on the HCA integration environment.
+`DSS_S3_BUCKET_STAGING` | The name of the HCA DSS' main bucket in S3 on the HCA staging environment.
+`DSS_S3_BUCKET_PROD` | The name of the HCA DSS' main bucket in S3 on the HCA production environment.
+`DSS_S3_CHECKOUT_BUCKET` | The name of the DSS' checkout bucket in S3. On `GET` during the checkout process copies files from `DSS_S3_BUCKET` to this bucket. This bucket name should be suffixed with `DSS_DEPLOYMENT_STAGE`.
+`DSS_S3_CHECKOUT_BUCKET_TEST` | The name of the DSS' test checkout bucket in S3. This bucket replaces `DSS_S3_CHECKOUT_BUCKET` during unit and integration tests. This bucket name should be suffixed with `DSS_DEPLOYMENT_STAGE`.
+`DSS_S3_CHECKOUT_BUCKET_UNWRITABLE` | The name of the DSS' unwritable checkout bucket. This bucket is used for testing purposes.
+`DSS_S3_CHECKOUT_BUCKET_INTEGRATION` | The name of the HCA DSS' checkout bucket in S3 on the HCA integration environment.
+`DSS_S3_CHECKOUT_BUCKET_STAGING` | The name of the HCA DSS' checkout bucket in S3 on the HCA staging environment.
+`DSS_S3_CHECKOUT_BUCKET_PROD` | The name of the HCA DSS' checkout bucket in S3 on the HCA prod environment.
+`DSS_GS_BUCKET` | The name of the DSS' main bucket in GS. This bucket stores file contents in `blobs/`, file metadata in ` files/` and bundle manifests in `bundles/`. The bucket name should be suffixed with `DSS_DEPLOYMENT_STAGE`.
+`DSS_GS_BUCKET_TEST` | The name of the DSS' test bucket in GS. This bucket replaces `DSS_S3_BUCKET` during unit and integration tests. The bucket name should be suffixed with `DSS_DEPLOYMENT_STAGE`.
+`DSS_GS_BUCKET_TEST_FIXTURES` | The name of the DSS' test fixtures bucket in GS. This bucket stores static test data such as bundles and files that are required to run unit and integration tests. Test fixture buckets can be populated by running the script: `tests/fixtures/populate.py --s3-bucket $DSS_S3_BUCKET_TEST_FIXTURES --gs-bucket $DSS_GS_BUCKET_TEST_FIXTURES`.
+`DSS_GS_BUCKET_INTEGRATION` | The name of the HCA DSS' main bucket in GS on the HCA integration environment.
+`DSS_GS_BUCKET_STAGING` | The name of the HCA DSS' main bucket in GS on the HCA staging environment.
+`DSS_GS_BUCKET_PROD` | The name of the HCA DSS' main bucket in GS on the HCA production environment.
+`DSS_GS_CHECKOUT_BUCKET` | The name of the DSS' checkout bucket in GS. On `GET` during the checkout process copies files from `DSS_S3_BUCKET` to this bucket. This bucket name should be suffixed with `DSS_DEPLOYMENT_STAGE`.
+`DSS_GS_CHECKOUT_BUCKET_TEST` | The name of the DSS' test checkout bucket in GS. This bucket replaces `DSS_S3_CHECKOUT_BUCKET` during unit and integration tests. This bucket name should be suffixed with `DSS_DEPLOYMENT_STAGE`.
+`DSS_GS_CHECKOUT_BUCKET_INTEGRATION` | The name of the HCA DSS' checkout bucket in GS on the HCA integration environment.
+`DSS_GS_CHECKOUT_BUCKET_STAGING` | The name of the HCA DSS' checkout bucket in GS on the HCA staging environment.
+`DSS_GS_CHECKOUT_BUCKET_PROD` | The name of the HCA DSS' checkout bucket in GS on the HCA prod environment.
+`DSS_BLOB_TTL_DAYS` | The time to live of an object in cloud storage enforced by the cloud provider's bucket lifecycle poilcy.
+`DSS_NOTIFICATION_SENDER` | 
+`ADMIN_USER_EMAILS` | 
+`DCP_DOMAIN` | 
+`API_DOMAIN_NAME` | The domain of the API host.
+`TOKENINFO_FUNC` | 
+`OIDC_AUDIENCE` | 
+`OPENID_PROVIDER` | 
+`OIDC_EMAIL_CLAIM` | 
+`OIDC_GROUP_CLAIM` | 
+`NOTIFY_URL` | 
+`DSS_AUTHORIZED_GOOGLE_PROJECT_DOMAIN_ARRAY` | 
+`DSS_AUTHORIZED_DOMAINS` | 
+`DSS_AUTHORIZED_DOMAINS_TEST` | 
+`DSS_ES_DOMAIN` | 
+`DSS_ES_INSTANCE_TYPE` | 
+`DSS_ES_VOLUME_SIZE` | 
+`DSS_ES_INSTANCE_COUNT` | 
+`DSS_CERTIFICATE_DOMAIN` | 
+`DSS_CERTIFICATE_ADDITIONAL_NAMES` | 
+`DSS_CERTIFICATE_VALIDATION` | 
+`DSS_ZONE_NAME` | 
+`PYTHONWARNINGS` | 
+`DSS_SECRETS_STORE` | 
+`EVENT_RELAY_AWS_USERNAME` | 
+`EVENT_RELAY_AWS_ACCESS_KEY_SECRETS_NAME` | 
+`GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME` | 
+`GOOGLE_APPLICATION_SECRETS_SECRETS_NAME` | 
+`ES_ALLOWED_SOURCE_IP_SECRETS_NAME` | 
+`DSS_DEBUG` | 
+`DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE` | "dss-config-{account_id}" - `{account_id}`, if present, will be replaced with the account ID associated with the AWS credentials used for deployment. It can be safely omitted.
+`DSS_NOTIFY_DELAYS` | Configure the delays between notification attempts. The first attempt is immediate. The second attempt is one minute later. Then ten minutes, one hour, and six hours in between. Then 24 hours minus all previous delays and lastly every 24 hours for six days. This is exponential initially and then levels off where exponential would be too infrequent. The last attempt is made seven days after the first one, which is easy to remember.
+`DSS_NOTIFY_TIMEOUT` | This may seem excessive but the default of 10s is not enough for Green's Lira and would cause the notification to be retried, causing Lira to make a duplicate submission.
+`DSS_XRAY_TRACE` | Enables X-Ray profiling of daemons running in AWS Lambdas. A value of 0 disables profiling. A value >1 will enable profiling.
+`DSS_GS_BUCKET_REGION` | Workaround for GS buckets with non-uniform regions
+`DSS_GS_BUCKET_TEST_REGION` | Workaround for GS buckets with non-uniform regions
+`DSS_GS_BUCKET_TEST_FIXTURES_REGION` | Workaround for GS buckets with non-uniform regions
+`DSS_GCP_SERVICE_ACCOUNT_NAME` | "travis-test"
+`DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS` | This list manages the GCP Users and serviceAccounts able to access direct URLs on the GS checkout bucket. Other GCP entities must use presigned urls, or checkout to an external GS bucket they have access to. 
+`AWS_SDK_LOAD_CONFIG` | Needed for Terraform to correctly use AWS assumed roles
+


### PR DESCRIPTION
Reorganize README into the following sections:
- Overview
- Getting Started
    - Configuration
    - Running tests
    - Deployment
- Development
- Contributing

More complex processes should be captured in separate documentation so as to not crowd the main README. A couple of these topics are:

- Description of environment variables: https://app.zenhub.com/workspace/o/humancellatlas/data-store/issues/1593
- Configuring the HCA CLI: https://app.zenhub.com/workspace/o/humancellatlas/data-store/issues/1594
- Checkout process

Certain sections in the current README should also be extracted into separate documents and expanded on, however, I think more involved discussion is required before organizing this.