### PR TITLE
[Easy] Sync logs INFO instead of ERROR for existing keys

### DIFF
--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -47,6 +47,8 @@ def launch_from_s3_event(event, context):
 
             for dest_replica in Config.get_replication_destinations(source_replica):
                 if exists(dest_replica, obj.key):
+                    # Logging error here causes daemons/invoke_lambda.sh to report failure, for some reason
+                    # - Brian Hannafious, 2019-01-31
                     logger.info("Key %s already exists in %s, skipping sync", obj.key, dest_replica)
                     continue
                 exec_name = bucket.name + "/" + obj.key + ":" + source_replica.name + ":" + dest_replica.name

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -47,7 +47,7 @@ def launch_from_s3_event(event, context):
 
             for dest_replica in Config.get_replication_destinations(source_replica):
                 if exists(dest_replica, obj.key):
-                    logger.error("Key %s already exists in %s, skipping sync", obj.key, dest_replica)
+                    logger.info("Key %s already exists in %s, skipping sync", obj.key, dest_replica)
                     continue
                 exec_name = bucket.name + "/" + obj.key + ":" + source_replica.name + ":" + dest_replica.name
                 exec_input = dict(source_replica=source_replica.name,


### PR DESCRIPTION
This appears to fix sync daemon deploy woes.

Perhaps the AWS CLI grabs Lambda output via Cloudwatch, causing logged errors to appear as Lambd failures?