### PR TITLE
Ignore cache objects when syncing

### DIFF
--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -38,6 +38,9 @@ def launch_from_s3_event(event, context):
         for event_record in event["Records"]:
             bucket = resources.s3.Bucket(event_record["s3"]["bucket"]["name"])
             obj = bucket.Object(unquote(event_record["s3"]["object"]["key"]))
+            if obj.key.startswith("cache"):
+                logger.info("Ignoring cache object")
+                continue
             if bucket.name != source_replica.bucket:
                 logger.error("Received S3 event for bucket %s with no configured replica", bucket.name)
                 continue


### PR DESCRIPTION
This gets rid of the following class of sync daemon error:
```
2019-01-23 19:26:30+00:00 Unknown prefix for key cache.1/3eecbe82f512d809efbcb817ae57bfe5c03dfd613eecbe82f512d809efbcb817ae57bfe5c03dfd61: NotImplementedError
Traceback (most recent call last):
  File "/var/task/domovoi/app.py", line 209, in __call__
    result = handler(event, context)
  File "/var/task/app.py", line 283, in check_deps
    if dependencies_exist(source_replica, dest_replica, event["source_key"]):
  File "/var/task/domovoilib/dss/events/handlers/sync.py", line 279, in dependencies_exist
    raise NotImplementedError("Unknown prefix for key {}".format(key))
NotImplementedError: Unknown prefix for key cache.1/3eecbe82f512d809efbcb817ae57bfe5c03dfd613eecbe82f512d809efbcb817ae57bfe5c03dfd61
```