### PR TITLE
[WIP] User checkout bucket functionality.  Addresses #1760.

### DIFF
--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -12,7 +12,6 @@ from dss.storage.checkout.bundle import (get_bundle_checkout_status,
 
 @dss_handler
 def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
-
     assert replica
     _replica: Replica = Replica[replica]
     dst_bucket = json_request_body.get('destination', _replica.checkout_bucket)
@@ -35,7 +34,7 @@ def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
 
 @dss_handler
 def get(replica: str, checkout_job_id: str):
-    assert replica is not None
+    assert replica
     _replica = Replica[replica]
     try:
         response = get_bundle_checkout_status(checkout_job_id, _replica, _replica.checkout_bucket)

--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -13,11 +13,13 @@ from dss.storage.checkout.bundle import (get_bundle_checkout_status,
 @dss_handler
 def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
 
-    assert replica is not None
+    assert replica
     _replica: Replica = Replica[replica]
     dst_bucket = json_request_body.get('destination', _replica.checkout_bucket)
     if '/' in dst_bucket:
-        raise DSSException(400, "illegal_arguments", "Destination bucket invalid!  Please use 'example_bucket_name' instead of 's3://example_bucket_name' or 'gs://example_bucket_name' or 'example_bucket_name/key'.")
+        raise DSSException(400, "illegal_arguments", "Destination bucket invalid!  Please use 'example_bucket_name' "
+                                                     "instead of 's3://example_bucket_name', 'gs://example_bucket_name'"
+                                                     " or 'example_bucket_name/key'.")
     try:
         execution_id = start_bundle_checkout(
             _replica,

--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -5,7 +5,9 @@ from flask import jsonify
 from dss import dss_handler, Replica
 from dss.error import DSSException
 from dss.storage.checkout import BundleNotFoundError
-from dss.storage.checkout.bundle import get_bundle_checkout_status, start_bundle_checkout
+from dss.storage.checkout.bundle import (get_bundle_checkout_status,
+                                         get_bundle_checkout_destination,
+                                         start_bundle_checkout)
 
 
 @dss_handler

--- a/dss/api/bundles/checkout.py
+++ b/dss/api/bundles/checkout.py
@@ -17,7 +17,7 @@ def post(uuid: str, json_request_body: dict, replica: str, version: str = None):
     _replica: Replica = Replica[replica]
     dst_bucket = json_request_body.get('destination', _replica.checkout_bucket)
     if '/' in dst_bucket:
-        raise DSSException(400, "illegal_arguments", "Destination bucket invalid!")
+        raise DSSException(400, "illegal_arguments", "Destination bucket invalid!  Please use 'example_bucket_name' instead of 's3://example_bucket_name' or 'gs://example_bucket_name' or 'example_bucket_name/key'.")
     try:
         execution_id = start_bundle_checkout(
             _replica,

--- a/dss/stepfunctions/checkout/checkout_states.py
+++ b/dss/stepfunctions/checkout/checkout_states.py
@@ -121,11 +121,11 @@ def notify_complete(event, context):
             replica)
     # record results of execution into S3
     mark_bundle_checkout_successful(
-        event[EventConstants.EXECUTION_ID],
-        replica,
-        event[EventConstants.STATUS_BUCKET],
-        get_dst_bucket(event),
-        event[_InternalEventConstants.SCHEDULE][_InternalEventConstants.SCHEDULED_DST_LOCATION],
+        execution_id=event[EventConstants.EXECUTION_ID],
+        replica=replica,
+        sts_bucket=event[EventConstants.STATUS_BUCKET],
+        dst_bucket=get_dst_bucket(event),
+        dst_location=event[_InternalEventConstants.SCHEDULE][_InternalEventConstants.SCHEDULED_DST_LOCATION],
     )
     logger.info("Checkout completed successfully jobId %s", event[EventConstants.EXECUTION_ID])
     return {_InternalEventConstants.RESULT: result}
@@ -146,10 +146,12 @@ def notify_complete_failure(event, context):
         result = send_checkout_failure_email(dss.Config.get_notification_email(), event[EventConstants.EMAIL], cause)
     # record results of execution into S3
     mark_bundle_checkout_failed(
-        event[EventConstants.EXECUTION_ID],
-        Replica[event[EventConstants.REPLICA]],
-        event[EventConstants.STATUS_BUCKET],
-        cause,
+        execution_id=event[EventConstants.EXECUTION_ID],
+        replica=Replica[event[EventConstants.REPLICA]],
+        sts_bucket=event[EventConstants.STATUS_BUCKET],
+        dst_bucket=get_dst_bucket(event),
+        dst_location=event[_InternalEventConstants.SCHEDULE][_InternalEventConstants.SCHEDULED_DST_LOCATION],
+        cause=cause,
     )
     logger.info("Checkout failed jobId %s", event[EventConstants.EXECUTION_ID])
     return {_InternalEventConstants.RESULT: result}

--- a/dss/storage/checkout/bundle.py
+++ b/dss/storage/checkout/bundle.py
@@ -237,10 +237,11 @@ def mark_bundle_checkout_failed(
         cause: str,
 ):
     handle = Config.get_blobstore_handle(replica)
-    data = {_STATUS_KEY: "FAILED",
-            _CAUSE_KEY: cause,
-            _LOCATION_KEY: f"{replica.storage_schema}://{dst_bucket}/{dst_location}",
-            _BUCKET_KEY: dst_bucket,
+    data = {
+        _STATUS_KEY: "FAILED",
+        _CAUSE_KEY: cause,
+        _LOCATION_KEY: f"{replica.storage_schema}://{dst_bucket}/{dst_location}",
+        _BUCKET_KEY: dst_bucket,
     }
     handle.upload_file_handle(
         sts_bucket,
@@ -255,8 +256,9 @@ def mark_bundle_checkout_started(
         dst_bucket: str,
 ):
     handle = Config.get_blobstore_handle(replica)
-    data = {_STATUS_KEY: "RUNNING",
-            _BUCKET_KEY: dst_bucket,
+    data = {
+        _STATUS_KEY: "RUNNING",
+        _BUCKET_KEY: dst_bucket,
     }
     handle.upload_file_handle(
         sts_bucket,


### PR DESCRIPTION
Addresses #1760.

`hca dss post-bundles-checkout` does not work with user buckets (i.e. `POST bundles/{uuid}/checkout`).

I ran into this while trying to do testing for #1887.  The reason seems to be various defaults to the canonical checkout bucket, but I'm still debugging this.

Initial error:
```
(venv) quokka@qcore:~/delete/data-store$ hca dss post-bundles-checkout --replica aws --uuid fff94e8e-6470-4330-9ba2-1cc2d822b67b --destination lon-dss-test
{
  "checkout_job_id": "45148616-f98e-4ad8-9a73-9f7ec4565957"
}
(venv) quokka@qcore:~/delete/data-store$ hca dss get-bundles-checkout --replica aws --checkout-job-id 45148616-f98e-4ad8-9a73-9f7ec4565957
{
  "status": "RUNNING"
}
(venv) quokka@qcore:~/delete/data-store$ hca dss get-bundles-checkout --replica aws --checkout-job-id 45148616-f98e-4ad8-9a73-9f7ec4565957
{
  "cause": "failure to complete work within allowed time interval",
  "status": "FAILED"
}
```

However, this succeeds:
```
(venv) quokka@qcore:~/delete/data-store$ hca dss post-bundles-checkout --replica aws --uuid fff94e8e-6470-4330-9ba2-1cc2d822b67b --destination org-humancellatlas-dss-checkout-integration
{
  "checkout_job_id": "7316428d-6ab1-41d3-8a39-132a384e9563"
}
(venv) quokka@qcore:~/delete/data-store$ hca dss get-bundles-checkout --replica aws --checkout-job-id 7316428d-6ab1-41d3-8a39-132a384e9563
{
  "status": "RUNNING"
}
(venv) quokka@qcore:~/delete/data-store$ hca dss get-bundles-checkout --replica aws --checkout-job-id 7316428d-6ab1-41d3-8a39-132a384e9563
{
  "location": "s3://org-humancellatlas-dss-checkout-integration/bundles/fff94e8e-6470-4330-9ba2-1cc2d822b67b.2019-01-28T060229.337876Z",
  "status": "SUCCEEDED"
}
```

So far this adds useful information (the destination bucket) to the status json the dss fetches for the execution ID.  The idea is to persist this after the initial call for both functional and debugging reasons.