### PR TITLE
[WIP] Fixing notify to send the tombstone doc when a bundle is deleted

### DIFF
--- a/dss/index/es/backend.py
+++ b/dss/index/es/backend.py
@@ -53,7 +53,7 @@ class ElasticsearchIndexBackend(IndexBackend):
         tombstone_doc = BundleTombstoneDocument.from_tombstone(tombstone)
         modified, index_name = doc.entomb(tombstone_doc, dryrun=self.dryrun)
         if self.notify or modified and self.notify is None:
-            self._notify(doc, index_name)
+            self._notify(tombstone_doc, index_name)
 
     def _notify(self, bundle, index_name):
         subscription_ids = self._find_matching_subscriptions(bundle, index_name)


### PR DESCRIPTION
Before this the notifier was sending the document that was tombstones, which result in an error when the users attempted to retrieve the doc.

### Test plan -->

<!-- Describe any special instructions to the operator who will deploy your code to the integration, 
     staging and production deployments. Uncomment below:
### Deployment instructions & migrations -->

### Release notes