### PR TITLE
Optional Audit logging for DSS in AWS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,17 @@ test-deploy-test cycle after this (the test after the deploy is required to test
         # do stuff     
     ```
 
+### Audit Logs
+The DSS uses AWS Cloudtrail and S3 to manage audit logs. By default audit logs are disable, but can be abled by setting 
+`ENABLE_AUDIT_LOGS` to 0 in the [environment file](environment) and providing a name for `DSS_AUDIT_LOGS_BUCKET`. The 
+Cloudtrail and S3 bucket will then be created by re-running `make deploy-infra`. Do not enable audit logs until after 
+you have sucesfully deployed the DSS at least once otherwise it will fail. This is because not all of the resources 
+monitored by the Cloudtrail are created until after the first `make deploy` is run. Specifically the AWS Lambdas which
+are deployed by chalice during `make deploy` and are not managed by terraform.
+
+The Audit logs monitor any managements changes in the AWS account, object read/write in the S3 replica, and invokation 
+of DSS-API and DSS-ADMIN Lambdas.
+
 ### Enabling Profiling
 AWS Xray tracing is used for profiling the performance of deployed lambdas. This can be enabled for `chalice/app.py` by 
 setting the lambda environment variable `DSS_XRAY_TRACE=1`. For all other daemons you must also check 

--- a/README.md
+++ b/README.md
@@ -370,14 +370,14 @@ test-deploy-test cycle after this (the test after the deploy is required to test
     ```
 
 ### Audit Logs
-The DSS uses AWS Cloudtrail and S3 to manage audit logs. By default audit logs are disable, but can be abled by setting 
+The DSS uses AWS Cloudtrail and S3 to manage audit logs. By default audit logs are disabled, but can be abled by setting 
 `ENABLE_AUDIT_LOGS` to 0 in the [environment file](environment) and providing a name for `DSS_AUDIT_LOGS_BUCKET`. The 
 Cloudtrail and S3 bucket will then be created by re-running `make deploy-infra`. Do not enable audit logs until after 
-you have sucesfully deployed the DSS at least once otherwise it will fail. This is because not all of the resources 
+you have successfully deployed the DSS at least once otherwise it will fail. This is because not all of the resources 
 monitored by the Cloudtrail are created until after the first `make deploy` is run. Specifically the AWS Lambdas which
 are deployed by chalice during `make deploy` and are not managed by terraform.
 
-The Audit logs monitor any managements changes in the AWS account, object read/write in the S3 replica, and invokation 
+The Audit logs monitor any managements changes in the AWS account, object read/write in the S3 replica, and invocation 
 of DSS-API and DSS-ADMIN Lambdas.
 
 ### Enabling Profiling

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -69,3 +69,5 @@ Environment Variable | Description
 `DSS_GCP_SERVICE_ACCOUNT_NAME` | "travis-test"
 `DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS` | This list manages the GCP Users and serviceAccounts able to access direct URLs on the GS checkout bucket. Other GCP entities must use presigned urls, or checkout to an external GS bucket they have access to. 
 `AWS_SDK_LOAD_CONFIG` | Needed for Terraform to correctly use AWS assumed roles
+`ENABLE_AUDIT_LOGS` | Determines if an AWS cloud trial log group will be created for audit logs. 0 means it will not be created. 1 means it will be created. The default value is 0. 
+`DSS_AUDIT_LOGS_BUCKET`| The name of the S3 bucket created to store the audit logs in.

--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -69,5 +69,5 @@ Environment Variable | Description
 `DSS_GCP_SERVICE_ACCOUNT_NAME` | "travis-test"
 `DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS` | This list manages the GCP Users and serviceAccounts able to access direct URLs on the GS checkout bucket. Other GCP entities must use presigned urls, or checkout to an external GS bucket they have access to. 
 `AWS_SDK_LOAD_CONFIG` | Needed for Terraform to correctly use AWS assumed roles
-`ENABLE_AUDIT_LOGS` | Determines if an AWS cloud trial log group will be created for audit logs. 0 means it will not be created. 1 means it will be created. The default value is 0. 
+`ENABLE_AUDIT_LOGS` | Determines if an AWS cloud trial log group will be created for audit logs. 0 means it will not be created. 1 means it will be created. The default value is 0. Warning: Do not enable audit logs until after you have succesfully deployed the DSS at least once otherwise it will fail.
 `DSS_AUDIT_LOGS_BUCKET`| The name of the S3 bucket created to store the audit logs in.

--- a/environment
+++ b/environment
@@ -104,6 +104,7 @@ ES_ALLOWED_SOURCE_IP_SECRETS_NAME="es_source_ip"
 DSS_DEBUG=0
 
 # Enable audit logs by setting ENABLE_AUDIT_LOGS to 1, and specifying the name of the bucket to store logs in.
+# Warning: Do not enable audit logs until after you have succesfully deployed the DSS at least once otherwise it will fail.
 ENABLE_AUDIT_LOGS=1
 DSS_AUDIT_LOGS_BUCKET=dss-audit-logs
 

--- a/environment
+++ b/environment
@@ -103,6 +103,10 @@ GOOGLE_APPLICATION_SECRETS_SECRETS_NAME="application_secrets.json"
 ES_ALLOWED_SOURCE_IP_SECRETS_NAME="es_source_ip"
 DSS_DEBUG=0
 
+# Enable audit logs by setting ENABLE_AUDIT_LOGS to 1, and specifying the name of the bucket to store logs in.
+ENABLE_AUDIT_LOGS=1
+DSS_AUDIT_LOGS_BUCKET=dss-audit-logs
+
 # `{account_id}`, if present, will be replaced with the account ID associated with the AWS credentials used for
 # deployment. It can be safely omitted.
 DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE="org-humancellatlas-{account_id}-terraform"

--- a/infra/build_deploy_config.py
+++ b/infra/build_deploy_config.py
@@ -87,6 +87,8 @@ env_vars_to_infra = [
     "DSS_ZONE_NAME",
     "ES_ALLOWED_SOURCE_IP_SECRETS_NAME",
     "GCP_DEFAULT_REGION",
+    "ENABLE_AUDIT_LOGS",
+    "DSS_AUDIT_LOGS_BUCKET"
 ]
 
 with open(os.path.join(infra_root, args.component, "backend.tf"), "w") as fp:

--- a/infra/cloudtrail/audit_trail.tf
+++ b/infra/cloudtrail/audit_trail.tf
@@ -4,6 +4,7 @@ resource aws_s3_bucket dss_audit_logs
   bucket = "${var.DSS_AUDIT_LOGS_BUCKET}"
   tags {
     managedby = "terraform"
+    application = "DSS"
   }
   server_side_encryption_configuration {
     rule {
@@ -43,9 +44,7 @@ resource "aws_cloudtrail" "dss" {
 
     data_resource {
       type = "AWS::Lambda::Function"
-      values = [
-        "arn:aws:lambda:::function:dss-admin-${var.DSS_DEPLOYMENT_STAGE}",
-        "arn:aws:lambda:::function:dss-${var.DSS_DEPLOYMENT_STAGE}"]
+      values = ["arn:aws:lambda:::function:dss-admin-${var.DSS_DEPLOYMENT_STAGE}"]
     }
     data_resource {
       type   = "AWS::S3::Object"
@@ -54,5 +53,6 @@ resource "aws_cloudtrail" "dss" {
   }
   tags {
     managedby = "terraform"
+    application = "DSS"
   }
 }

--- a/infra/cloudtrail/audit_trail.tf
+++ b/infra/cloudtrail/audit_trail.tf
@@ -1,0 +1,59 @@
+resource aws_s3_bucket dss_audit_logs
+{
+  count = "${var.ENABLE_AUDIT_LOGS == 1 ? 1 : 0}"
+  bucket = "${var.DSS_AUDIT_LOGS_BUCKET}"
+  tags {
+    managedby = "terraform"
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "AES256"
+      }
+    }
+  }
+  lifecycle_rule {
+    id      = "logs"
+    enabled = true
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+    expiration {
+      days          = 1096  # Three Years
+    }
+  }
+}
+
+resource "aws_cloudtrail" "dss" {
+  count = "${var.ENABLE_AUDIT_LOGS == 1 ? 1 : 0}"
+  name = "dss-audit-trail"
+  s3_bucket_name = "${aws_s3_bucket.dss_audit_logs.bucket}"
+  s3_key_prefix = "aws"
+  enable_log_file_validation = true
+  include_global_service_events = true
+
+  event_selector {
+    read_write_type = "All"
+    include_management_events = true
+
+    data_resource {
+      type = "AWS::Lambda::Function"
+      values = [
+        "arn:aws:lambda:::function:dss-admin-${var.DSS_DEPLOYMENT_STAGE}",
+        "arn:aws:lambda:::function:dss-${var.DSS_DEPLOYMENT_STAGE}"]
+    }
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3:::${var.DSS_S3_BUCKET}"]
+    }
+  }
+  tags {
+    managedby = "terraform"
+  }
+}

--- a/infra/cloudtrail/audit_trail.tf
+++ b/infra/cloudtrail/audit_trail.tf
@@ -34,7 +34,6 @@ resource "aws_cloudtrail" "dss" {
   count = "${var.ENABLE_AUDIT_LOGS == 1 ? 1 : 0}"
   name = "dss-audit-trail"
   s3_bucket_name = "${aws_s3_bucket.dss_audit_logs.bucket}"
-  s3_key_prefix = "aws"
   enable_log_file_validation = true
   include_global_service_events = true
 


### PR DESCRIPTION
- Adding terraform script to enable audit logging for AWS resource
- Update documentation with instruction on how to enable audit logging
- Added environment variable to toggle audit logging
- Updated documentation for new environment variables.

- connects to #1667 

### Test plan
Tested the terraform plan, and verified the logs were generated.

### Release notes
- can now toggle audit logging for the DSS.