### PR TITLE
Fix JMESPath notification race condition

### DIFF
--- a/dss/events/handlers/notify_v2.py
+++ b/dss/events/handlers/notify_v2.py
@@ -84,6 +84,9 @@ def notify(subscription: dict, metadata_document: dict, key: str):
     """
     fqid = key.split("/")[1]
     bundle_uuid, bundle_version = fqid.split(".", 1)
+    sfx = f".{TOMBSTONE_SUFFIX}"
+    if bundle_version.endswith(sfx):
+        bundle_version = bundle_version[:-len(sfx)]
 
     payload = {
         'transaction_id': str(uuid4()),

--- a/tests/test_notify_v2.py
+++ b/tests/test_notify_v2.py
@@ -123,7 +123,7 @@ class TestNotifyV2(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         notification = self._get_notification_from_s3_object(bucket, notification_object_key)
         self.assertEquals(notification['subscription_id'], subscription['uuid'])
         self.assertEquals(notification['match']['bundle_uuid'], bundle_uuid)
-        self.assertEquals(notification['match']['bundle_version'], f"{bundle_version}.dead")
+        self.assertEquals(notification['match']['bundle_version'], f"{bundle_version}")
 
     @testmode.standalone
     def _test_notify_or_queue(self, metadata_document):


### PR DESCRIPTION
This fixes a bug causing notifications to remain in queue after object has been deleted.

Instead, dequeue and log notification failure.