### PR TITLE
Remove unnecessary lambda Get/List permissions for s3.

### DIFF
--- a/iam/policy-templates/dss-admin-lambda.json
+++ b/iam/policy-templates/dss-admin-lambda.json
@@ -35,8 +35,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-checkout-sfn-lambda.json
+++ b/iam/policy-templates/dss-checkout-sfn-lambda.json
@@ -80,8 +80,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-dlq-reaper-lambda.json
+++ b/iam/policy-templates/dss-dlq-reaper-lambda.json
@@ -34,8 +34,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-gs-copy-sfn-lambda.json
+++ b/iam/policy-templates/dss-gs-copy-sfn-lambda.json
@@ -24,8 +24,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-gs-copy-write-metadata-sfn-lambda.json
+++ b/iam/policy-templates/dss-gs-copy-write-metadata-sfn-lambda.json
@@ -24,8 +24,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-index-lambda.json
+++ b/iam/policy-templates/dss-index-lambda.json
@@ -53,8 +53,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -60,8 +60,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-notify-lambda.json
+++ b/iam/policy-templates/dss-notify-lambda.json
@@ -42,8 +42,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-s3-copy-sfn-lambda.json
+++ b/iam/policy-templates/dss-s3-copy-sfn-lambda.json
@@ -49,8 +49,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-s3-copy-write-metadata-sfn-lambda.json
+++ b/iam/policy-templates/dss-s3-copy-write-metadata-sfn-lambda.json
@@ -45,8 +45,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-scalability-test-lambda.json
+++ b/iam/policy-templates/dss-scalability-test-lambda.json
@@ -72,8 +72,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-sfn-launcher-lambda.json
+++ b/iam/policy-templates/dss-sfn-launcher-lambda.json
@@ -41,8 +41,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-sync-sfn-lambda.json
+++ b/iam/policy-templates/dss-sync-sfn-lambda.json
@@ -52,8 +52,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"

--- a/iam/policy-templates/dss-visitation-lambda.json
+++ b/iam/policy-templates/dss-visitation-lambda.json
@@ -62,8 +62,6 @@
       "Effect": "Allow",
       "Action": [
           "xray:PutTelemetryRecords",
-          "s3:Get*",
-          "s3:List*",
           "xray:PutTraceSegments"
       ],
       "Resource": "*"


### PR DESCRIPTION
Connected to #1623 .

All lambdas were given robust s3 Get*/List* permissions for X-ray I believe, however I believe this is only needed for EC2 instances.  We're trying to tighten down privileges for our data store on the commons side and wanted to submit a PR.  Also to double-check and make sure it passes tests on the HCA side.

Documentation here: https://docs.aws.amazon.com/xray/latest/devguide/xray-permissions.html

> AmazonS3ReadOnlyAccess **(Amazon EC2 only)** – Gives the instance permission to download the X-Ray daemon from Amazon S3.