### PR TITLE
Retry join state in s3 copy sfn

### DIFF
--- a/dss/stepfunctions/s3copyclient/implementation.py
+++ b/dss/stepfunctions/s3copyclient/implementation.py
@@ -309,7 +309,7 @@ def _sfn(parallelization_factor):
                 "End": True,
                 # Retry Lambda launch failures, but not join() failures
                 # https://docs.aws.amazon.com/step-functions/latest/dg/bp-lambda-serviceexception.html
-                "Retry": _retry_default(2, 6, 2, ["Lambda.ServiceException", "Lambda.SdkClientException"]),
+                "Retry": _retry_default(2, 6, 2),
                 "Catch": _catch_default(),
             },
             "FailTask": {


### PR DESCRIPTION
Retry on all errors to catch
```
{
  "error": "States.TaskFailed",
  "cause": "An attempt was made to invoke the Lambda function. Step Functions cannot determine whether Lambda successfully received the call and executed the function."
}
```