### PR TITLE
Define GitLab prod release/deploy

### DIFF
--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -1,0 +1,40 @@
+image: humancellatlas/dss-build-box
+# The Docker image `humancellatlas/dss-build-box` is created through a manual process from
+# `${DSS_HOME}/Dockerfile.allspark`. See the contents of `${DSS_HOME}/Dockerfile.allspark`
+# creation and usage instructions.
+
+variables:
+  GIT_SUBMODULE_STRATEGY: normal
+  DSS_ES_TIMEOUT: 30
+  DSS_UNITTEST_OPTS: "-v"
+  GITHUB_API: "https://api.github.com"
+
+stages:
+  - deploy
+
+before_script:
+  - export COMMITS_URL=${GITHUB_API}/repos/HumanCellAtlas/data-store/commits
+  - if not [[ CI_COMMIT_SHA == $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
+# TODO: figure out how to get the gitlab-runner to not clone the repo as root - Brian H
+  - cp -r /HumanCellAtlas/data-store ~/data-store && cd ~/data-store
+  - git reset --hard HEAD
+  - virtualenv ~/venv
+  - source ~/venv/bin/activate
+  - pip install -r requirements-dev.txt
+  - source environment
+  - source environment.prod
+  - scripts/fetch_secret.sh application_secrets.json > application_secrets.json
+  - scripts/fetch_secret.sh gcp-credentials.json > gcp-credentials.json
+  - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
+
+deploy:
+  stage: deploy
+  script:
+    - make plan-infra
+    - make deploy
+  environment:
+    name: prod
+    url: https://dss.data.humancellatlas.org
+  only:
+    - prod
+  when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,3 +154,31 @@ force_release_staging:
   only:
     - integration
   when: manual
+
+release_prod:
+  stage: release
+  script:
+    - git remote set-url origin https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git
+    - for i in $(seq 1 40); do
+    -   status=$(scripts/status.sh HumanCellAtlas dcp prod)
+    -   if [[ pending != "${status}" && running != "${status}" ]]; then break; fi
+    -   echo "waiting for DCP Integration test to complete";
+    -   sleep 30;  # This loop will check status for 20 minutes and then quit
+    - done
+    - if [[ success != "${status}" ]]; then
+    -   echo "DCP Integration test returned status ${status}";
+    -   exit 1
+    - fi
+    - scripts/release.sh staging prod --no-deploy --skip-github-status --skip-account-verification
+  only:
+    - staging
+  when: manual 
+
+force_release_prod:
+  stage: release
+  script:
+    - git remote set-url origin https://$GITHUB_TOKEN@github.com/HumanCellAtlas/data-store.git
+    - scripts/release.sh staging prod --force --no-deploy --skip-github-status --skip-account-verification
+  only:
+    - staging
+  when: manual


### PR DESCRIPTION
This adds two manual GitLab jobs to enable  `prod` releases:
1. Prod release/force-release buttons in dev GitLab
2. A manual prod build job in prod GitLab

This means that the operator cannot release `prod` until tests are passing on `staging`, and the operator must have access to the prod build box.

Closes #1620