### PR TITLE
Update infra defs for prod

### DIFF
--- a/environment.prod
+++ b/environment.prod
@@ -9,11 +9,14 @@ DSS_GS_CHECKOUT_BUCKET=$DSS_GS_CHECKOUT_BUCKET_PROD
 DSS_ES_DOMAIN="dss-index-$DSS_DEPLOYMENT_STAGE"
 DCP_DOMAIN=data.humancellatlas.org
 API_DOMAIN_NAME="dss.${DCP_DOMAIN}"
+DSS_CERTIFICATE_ADDITIONAL_NAMES=""
+DSS_CERTIFICATE_DOMAIN="*.data.humancellatlas.org"
+DSS_CERTIFICATE_VALIDATION=""  # cert validation not TF managed in prod
 DSS_GCP_SERVICE_ACCOUNT_NAME="org-humancellatlas-prod"
 DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE="org-humancellatlas-109067257620-terraform"
 DSS_ZONE_NAME="${DCP_DOMAIN}."
 DSS_ES_INSTANCE_COUNT="3"
-DSS_ES_VOLUME_SIZE="1500"
+DSS_ES_VOLUME_SIZE="512"  # Maximum volume size for m4.large.elasticsearch
 DSS_AUTHORIZED_DOMAINS="hca-dcp-production.iam.gserviceaccount.com hca-dcp-pipelines-prod.iam.gserviceaccount.com ${DSS_AUTHORIZED_DOMAINS}"
 set +a
 

--- a/infra/domain/main.tf
+++ b/infra/domain/main.tf
@@ -34,6 +34,7 @@ resource "aws_acm_certificate_validation" "cert_email" {
 #   Terraform does not currently support regional API Gateway endpoints:
 #   https://github.com/terraform-providers/terraform-provider-aws/issues/2195
 resource null_resource dss_domain {
+  count  = "${length(var.DSS_CERTIFICATE_VALIDATION ) > 0 ? 1 : 0}"
   provisioner "local-exec" {
     command = "./create_regional_domain_name.py --domain-name ${var.API_DOMAIN_NAME} --certificate-arn ${aws_acm_certificate.cert.arn} --zone-id ${data.aws_route53_zone.selected.zone_id}"
   }


### PR DESCRIPTION
- Increase ES volume size to max for cluster
- Don't manage cert validation through TF

The prod domain and certificate was not created through Terraform, cannot be straightforwardly imported into the Terraform state file, and there appears to be little value in managing it through Terraform.