### PR TITLE
Convenience function for temporary local storage of gcp credentials

### DIFF
--- a/dss/util/__init__.py
+++ b/dss/util/__init__.py
@@ -1,5 +1,9 @@
+import os
+import boto3
+import tempfile
 from urllib.parse import SplitResult, parse_qsl, urlencode, urlsplit, urlunsplit
 import typing
+from functools import lru_cache
 
 
 def paginate(boto3_paginator, *args, **kwargs):
@@ -104,3 +108,23 @@ def reject(condition: bool, *args, exception: type = RequirementError):
     """
     if condition:
         raise exception(*args)
+
+
+@lru_cache()
+def get_gcp_credentials_file():
+    """
+    Aquire GCP credentials from AWS secretsmanager and write them to a temporary file.
+    A reference to the temporary file is saved in lru_cache so it is not cleaned up
+    before a GCP client, which expects a credentials file in the file system, is instantiated.
+
+    Normal usage is local execution. For cloud execution (AWS Lambda, etc.),
+    credentials are typically available at GOOGLE_APPLICATION_CREDENTIALS.
+    """
+    secret_store = os.environ['DSS_SECRETS_STORE']
+    stage = os.environ['DSS_DEPLOYMENT_STAGE']
+    secret_id = f"{secret_store}/{stage}/gcp-credentials.json"
+    resp = boto3.client("secretsmanager").get_secret_value(SecretId=secret_id)
+    tf = tempfile.NamedTemporaryFile("w")
+    tf.write(resp['SecretString'])
+    tf.flush()
+    return tf

--- a/scripts/deploy_gcf.py
+++ b/scripts/deploy_gcf.py
@@ -8,7 +8,6 @@ import os, sys, time, io, zipfile, random, string, binascii, datetime, argparse,
 import json
 import boto3
 import socket
-import tempfile
 import httplib2
 import google.cloud.storage
 import google.cloud.exceptions
@@ -16,6 +15,12 @@ from apitools.base.py import http_wrapper
 from google.cloud.client import ClientWithProject
 from google.cloud._http import JSONConnection
 from urllib3.util.retry import Retry
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+import dss
+import dss.util
 
 class GCPClient(ClientWithProject):
     SCOPE = ["https://www.googleapis.com/auth/cloud-platform",
@@ -38,17 +43,7 @@ args = parser.parse_args()
 args.gcf_name = "-".join([args.src_dir, os.environ["DSS_DEPLOYMENT_STAGE"]])
 
 gcp_region = os.environ["GCP_DEFAULT_REGION"]
-with tempfile.NamedTemporaryFile() as fp:
-    creds = boto3.client("secretsmanager").get_secret_value(
-        SecretId='{}/{}/{}'.format(
-            os.environ['DSS_SECRETS_STORE'],
-            os.environ['DSS_DEPLOYMENT_STAGE'],
-            "gcp-credentials.json"
-        )
-    )['SecretString']
-    fp.write(creds.encode("utf-8"))
-    fp.flush()
-    gcp_client = GCPClient.from_service_account_json(fp.name)
+gcp_client = GCPClient(dss.util.get_gcp_credentials_file().name)
 gcp_client._http.adapters["https://"].max_retries = Retry(status_forcelist={503, 504})
 grtc_conn = GoogleRuntimeConfigConnection(client=gcp_client)
 gcf_conn = GoogleCloudFunctionsConnection(client=gcp_client)


### PR DESCRIPTION
This is useful for local testing and local scripting requiring GCP service credentials.