### PR TITLE
Raise sync exception when s3/gs presigned urls fail to resolve

### DIFF
--- a/dss/events/handlers/sync.py
+++ b/dss/events/handlers/sync.py
@@ -63,7 +63,7 @@ def sync_s3_to_gs_oneshot(source: BlobLocation, dest: BlobLocation):
     )
     with closing(http.request("GET", s3_blob_url, preload_content=False)) as fh:
         if 200 != fh.status:
-            msg = f"failed to resolve s3 presigned url for {source.blob.key}"
+            msg = f"failed to resolve s3 presigned url for {source.blob.key} with status {fh.status}"
             logger.error(msg)
             raise Exception(msg)
         gs_blob = dest.bucket.blob(source.blob.key, chunk_size=1024 * 1024)
@@ -75,7 +75,7 @@ def sync_gs_to_s3_oneshot(source: BlobLocation, dest: BlobLocation):
     gs_blob_url = source.blob.generate_signed_url(expiration=expires_timestamp)
     with closing(http.request("GET", gs_blob_url, preload_content=False)) as fh:
         if 200 != fh.status:
-            msg = f"failed to resolve gs presigned url for {source.blob.key}"
+            msg = f"failed to resolve gs presigned url for {source.blob.key} with status {fh.status}"
             logger.error(msg)
             raise Exception(msg)
         dest.blob.upload_fileobj(fh, ExtraArgs=dict(Metadata=source.blob.metadata or {}))


### PR DESCRIPTION
This will cause the sync sfn to retry oneshot copies when presigned urls fail to resolve.

fixes #1636