### PR TITLE
Put admin user emails in SSM store

### DIFF
--- a/chalice/build_deploy_config.sh
+++ b/chalice/build_deploy_config.sh
@@ -57,14 +57,5 @@ if [[ ${CI:-} == true ]]; then
     cat "$config_json" | jq .manage_iam_role=false | jq .iam_role_arn=env.iam_role_arn | sponge "$config_json"
 fi
 
-# Add service account email to list of authorized emails for ci-cd testing.
-service_account_email=`jq -r ".client_email" chalicelib/gcp-credentials.json`
-admin_user_emails_length=${#ADMIN_USER_EMAILS}
-if [[ $admin_user_emails_length>0 ]]; then
-	export ADMIN_USER_EMAILS="${ADMIN_USER_EMAILS},${service_account_email}"
-else
-	export ADMIN_USER_EMAILS="${service_account_email}"
-fi
-
 cat "$iam_policy_template" | envsubst '$DSS_S3_BUCKET $DSS_S3_CHECKOUT_BUCKET $dss_es_domain $account_id $stage' > "$policy_json"
 cp "$policy_json" "$stage_policy_json"

--- a/daemons/package_daemon.sh
+++ b/daemons/package_daemon.sh
@@ -27,13 +27,4 @@ cp -R ../dss ../dss-api.yml $daemon/domovoilib
 aws secretsmanager get-secret-value --secret-id ${DSS_SECRETS_STORE}/${DSS_DEPLOYMENT_STAGE}/gcp-credentials.json \
     | jq -r .SecretString > $daemon/domovoilib/gcp-credentials.json
 
-# Add service account email to list of authorized emails for ci-cd testing.
-service_account_email=`jq -r ".client_email" $daemon/domovoilib/gcp-credentials.json`
-admin_user_emails_length=${#ADMIN_USER_EMAILS}
-if [[ $admin_user_emails_length > 0 ]]; then
-	export ADMIN_USER_EMAILS="${ADMIN_USER_EMAILS},${service_account_email}"
-else
-	export ADMIN_USER_EMAILS="${service_account_email}"
-fi
-
 chmod -R ugo+rX $daemon/domovoilib


### PR DESCRIPTION
This fixes a bug causing ADMIN_USER_EMAILS to be set to an empty string during deploy.