### PR TITLE
Modifying file name regex

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1392,7 +1392,7 @@ paths:
                         - Only relative paths with "/" (forward)slashes allowed.  e.g. "path/file.json" or "file.json"
                         - Please upload using "/" (forward)slashes, even if on Windows.
                       type: string
-                      pattern: "^(\\.?[\\w][\\w\\s.]*)+((\\.?[\\w][\\w\\s.]*)|\\/)*$"
+                      pattern: "^(\\.?[\\w\\-!#%()'][\\w.\\-~!#%()']*)+((\\.?[\\w\\-~!#%()'][\\w.\\-~!#%()']*)|\\/)*$"
                     indexed:
                       description: True iff this file should be indexed.
                       type: boolean

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -611,7 +611,8 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
         examples_of_bad_paths = unix_bad_paths + windows_bad_paths
 
         unix_good_paths = ['path', 'path.json2', 'good..path', 'path.json2/', 'good..path2/',
-                           'pa/th.2json', 'go/od..2path', 'a/2b/c/22d2', 'a/b.2c/d2.json', '.2bashrc']
+                           'pa/th.2json', 'go/od..2path', 'a/2b/c/22d2', 'a/b.2c/d2.json', '.2bashrc',
+                           'abedf40-299a-484d-a1b7-1c6103fcfc87_qc.bait_bias_summary_metrics.txt']
         windows_good_paths = []
         examples_of_good_paths = unix_good_paths + windows_good_paths
 


### PR DESCRIPTION
- white space it no allowed
- adding allowed characters -~!#%()'

These changes were made based on the this article on cross platform compatible file names http://www.imagemontage.com/archives/FileExchange/FileNames.html

We will need to create some more test cases to verify this

test case `abedf40-299a-484d-a1b7-1c6103fcfc87_qc.bait_bias_summary_metrics.txt`