### PR TITLE
Parameterize SSM store name in environment

### DIFF
--- a/docs/environment/README.md
+++ b/docs/environment/README.md
@@ -51,11 +51,12 @@ Environment Variable | Description
 `DSS_CERTIFICATE_VALIDATION` | Validation method for the https certificate.
 `DSS_ZONE_NAME` | Name of the route53 zone containing the domain name.
 `PYTHONWARNINGS` | 
-`DSS_SECRETS_STORE` | The prefix for DSS secrets stored in aws secrets manager.
+`DSS_SECRETS_STORE` | The prefix for DSS secrets stored in AWS Secrets Manager.
+`DSS_PARAMETER_STORE` | The prefix for DSS parameters stored in AWS Systems Manager.
 `EVENT_RELAY_AWS_USERNAME` | The name of the AWS IAM user authorized for the GCP->AWS event relay.
-`EVENT_RELAY_AWS_ACCESS_KEY_SECRETS_NAME` | The name of the secret stored in aws secrets manager.
-`GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME` | The name of the secret stored in aws secrets manager.
-`GOOGLE_APPLICATION_SECRETS_SECRETS_NAME` | The name of the secret stored in aws secrets manager.
+`EVENT_RELAY_AWS_ACCESS_KEY_SECRETS_NAME` | The name of the secret stored in AWS Secrets Manager.
+`GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME` | The name of the secret stored in AWS Secrets Manager.
+`GOOGLE_APPLICATION_SECRETS_SECRETS_NAME` | The name of the secret stored in AWS Secrets Manager.
 `ES_ALLOWED_SOURCE_IP_SECRETS_NAME` | Source IP access list for the AWS Elasticsearch cluster. This should be a comma seperated list of IPs.
 `DSS_DEBUG` | An interger specifying the log level. See [dss.logging](https://github.com/HumanCellAtlas/data-store/blob/c61e2cf000bf64e54a572f5dc29807feb8ee34c6/dss/logging.py#L31).
 `DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE` | "dss-config-{account_id}" - `{account_id}`, if present, will be replaced with the account ID associated with the AWS credentials used for deployment. It can be safely omitted.

--- a/environment
+++ b/environment
@@ -95,6 +95,7 @@ DSS_CERTIFICATE_VALIDATION="EMAIL"
 DSS_ZONE_NAME="dev.data.humancellatlas.org."
 PYTHONWARNINGS=ignore:ResourceWarning,ignore::UserWarning:zipfile:
 DSS_SECRETS_STORE="dcp/dss"
+DSS_PARAMETER_STORE="dcp/dss"
 EVENT_RELAY_AWS_USERNAME="dss-event-relay-${DSS_DEPLOYMENT_STAGE}"
 EVENT_RELAY_AWS_ACCESS_KEY_SECRETS_NAME="event-relay-user-aws-access-key"
 GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME="gcp-credentials.json"

--- a/scripts/populate_lambda_ssm_parameters.py
+++ b/scripts/populate_lambda_ssm_parameters.py
@@ -28,7 +28,7 @@ def get_local_lambda_environment():
 
 def get_ssm_lambda_environment():
     parms = ssm_client.get_parameter(
-        Name=f"/dcp/dss/{os.environ['DSS_DEPLOYMENT_STAGE']}/environment"
+        Name=f"/{os.environ['DSS_PARAMETER_STORE']}/{os.environ['DSS_DEPLOYMENT_STAGE']}/environment"
     )['Parameter']['Value']
     return json.loads(parms)
 


### PR DESCRIPTION
This is needed for non-DCP deployments to use their own SSM parameter store.