### PR TITLE
[WIP] Increase parallelization of PATCH /collections

### DIFF
--- a/chalice/.chalice/config.json
+++ b/chalice/.chalice/config.json
@@ -13,5 +13,5 @@
     }
   },
   "lambda_timeout": 300,
-  "lambda_memory_size": 256
+  "lambda_memory_size": 1536
 }

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -187,6 +187,6 @@ def verify_collection(contents: List[dict], replica: Replica, blobstore_handle: 
     """
     verifier = partial(resolve_content_item, replica, blobstore_handle)
     for i in range(0, len(contents), batch_size):
-        with ThreadPoolExecutor(max_workers=8) as e:
+        with ThreadPoolExecutor(max_workers=20) as e:
             for result in e.map(verifier, contents[i:i + batch_size]):
                 pass

--- a/dss/config.py
+++ b/dss/config.py
@@ -133,6 +133,9 @@ class Config:
             boto_config.read_timeout = Config.BLOBSTORE_READ_TIMEOUT
         if Config.BLOBSTORE_RETRIES is not None:
             boto_config.retries = {'max_attempts': Config.BLOBSTORE_RETRIES}
+        if boto_config.max_pool_connections < 20:
+            # increase the number of parallel network connections available to boto
+            boto_config.max_pool_connections = 20
         return boto3.client("s3", config=boto_config)
 
     @staticmethod


### PR DESCRIPTION
The primary bottle neck in PATCH /collections is collection verification. This can be partially overcome by increasing the parallelization of verification logic.

Via testing from local API server on EC2 instance, we find:
- Lambda memory needs to be scaled to 704MB to take advantage of concurrency. Note that Lambda CPU scales automatically with memory.
- collections can grow to millions of items via the aws replica
- gcp not as scalable due to cross-cloud network calls