### PR TITLE
Update domovoi and change naming to reflect changes in domovoi.

### DIFF
--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -109,7 +109,7 @@
         "arn:aws:es:*:$account_id:domain/dss-index-integration", "arn:aws:es:*:$account_id:domain/dss-index-integration/*",
         "arn:aws:es:*:$account_id:domain/dss-index-staging", "arn:aws:es:*:$account_id:domain/dss-index-staging/*",
         "arn:aws:sns:*:$account_id:dss-*",
-        "arn:aws:sns:*:$account_id:domovoi-s3-bucket-events-*",
+        "arn:aws:sns:*:$account_id:domovoi-s3-events-*",
         "arn:aws:states:*:$account_id:*:dss-*"
       ],
       "Effect": "Allow"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ cryptography==2.4.2
 dcplib==1.4.0
 dnspython==1.16.0
 docutils==0.14
-domovoi==1.8.3
+domovoi==1.9.0
 elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 enum-compat==0.0.2

--- a/scripts/deploy_gcf.py
+++ b/scripts/deploy_gcf.py
@@ -61,7 +61,7 @@ aws_access_key_info = json.loads(
 
 boto3_session = boto3.session.Session()
 aws_account_id = boto3.client("sts").get_caller_identity()["Account"]
-relay_sns_topic_name = "dss-gs-bucket-events-" + os.environ["DSS_GS_BUCKET"]
+relay_sns_topic_name = "dss-gs-events-" + os.environ["DSS_GS_BUCKET"]
 relay_sns_topic = boto3_session.resource("sns").create_topic(Name=relay_sns_topic_name)
 
 sync_sqs_queue_name = "dss-sync-" + os.environ["DSS_DEPLOYMENT_STAGE"]


### PR DESCRIPTION
Bumps the version and fixes an excessively long name that caused an error as the queue name (80+ chars): https://github.com/kislyuk/domovoi/commit/b976b873aa742699514ff49cea90e399a1a40682

Domovoi only changes s3.  I've changed both s3 and gs to reflect the new naming here.