### PR TITLE
Add s3:GetObjectTagging permissions to the visitation lambda explicitly.

### DIFF
--- a/iam/policy-templates/dss-visitation-lambda.json
+++ b/iam/policy-templates/dss-visitation-lambda.json
@@ -16,6 +16,7 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetObject",
+        "s3:GetObjectTagging",
         "s3:ListBucket",
         "s3:PutObject"
       ],


### PR DESCRIPTION
This fixes an issue with `integration` that occured during the bucket move.