### PR TITLE
Fixing search for tombstones

### DIFF
--- a/dss/index/es/document.py
+++ b/dss/index/es/document.py
@@ -362,6 +362,7 @@ class BundleTombstoneDocument(IndexDocument):
     def from_tombstone(cls, tombstone: Tombstone) -> 'BundleTombstoneDocument':
         self = cls(tombstone.replica, tombstone.fqid, tombstone.body)
         self['uuid'] = self.fqid.uuid
+        self['manifest'] = {'version': self.fqid.version}
         return self
 
 def prepare_filename(name: str) -> str:

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -5,6 +5,8 @@ from typing import Type
 BUNDLE_PREFIX = "bundles"
 FILE_PREFIX = "files"
 COLLECTION_PREFIX = "collections"
+# The value of TOMBSTONE_SUFFIX must be lexicographically greater than a VERSION string. This is ensure global and
+# versioned tombstones are indexed after all bundles during a reindex operation.
 TOMBSTONE_SUFFIX = "dead"
 
 UUID_PATTERN = "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"

--- a/tests/sample_vx_index_doc_tombstone.json
+++ b/tests/sample_vx_index_doc_tombstone.json
@@ -1,0 +1,9 @@
+{
+  "email": "test@test.com",
+  "reason": "disappeared", 
+  "admin_deleted": true,
+  "uuid": "2712e1e7-d276-4c56-b33f-ead49e50b19e",
+  "manifest": {
+    "version": "2019-01-18T190257.602413Z"
+  }
+}

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -241,7 +241,8 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             }
             search_results = self.get_search_results(exact_query, 1)
             self.assertEqual(1, len(search_results))
-            expected_search_result = dict(tombstone_data, uuid=tombstone_id.uuid)
+            tombstone = dss.index.bundle.Tombstone(self.replica, tombstone_id, tombstone_data)
+            expected_search_result = dss.index.es.document.BundleTombstoneDocument.from_tombstone(tombstone)
             self.assertDictEqual(search_results[0], expected_search_result)
 
     @testmode.standalone


### PR DESCRIPTION
### Test plan
added search test cases specifically related to tombstones and paging.

### Deployment instructions & migrations
Will require reindexing from the replicas. relates to #805 

### Release notes
Fixes #1771 
