### PR TITLE
Use async state to catch/expose copy sfn errors

### DIFF
--- a/dss/events/handlers/sync.py
+++ b/dss/events/handlers/sync.py
@@ -114,7 +114,8 @@ def copy_part(upload_url: str, source_url: str, dest_platform: str, part: dict):
             logger.info("Part etag: {}".format(res.headers["ETag"]))
         elif dest_platform == "gs":
             logger.info(f"Uploading part {part} to gs")
-            gs_transport = google.auth.transport.requests.AuthorizedSession(gs._credentials)
+            # TODO: brianh: is mypy suppression ok?
+            gs_transport = google.auth.transport.requests.AuthorizedSession(gs._credentials)  # type: ignore
             for start in range(0, part["end"] - part["start"] + 1, gs_upload_chunk_size):
                 chunk = fh.read(gs_upload_chunk_size)
                 headers = {"content-range": get_content_range(start, start + len(chunk) - 1, total_bytes=None)}

--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -63,6 +63,13 @@
           "xray:PutTraceSegments"
       ],
       "Resource": "*"
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:*"
+        ],
+        "Resource": "arn:aws:dynamodb:*:$account_id:table/dss-async-state-$stage"
     }
   ]
 }

--- a/iam/policy-templates/dss-s3-copy-sfn-lambda.json
+++ b/iam/policy-templates/dss-s3-copy-sfn-lambda.json
@@ -2,8 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow",
-      "Action": [
+      "Effect": "Allow", "Action": [
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents"
@@ -52,6 +51,13 @@
           "xray:PutTraceSegments"
       ],
       "Resource": "*"
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:*"
+        ],
+        "Resource": "arn:aws:dynamodb:*:$account_id:table/dss-async-state-$stage"
     }
   ]
 }

--- a/iam/policy-templates/dss-s3-copy-sfn-lambda.json
+++ b/iam/policy-templates/dss-s3-copy-sfn-lambda.json
@@ -2,7 +2,8 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Effect": "Allow", "Action": [
+      "Effect": "Allow",
+      "Action": [
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents"

--- a/iam/policy-templates/dss-s3-copy-write-metadata-sfn-lambda.json
+++ b/iam/policy-templates/dss-s3-copy-write-metadata-sfn-lambda.json
@@ -48,6 +48,13 @@
           "xray:PutTraceSegments"
       ],
       "Resource": "*"
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:*"
+        ],
+        "Resource": "arn:aws:dynamodb:*:$account_id:table/dss-async-state-$stage"
     }
   ]
 }

--- a/tests/fixtures/cloud_uploader.py
+++ b/tests/fixtures/cloud_uploader.py
@@ -77,6 +77,7 @@ class S3Uploader(Uploader):
             content_type: str = "application/octet-stream",
             metadata_keys: typing.Dict[str, str] = None,
             tags: typing.Dict[str, str] = None,
+            s3_part_size: int = None,
             *args,
             **kwargs) -> None:
         if metadata_keys is None:
@@ -87,10 +88,12 @@ class S3Uploader(Uploader):
         fp = os.path.join(self.local_root, local_path)
         sz = os.stat(fp).st_size
 
-        chunk_sz = get_s3_multipart_chunk_size(sz)
+        if s3_part_size is None:
+            s3_part_size = get_s3_multipart_chunk_size(sz)
+
         transfer_config = TransferConfig(
             multipart_threshold=MULTIPART_THRESHOLD,
-            multipart_chunksize=chunk_sz,
+            multipart_chunksize=s3_part_size,
         )
 
         logger.info(f"Uploading {local_path} to s3://{self.bucket}/{remote_path}")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import time
 import datetime
 import hashlib
 import json
@@ -140,14 +141,15 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
             uploader_class: typing.Type[Uploader],
             bucket: str,
             key: str,
-            data: bytes) -> None:
+            data: bytes,
+            s3_part_size: int = None) -> None:
         tempdir = tempfile.gettempdir()
         uploader = uploader_class(tempdir, bucket)
         with tempfile.NamedTemporaryFile(delete=True) as fh:
             fh.write(data)
             fh.flush()
 
-            uploader.checksum_and_upload_file(fh.name, key, "text/plain")
+            uploader.checksum_and_upload_file(fh.name, key, "text/plain", s3_part_size=s3_part_size)
 
     @testmode.standalone
     def test_file_put_large_sync(self):
@@ -203,6 +205,56 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
                         }
                     )
                     self.assertIn('version', resp_obj.json)
+
+    @testmode.integration
+    def test_file_put_large_incorrect_s3_etag(self) -> None:
+        bucket = self.s3_test_bucket
+        src_key = generate_test_key()
+        src_data = os.urandom(ASYNC_COPY_THRESHOLD + 1)
+
+        # upload file with incompatible s3 part size
+        self._upload_file_to_mock_ingest(S3Uploader, bucket, src_key, src_data, s3_part_size=6 * 1024 * 1024)
+
+        file_uuid = str(uuid.uuid4())
+        timestamp = datetime.datetime.utcnow()
+        file_version = datetime_to_version_format(timestamp)
+        url = UrlBuilder().set(path=f"/v1/files/{file_uuid}")
+        url.add_query("version", file_version)
+        source_url = f"s3://{bucket}/{src_key}"
+
+        # put file into DSS, starting an async copy which will fail
+        expected_codes = requests.codes.accepted,
+        self.assertPutResponse(
+            str(url),
+            expected_codes,
+            json_request_body=dict(
+                file_uuid=file_uuid,
+                creator_uid=0,
+                source_url=source_url,
+            ),
+        )
+
+        # should eventually get unprocessable after async copy fails
+        start_time = time.time()
+        timeout = 120
+        while True:
+            time.sleep(1)
+            if time.time() - start_time > timeout:
+                break
+            try:
+                self.assertHeadResponse(
+                    f"/v1/files/{file_uuid}?replica=aws&version={file_version}",
+                    requests.codes.unprocessable)
+                break
+            except AssertionError:
+                pass
+        else:
+            self.fail("Never got expected 'unprocessable' response")
+
+        # should get unprocessable on GCP too
+        self.assertHeadResponse(
+            f"/v1/files/{file_uuid}?replica=gcp&version={file_version}",
+            requests.codes.unprocessable)
 
     # This is a test specific to AWS since it has separate notion of metadata and tags.
     @testmode.standalone


### PR DESCRIPTION
Stash copy sfn errors into async state and raise on GET or HEAD /file.

depends on #1705 
fixes #1616 