### PR TITLE
Error returned if partial results are returned.

### DIFF
--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -70,6 +70,10 @@ def post(json_request_body: dict,
                            "internal_server_error",
                            "Elasticsearch Internal Server Error")
     else:
+        if page['_shards']['failed'] != 0:
+            raise DSSException(requests.codes.internal_server_error, "internal_server_error",
+                               f"Elasticsearch: {page['_shards']['failed']} "
+                               f"of {page['_shards']['total']} shards failed.")
         request_dict = _format_request_body(page, es_query, replica_enum, output_format)
         request_body = jsonify(request_dict)
 


### PR DESCRIPTION
Checking that all shards returned successfully to preventing partial search result from being returned. 

### Test plan
None
### Deployment instructions & migrations
None
### Release notes
Search will return an internal_server error if partial search results were retrieved due to shard failure.
Fixes #1770

