### PR TITLE
Store and recover chunks of state in dynamodb

### DIFF
--- a/dss/util/async_state.py
+++ b/dss/util/async_state.py
@@ -24,7 +24,7 @@ class AsyncStateItem:
 
     def __init__(self, key: str, body: dict) -> None:
         self.key = key
-        if not body.get('_type', None):
+        if not body.get('_type'):
             body['_type'] = type(self).__name__
         self.body = body
 

--- a/dss/util/async_state.py
+++ b/dss/util/async_state.py
@@ -1,0 +1,112 @@
+import os
+import json
+import typing
+
+import dss
+from dss import Replica
+from dss.util.aws.clients import dynamodb  # type: ignore
+
+
+class AsyncStateItem:
+    """
+    Store and recover json-serializable state into dynamodb
+    Subclasses of AsyncStateItem are instantiated with AsyncStateItem.get
+    for example:
+        class MyAsyncSubclass(AsyncStateItem):
+            pass
+        foo = MyAsyncSubclass.put("test_key", {})
+        bar = AsyncStateItem.get("test_key")
+        type(foo) == MyAsyncSubclass  # True
+        type(bar) == MyAsyncSubclass  # True
+    """
+
+    table = f"dss-async-state-{os.environ['DSS_DEPLOYMENT_STAGE']}"
+
+    def __init__(self, key: str, body: dict) -> None:
+        self.key = key
+        if not body.get('_type', None):
+            body['_type'] = type(self).__name__
+        self.body = body
+
+    def _put(self) -> typing.Any:
+        return dynamodb.put_item(
+            TableName=self.table,
+            Item={
+                'key': {
+                    'S': self.key
+                },
+                'body': {
+                    'S': json.dumps(self.body)
+                },
+            }
+        )
+
+    @classmethod
+    def put(cls, key: str, body: dict = None) -> typing.Any:
+        item = cls(key, body if body else dict())
+        item._put()
+        return item
+
+    @classmethod
+    def get(cls, key: str) -> typing.Any:
+        try:
+            item = dynamodb.get_item(  # mypy: ignore
+                TableName=cls.table,
+                Key={
+                    'key': {
+                        'S': key
+                    }
+                }
+            )['Item']
+        except KeyError:
+            return None
+
+        body = json.loads(item['body']['S'])
+        item_class = _all_subclasses(cls)[body['_type']]
+        return item_class(key, body)
+
+    @classmethod
+    def delete(cls, key: str) -> None:
+        dynamodb.delete_item(
+            TableName=cls.table,
+            Key={
+                'key': {
+                    'S': key
+                },
+            }
+        )
+
+    def delete_item(self):
+        AsyncStateItem.delete(self.key)
+
+
+class AsyncStateError(AsyncStateItem, Exception):
+    """
+    Store an error state into dynamodb
+    Errors may be recovered and raised remotely. Example:
+        Class MyAsyncError(AsyncStateError):
+            pass
+        MyAsyncError().put("my_key", "error message")
+
+        possible_error = AsyncStateItem.get("my_key")
+        if isinstance(possible_error, MyAsyncError):
+            raise possible_error
+    """
+    @property
+    def message(self) -> dict:
+        return self.body['message']
+
+    @classmethod
+    def put(cls, key: str, message: str):  # type: ignore
+        item = cls(key, {"message": message})
+        item._put()
+        return item
+
+
+def _all_subclasses(cls):
+    classes = {c.__name__: c
+               for c in cls.__subclasses__()}
+    for c in classes.copy().values():
+        classes.update(_all_subclasses(c))
+    classes[cls.__name__] = cls
+    return classes

--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -126,7 +126,10 @@
       "Resource": [
         "arn:aws:dynamodb:*:$account_id:table/scalability_test",
         "arn:aws:dynamodb:*:$account_id:table/scalability_test_result",
-        "arn:aws:dynamodb:*:$account_id:table/scalability_test/stream/*"
+        "arn:aws:dynamodb:*:$account_id:table/scalability_test/stream/*",
+        "arn:aws:dynamodb:*:$account_id:table/dss-async-state-dev",
+        "arn:aws:dynamodb:*:$account_id:table/dss-async-state-integration",
+        "arn:aws:dynamodb:*:$account_id:table/dss-async-state-staging"
       ]
     },
     {

--- a/infra/async_state_db/main.tf
+++ b/infra/async_state_db/main.tf
@@ -1,0 +1,11 @@
+resource "aws_dynamodb_table" "sfn_state" {
+  name           = "dss-async-state-${var.DSS_DEPLOYMENT_STAGE}"
+  read_capacity  = 20
+  write_capacity = 20
+  hash_key       = "key"
+
+  attribute {
+    name = "key"
+    type = "S"
+  }
+}

--- a/tests/test_async_state.py
+++ b/tests/test_async_state.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import sys
+import uuid
+import unittest
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+import dss
+from dss.logging import configure_test_logging
+from dss.config import Replica
+from tests.infra import testmode
+from dss.util.async_state import AsyncStateItem, AsyncStateError
+
+def setUpModule():
+    configure_test_logging()
+
+@testmode.standalone
+class TestAsyncState(unittest.TestCase):
+    def test_item(self):
+        key = str(uuid.uuid4())
+        msg = "some test msg"
+
+        # Getting a non-existent item should return None
+        item = AsyncStateItem.get(key)
+        self.assertIsNone(item)
+
+        # insert item
+        put_item = AsyncStateItem.put(key, {'message': msg})
+
+        # test get item
+        item = AsyncStateItem.get(key)
+        self.assertEqual(item.body['message'], put_item.body['message'])
+
+        # test delete item
+        item.delete_item()
+        self.assertIsNone(AsyncStateItem.get(key))
+
+    def test_error(self):
+        class TestAsyncError(AsyncStateError):
+            pass
+
+        key = str(uuid.uuid4())
+        message = "what went wrong"
+
+        # insert item
+        TestAsyncError.put(key, message)
+
+        # test get error
+        error = AsyncStateItem.get(key)
+        self.assertEqual(error.message, message)
+
+        # raise it and catch it
+        with self.assertRaises(TestAsyncError):
+            raise error
+
+        # test delete item
+        error.delete_item()
+        self.assertIsNone(TestAsyncError.get(key))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This will make it possible to catch copy sfn errors and expose them to the api.

It may also be useful as a lightweight caching mechanism.

related to #1616 