### PR TITLE
notify tombstone

### DIFF
--- a/tests/sample_doc_tombstone.json
+++ b/tests/sample_doc_tombstone.json
@@ -1,0 +1,5 @@
+{
+  "email": "test@test.com",
+  "reason": "disappeared", 
+  "admin_deleted": true
+}

--- a/tests/sample_search_queries.py
+++ b/tests/sample_search_queries.py
@@ -20,3 +20,17 @@ smartseq2_paired_ends_vx_query = \
             }
         }
     }
+
+tombstone_query = {
+    "query": {
+        'bool': {
+            'must': [
+                {
+                    'match': {
+                        "admin_deleted": True
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/sample_search_queries.py
+++ b/tests/sample_search_queries.py
@@ -26,7 +26,7 @@ tombstone_query = {
         'bool': {
             'must': [
                 {
-                    'match': {
+                    'term': {
                         "admin_deleted": True
                     }
                 }

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -55,7 +55,7 @@ from tests import eventually, get_auth_header, get_bundle_fqid, get_file_fqid, g
 from tests.infra import DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, TestBundle, testmode
 from tests.infra.elasticsearch_test_case import ElasticsearchTestCase
 from tests.infra.server import ThreadedLocalServer
-from tests.sample_search_queries import smartseq2_paired_ends_vx_query
+from tests.sample_search_queries import smartseq2_paired_ends_vx_query, tombstone_query
 
 
 logger = logging.getLogger(__name__)
@@ -111,6 +111,8 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         cls.test_bucket = cls.replica.bucket
         cls.indexer_cls = Indexer.for_replica(cls.replica)
         cls.executor = ThreadPoolExecutor(len(DEFAULT_BACKENDS))
+        with open(os.path.join(os.path.dirname(__file__), "sample_doc_tombstone.json"), 'r') as fp:
+            cls.tombstone_data = json.load(fp)
 
     @classmethod
     def tearDownClass(cls):
@@ -182,15 +184,14 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
     def _create_tombstone(self, tombstone_id):
         blobstore = Config.get_blobstore_handle(self.replica)
         bucket = self.replica.bucket
-        tombstone_data = {"status": "disappeared"}
-        tombstone_data_bytes = io.BytesIO(json.dumps(tombstone_data).encode('utf-8'))
+        tombstone_data_bytes = io.BytesIO(json.dumps(self.tombstone_data).encode('utf-8'))
         # noinspection PyTypeChecker
         blobstore.upload_file_handle(bucket, tombstone_id.to_key(), tombstone_data_bytes)
         # Without this, the tombstone would break subsequent tests, due to the caching added in e12a5f7:
         self.addCleanup(self._delete_tombstone, tombstone_id)
         sample_event = self.create_bundle_deleted_event(tombstone_id.to_key())
         self._process_new_indexable_object_with_retry(sample_event)
-        return tombstone_data
+        return self.tombstone_data
 
     def _process_new_indexable_object_with_retry(self, sample_event, retry_method='index'):
         # Remove cached ES client instances (patching the class wouldn't affect them)
@@ -432,18 +433,18 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             self.process_new_indexable_object(sample_event)
             prefix, _, bundle_fqid = bundle_key.partition("/")
             self.verify_notification(subscription_id, smartseq2_paired_ends_vx_query, bundle_fqid, endpoint)
+        subscription_id_tombstone = self.subscribe_for_notification(es_query=tombstone_query, **endpoint.to_dict())
         with self.subTest("A notification is received when an indexing event for a deleted bundle version replica "
-                          "matching my subscription is received."):
+                          "matching my subscription for tombstones is received."):
             bundle_fqid = BundleFQID.from_key(bundle_key)
             tombstone_id = bundle_fqid.to_tombstone_id()
             self._create_tombstone(tombstone_id)
-            self.verify_notification(subscription_id, smartseq2_paired_ends_vx_query, str(bundle_fqid), endpoint)
-        self.delete_subscription(subscription_id)
+            self.verify_notification(subscription_id_tombstone, tombstone_query, str(bundle_fqid), endpoint)
 
     def delete_subscription(self, subscription_id):
         self.assertDeleteResponse(
             str(UrlBuilder().set(path=f"/v1/subscriptions/{subscription_id}").add_query("replica", self.replica.name)),
-            requests.codes.ok,
+            [requests.codes.ok, requests.codes.not_found],
             headers=get_auth_header())
 
     @testmode.always
@@ -963,6 +964,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                                           json_request_body=body,
                                           headers=get_auth_header())
         uuid_ = resp_obj.json['uuid']
+        self.addCleanup(self.delete_subscription, uuid_)
         return uuid_
 
     def verify_index_document_structure_and_content(self, actual_index_document, bundle_key, files):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -440,11 +440,13 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             tombstone_id = bundle_fqid.to_tombstone_id()
             self._create_tombstone(tombstone_id)
             self.verify_notification(subscription_id_tombstone, tombstone_query, str(bundle_fqid), endpoint)
+        self.delete_subscription(subscription_id)
+        self.delete_subscription(subscription_id_tombstone)
 
     def delete_subscription(self, subscription_id):
         self.assertDeleteResponse(
             str(UrlBuilder().set(path=f"/v1/subscriptions/{subscription_id}").add_query("replica", self.replica.name)),
-            [requests.codes.ok, requests.codes.not_found],
+            requests.codes.ok,
             headers=get_auth_header())
 
     @testmode.always
@@ -964,7 +966,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
                                           json_request_body=body,
                                           headers=get_auth_header())
         uuid_ = resp_obj.json['uuid']
-        self.addCleanup(self.delete_subscription, uuid_)
         return uuid_
 
     def verify_index_document_structure_and_content(self, actual_index_document, bundle_key, files):


### PR DESCRIPTION
This ensures that notifications are sent to a subscriber_id if the tombstoned bundle matches their query or if the subscriber is subscribed to tombstones.