### PR TITLE
Updating lambda IAM policies to denying delete on DSS_S3_BUCKET

### DIFF
--- a/iam/policy-templates/dss-index-lambda.json
+++ b/iam/policy-templates/dss-index-lambda.json
@@ -19,6 +19,14 @@
       ]
     },
     {
+      "Effect": "Deny",
+      "Action": "s3:Delete*",
+      "Resource": [
+        "arn:aws:s3:::$DSS_S3_BUCKET",
+        "arn:aws:s3:::$DSS_S3_BUCKET/*"
+        ]
+    },
+    {
       "Effect": "Allow",
       "Action": [
         "es:ESHttpDelete",

--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -23,6 +23,14 @@
       ]
     },
     {
+      "Effect": "Deny",
+      "Action": "s3:Delete*",
+      "Resource": [
+        "arn:aws:s3:::$DSS_S3_BUCKET",
+        "arn:aws:s3:::$DSS_S3_BUCKET/*"
+        ]
+    },
+    {
       "Effect": "Allow",
       "Action": [
         "s3:Get*",

--- a/iam/policy-templates/dss-sync-sfn-lambda.json
+++ b/iam/policy-templates/dss-sync-sfn-lambda.json
@@ -19,6 +19,14 @@
       ]
     },
     {
+      "Effect": "Deny",
+      "Action": "s3:Delete*",
+      "Resource": [
+        "arn:aws:s3:::$DSS_S3_BUCKET",
+        "arn:aws:s3:::$DSS_S3_BUCKET/*"
+        ]
+    },
+    {
       "Effect": "Allow",
       "Action": [
         "states:StartExecution"


### PR DESCRIPTION
This is a preventative measure to reduce the number of resource with permissions to perform destructive operations on the data store.

These same protections do not exists for GCP. We will need to create read and write only google service account for lambdas to use.

### Deployment instructions & migrations
None

