### PR TITLE
Changes to dss-sync-sfn for debugging and maybe a fix.

### DIFF
--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -49,7 +49,8 @@ def launch_from_s3_event(event, context):
                 if exists(dest_replica, obj.key):
                     # Logging error here causes daemons/invoke_lambda.sh to report failure, for some reason
                     # - Brian Hannafious, 2019-01-31
-                    logger.info("Key %s already exists in %s, skipping sync", obj.key, dest_replica)
+                    logger.info("[s3 Event] Key %s already exists in %s, skipping sync.", str(obj.key),
+                                                                                          str(dest_replica.name))
                     continue
                 exec_name = bucket.name + "/" + obj.key + ":" + source_replica.name + ":" + dest_replica.name
                 exec_input = dict(source_replica=source_replica.name,
@@ -71,12 +72,13 @@ def launch_from_forwarded_event(event, context):
             bucket = source_replica.bucket
             for dest_replica in Config.get_replication_destinations(source_replica):
                 if exists(dest_replica, source_key):
-                    logger.info("Key %s already exists in %s, skipping sync", source_key, dest_replica)
+                    logger.info("[Forwarded Event] Key %s already exists in %s, skipping sync.", str(source_key),
+                                                                                                 str(dest_replica.name))
                     continue
-                exec_name = bucket + "/" + message["name"] + ":" + source_replica.name + ":" + dest_replica.name
+                exec_name = bucket + "/" + source_key + ":" + source_replica.name + ":" + dest_replica.name
                 exec_input = dict(source_replica=source_replica.name,
                                   dest_replica=dest_replica.name,
-                                  source_key=message["name"],
+                                  source_key=source_key,
                                   source_obj_metadata=message)
                 executions[exec_name] = app.state_machine.start_execution(**exec_input)["executionArn"]
         else:

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -49,8 +49,9 @@ def launch_from_s3_event(event, context):
                 if exists(dest_replica, obj.key):
                     # Logging error here causes daemons/invoke_lambda.sh to report failure, for some reason
                     # - Brian Hannafious, 2019-01-31
-                    logger.info("[s3 Event] Key %s already exists in %s, skipping sync.", str(obj.key),
-                                                                                          str(dest_replica.name))
+                    logger.info("[s3 Event] Key %s already exists in %s, skipping sync.",
+                                str(obj.key),
+                                str(dest_replica.name))
                     continue
                 exec_name = bucket.name + "/" + obj.key + ":" + source_replica.name + ":" + dest_replica.name
                 exec_input = dict(source_replica=source_replica.name,
@@ -72,8 +73,9 @@ def launch_from_forwarded_event(event, context):
             bucket = source_replica.bucket
             for dest_replica in Config.get_replication_destinations(source_replica):
                 if exists(dest_replica, source_key):
-                    logger.info("[Forwarded Event] Key %s already exists in %s, skipping sync.", str(source_key),
-                                                                                                 str(dest_replica.name))
+                    logger.info("[Forwarded Event] Key %s already exists in %s, skipping sync.",
+                                str(source_key),
+                                str(dest_replica.name))
                     continue
                 exec_name = bucket + "/" + source_key + ":" + source_replica.name + ":" + dest_replica.name
                 exec_input = dict(source_replica=source_replica.name,

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -51,7 +51,7 @@ def launch_from_s3_event(event, context):
                     # - Brian Hannafious, 2019-01-31
                     logger.info("[s3 Event] Key %s already exists in %s, skipping sync.",
                                 str(obj.key),
-                                str(dest_replica.name))
+                                str(dest_replica))
                     continue
                 exec_name = bucket.name + "/" + obj.key + ":" + source_replica.name + ":" + dest_replica.name
                 exec_input = dict(source_replica=source_replica.name,
@@ -75,12 +75,12 @@ def launch_from_forwarded_event(event, context):
                 if exists(dest_replica, source_key):
                     logger.info("[Forwarded Event] Key %s already exists in %s, skipping sync.",
                                 str(source_key),
-                                str(dest_replica.name))
+                                str(dest_replica))
                     continue
-                exec_name = bucket + "/" + source_key + ":" + source_replica.name + ":" + dest_replica.name
+                exec_name = bucket + "/" + message["name"] + ":" + source_replica.name + ":" + dest_replica.name
                 exec_input = dict(source_replica=source_replica.name,
                                   dest_replica=dest_replica.name,
-                                  source_key=source_key,
+                                  source_key=message["name"],
                                   source_obj_metadata=message)
                 executions[exec_name] = app.state_machine.start_execution(**exec_input)["executionArn"]
         else:


### PR DESCRIPTION
Error is that `dss-copy-sfn` fails intermittantly and must be manually deployed.  This just changes the log messages to force strings and tags them since this message appears in the successful attempts but not in the failed attempts.  Knowing which function it hits in the future might help with debugging.  If one is erroring because of an improper string while the other is correct, this might also fix that, though I'm not sure that that is what this is.