### PR TITLE
Add the current bucket policy into the terraform script.

### DIFF
--- a/infra/buckets/s3.tf
+++ b/infra/buckets/s3.tf
@@ -10,6 +10,36 @@ resource aws_s3_bucket dss_s3_bucket {
   }
 }
 
+resource aws_s3_bucket_policy dss_s3_bucket {
+  bucket = "${var.DSS_S3_BUCKET}"
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "deletion",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:Delete*",
+            "Resource": [
+                "arn:aws:s3:::${var.DSS_S3_BUCKET}/*",
+                "arn:aws:s3:::${var.DSS_S3_BUCKET}"
+            ],
+            "Condition": {
+                "StringNotLike": {
+                    "aws:userId": [
+                        "AROAJ23BFIAHUA2LYWH7O:*",
+                        "AROAIMNTAUAUQTOHJIYCK:*",
+                        "AROAJNRWW7RYZ4IDKDFIK:*"
+                    ]
+                }
+            }
+        }
+    ]
+}
+POLICY
+}
+
 resource aws_s3_bucket dss_s3_bucket_test {
   count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
   bucket = "${var.DSS_S3_BUCKET_TEST}"


### PR DESCRIPTION
Not sure exactly why terraform would complain about this now, but this does fix the current deployment error by adding in the policy present on the buckets into the terrrafom script.

I may have missed something though, @xbrianh , could you take a look?