### PR TITLE
Notification sent out for all versions of a deleted bundle

### DIFF
--- a/dss/index/es/backend.py
+++ b/dss/index/es/backend.py
@@ -49,11 +49,11 @@ class ElasticsearchIndexBackend(IndexBackend):
     @elasticsearch_retry(logger, timeout)
     def remove_bundle(self, bundle: Bundle, tombstone: Tombstone):
         elasticsearch_retry.add_context(tombstone=tombstone, bundle=bundle)
-        doc = BundleDocument.from_bundle(bundle)
+        original_doc = BundleDocument.from_bundle(bundle)
         tombstone_doc = BundleTombstoneDocument.from_tombstone(tombstone)
-        modified, index_name = doc.entomb(tombstone_doc, dryrun=self.dryrun)
+        modified, index_name, tombstoned_doc = original_doc.entomb(tombstone_doc, dryrun=self.dryrun)
         if self.notify or modified and self.notify is None:
-            self._notify(tombstone_doc, index_name)
+            self._notify(tombstoned_doc, index_name)
 
     def _notify(self, bundle, index_name):
         subscription_ids = self._find_matching_subscriptions(bundle, index_name)

--- a/dss/index/es/document.py
+++ b/dss/index/es/document.py
@@ -174,7 +174,7 @@ class BundleDocument(IndexDocument):
         return True, index_name
 
     @elasticsearch_retry(logger)
-    def entomb(self, tombstone: 'BundleTombstoneDocument', dryrun=False) -> typing.Tuple[bool, str]:
+    def entomb(self, tombstone: 'BundleTombstoneDocument', dryrun=False) -> typing.Tuple[bool, str, 'BundleDocument']:
         """
         Ensure that there is exactly one up-to-date instance of a tombstone for this document in exactly one
         ES index. The tombstone data overrides the document's data in the index.
@@ -192,7 +192,7 @@ class BundleDocument(IndexDocument):
         # … and place into proper index.
         modified, index_name = other._index_into(index_name, dryrun)
         logger.info(f"Finished writing tombstone for {self.replica.name} bundle: {self.fqid}")
-        return modified, index_name
+        return modified, index_name, other
 
     def _write_to_index(self, index_name: str, version: typing.Optional[int] = None):
         es_client = ElasticsearchClient.get()


### PR DESCRIPTION
- fixes #1866
- When a bundle delete is performed without the version specified, all bundles sharing that UUID are deleted. Notifications will be sent out for each version of that bundle that has been deleted when a bundle deletion for all version is processed.
- The LocalNotificationRequestHandler infrastructure was modified to track all notification received by the local notification server, and returns the requests in LIFO order.
- A new local test was added test_unversioned_tombstone_notifications