### PR TITLE
Adding negative test cases to deleted from replicas

### DIFF
--- a/tests/test_gshcablobstore.py
+++ b/tests/test_gshcablobstore.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # coding: utf-8
-
+import google
+import io
 import os
 import sys
 import unittest
 
+from cloud_blobstore import BlobNotFoundError
 from cloud_blobstore.gs import GSBlobStore
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
@@ -17,6 +19,7 @@ from tests.hcablobstore_base import HCABlobStoreTests
 
 class TestGSHCABlobStore(unittest.TestCase, HCABlobStoreTests):
     def setUp(self):
+        self.bucket = infra.get_env("DSS_GS_BUCKET")
         self.credentials = infra.get_env("GOOGLE_APPLICATION_CREDENTIALS")
         self.test_bucket = infra.get_env("DSS_GS_BUCKET_TEST")
         self.test_fixtures_bucket = infra.get_env("DSS_GS_BUCKET_TEST_FIXTURES")
@@ -25,6 +28,23 @@ class TestGSHCABlobStore(unittest.TestCase, HCABlobStoreTests):
 
     def tearDown(self):
         pass
+
+    def test_delete_object(self):
+        file_name = 'Deletion_test.txt'
+        # reupload the test file if it was deleted
+        try:
+            self.blobhandle.get_content_type(self.bucket, file_name)
+        except BlobNotFoundError:
+            fobj = io.BytesIO(b"This should never be deleted by a test.")
+            self.blobhandle.upload_file_handle(self.bucket, file_name, fobj)
+
+        # Try deleting the file from the replica. This should fail.
+        try:
+            self.blobhandle.delete(self.bucket, file_name)
+        except google.api_core.exceptions.Forbidden as ex:
+            self.assertEqual(ex.response.status_code, 403)
+        else:
+            self.fail(f"Excepted 403")
 
 
 if __name__ == '__main__':

--- a/tests/test_s3hcablobstore.py
+++ b/tests/test_s3hcablobstore.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # coding: utf-8
-
+import io
 import os
 import sys
 import unittest
 
+import botocore
+from cloud_blobstore import BlobNotFoundError
 from cloud_blobstore.s3 import S3BlobStore
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
@@ -17,6 +19,7 @@ from tests.hcablobstore_base import HCABlobStoreTests
 
 class TestS3HCABlobStore(unittest.TestCase, HCABlobStoreTests):
     def setUp(self):
+        self.bucket = infra.get_env("DSS_S3_BUCKET")
         self.test_bucket = infra.get_env("DSS_S3_BUCKET_TEST")
         self.test_fixtures_bucket = infra.get_env("DSS_S3_BUCKET_TEST_FIXTURES")
         self.blobhandle = S3BlobStore.from_environment()
@@ -24,6 +27,23 @@ class TestS3HCABlobStore(unittest.TestCase, HCABlobStoreTests):
 
     def tearDown(self):
         pass
+
+    def test_delete_object(self):
+        file_name = 'Deletion_test.txt'
+        # reupload the test file if it was deleted
+        try:
+            self.blobhandle.get_content_type(self.bucket, file_name)
+        except BlobNotFoundError:
+            fobj = io.BytesIO(b"This should never be deleted by a test.")
+            self.blobhandle.upload_file_handle(self.bucket, file_name, fobj)
+
+        # Try deleting the file from the replica. This should fail.
+        try:
+            self.blobhandle.delete(self.bucket, file_name)
+        except botocore.exceptions.ClientError as ex:
+            self.assertEqual(ex.response["Error"]["Code"], '403')
+        else:
+            self.fail(f"Excepted 403")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Test plan
- Negative test cases have been added to verify that we are unable to delete from the main replica.
