### PR TITLE
State that terraform is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ git clone git@github.com:HumanCellAtlas/data-store.git
 cd data-store
 pip install -r requirements-dev.txt
 ```
+
+Also install [terraform from Hashicorp](https://www.terraform.io/) from your favourite package manager.
+
 ### Configuration
 
 The DSS is configured via environment variables. The required environment variables and their default values


### PR DESCRIPTION
Otherwise "make deploy-infra" will fail with:

```
$ make deploy-infra
make -C infra apply-all
make[1]: Entering directory '/home/ubuntu/data-store/infra'
make[2]: Entering directory '/home/ubuntu/data-store/infra'
rm -rf buckets/.terraform/*.tfstate
./build_deploy_config.py buckets
cd buckets; terraform init;
/bin/sh: 1: terraform: not found
make[2]: *** [Makefile:45: init] Error 127
make[2]: Leaving directory '/home/ubuntu/data-store/infra'
make[1]: *** [Makefile:17: apply-all] Error 1
make[1]: Leaving directory '/home/ubuntu/data-store/infra'
make: *** [Makefile:80: deploy-infra] Error 2
```