### PR TITLE
Restrict encryption to only certain buckets.

### DIFF
--- a/infra/buckets/s3.tf
+++ b/infra/buckets/s3.tf
@@ -13,9 +13,6 @@ resource aws_s3_bucket dss_s3_bucket {
 resource aws_s3_bucket dss_s3_bucket_test {
   count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_BUCKET_TEST}"
-  server_side_encryption_configuration {
-    rule {apply_server_side_encryption_by_default {sse_algorithm = "AES256"}}
-  }
   lifecycle_rule {
     id = "prune old things"
     enabled = true
@@ -33,9 +30,6 @@ resource aws_s3_bucket dss_s3_bucket_test {
 resource aws_s3_bucket dss_s3_bucket_test_fixtures {
   count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_BUCKET_TEST_FIXTURES}"
-  server_side_encryption_configuration {
-    rule {apply_server_side_encryption_by_default {sse_algorithm = "AES256"}}
-  }
   tags {
     CreatedBy = "Terraform"
     Application = "DSS"
@@ -78,9 +72,6 @@ resource aws_s3_bucket dss_s3_checkout_bucket {
 resource aws_s3_bucket dss_s3_checkout_bucket_test {
   count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_CHECKOUT_BUCKET_TEST}"
-  server_side_encryption_configuration {
-    rule {apply_server_side_encryption_by_default {sse_algorithm = "AES256"}}
-  }
   lifecycle_rule {
     id = "dss_checkout_expiration"
     enabled = true
@@ -98,9 +89,6 @@ resource aws_s3_bucket dss_s3_checkout_bucket_test {
 resource aws_s3_bucket dss_s3_checkout_bucket_unwritable {
   count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE}"
-  server_side_encryption_configuration {
-    rule {apply_server_side_encryption_by_default {sse_algorithm = "AES256"}}
-  }
   tags {
     CreatedBy = "Terraform"
     Application = "DSS"


### PR DESCRIPTION
Merging #1755 added encryption at rest for all buckets.  It's easier to do this a few buckets at a time so I'm reverting a few of these.  They'll be added back later when the bucket contents have been transferred.