### PR TITLE
Update swagger with explicit retry-after headers.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1453,6 +1453,11 @@ paths:
                   - code
         500:
           description: Server error
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
           schema:
             allOf:
               - $ref: '#/definitions/Error'
@@ -1475,6 +1480,11 @@ paths:
           $ref: '#/responses/BadGateway'
         503:
           description: Service unavailable
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
           schema:
             allOf:
               - $ref: '#/definitions/Error'

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -260,6 +260,34 @@ paths:
             Link:
               type: string
               description: URL to retrieve the next page of results.
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -325,6 +353,34 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: >
@@ -416,6 +472,34 @@ paths:
                     enum: [illegal_token]
                 required:
                   - code
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -565,6 +649,34 @@ paths:
                     enum: [missing_checksum]
                 required:
                 - code
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -612,6 +724,34 @@ paths:
                   $ref: "#/definitions/Subscription"
             required:
               - subscriptions
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -813,6 +953,34 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -872,6 +1040,34 @@ paths:
             properties:
               subscription:
                 $ref: "#/definitions/Subscription"
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -924,6 +1120,34 @@ paths:
                 format: DSS_VERSION
             required:
               - timeDeleted
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -994,6 +1218,34 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1048,6 +1300,34 @@ paths:
             properties:
               collection:
                 $ref: "#/definitions/Collection"
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1202,6 +1482,34 @@ paths:
                     enum: [invalid_link]
                 required:
                   - code
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1238,6 +1546,34 @@ paths:
       responses:
         200:
           description: OK
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1364,7 +1700,61 @@ paths:
                 required:
                   - code
         500:
-          description: Server error
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+                      The code `unhandled_exception` is returned when an unexpected exception is encountered.
+                      The code `checkout_error` is returned when the checkout fails.
+                    enum: [unhandled_exception, checkout_error]
+                required:
+                  - code
+        503:
+          description: Service unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+                      The code `service_unavailable` is returned when service is unavailable because of unusually high
+                      load/latency
+                    enum: [service_unavailable]
+                required:
+                  - code
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
           schema:
             allOf:
               - $ref: '#/definitions/Error'
@@ -1553,6 +1943,34 @@ paths:
                     enum: [bundle_already_exists]
                 required:
                   - code
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1645,6 +2063,34 @@ paths:
                     enum: [bundle_tombstone_already_exists]
                 required:
                   - code
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1779,6 +2225,34 @@ paths:
                     description: Detailed error message.
                 required:
                   - code
+        500:
+          description: Server error.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        502:
+          description: Bad Gateway.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        503:
+          description: Service Unavailable.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
+        504:
+          description: Gateway Timeout.
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
         default:
           description: Unexpected error
           schema:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1452,10 +1452,10 @@ paths:
                 required:
                   - code
         500:
-          description: Server error
+          description: Server Error.
           headers:
             Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
+              description: Delay in seconds, service clients should retry after the delay.
               type: integer
               format: int64
           schema:
@@ -1479,10 +1479,10 @@ paths:
         502:
           $ref: '#/responses/BadGateway'
         503:
-          description: Service unavailable
+          description: Service Unavailable.
           headers:
             Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
+              description: Delay in seconds, service clients should retry after the delay.
               type: integer
               format: int64
           schema:
@@ -2288,30 +2288,30 @@ definitions:
 
 responses:
   ServerError:
-    description: Server error.
+    description: Server Error.
     headers:
       Retry-After:
-        description: Delay in seconds, downstream users should retry after the delay.
+        description: Delay in seconds, service clients should retry after the delay.
         type: integer
         format: int64
   BadGateway:
     description: Bad Gateway.
     headers:
       Retry-After:
-        description: Delay in seconds, downstream users should retry after the delay.
+        description: Delay in seconds, service clients should retry after the delay.
         type: integer
         format: int64
   ServiceUnavailable:
     description: Service Unavailable.
     headers:
       Retry-After:
-        description: Delay in seconds, downstream users should retry after the delay.
+        description: Delay in seconds, service clients should retry after the delay.
         type: integer
         format: int64
   GatewayTimeout:
     description: Gateway Timeout.
     headers:
       Retry-After:
-        description: Delay in seconds, downstream users should retry after the delay.
+        description: Delay in seconds, service clients should retry after the delay.
         type: integer
         format: int64

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -260,26 +260,6 @@ paths:
             Link:
               type: string
               description: URL to retrieve the next page of results.
-        500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
-        502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
-        503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
-        504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -346,25 +326,13 @@ paths:
               type: string
               pattern: "^[a-z0-9]{64}$"
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: >
@@ -457,25 +425,13 @@ paths:
                 required:
                   - code
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -626,25 +582,13 @@ paths:
                 required:
                 - code
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -693,25 +637,13 @@ paths:
             required:
               - subscriptions
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -914,25 +846,13 @@ paths:
             required:
               - uuid
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -993,25 +913,13 @@ paths:
               subscription:
                 $ref: "#/definitions/Subscription"
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -1065,25 +973,13 @@ paths:
             required:
               - timeDeleted
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -1155,25 +1051,13 @@ paths:
             required:
               - uuid
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -1229,25 +1113,13 @@ paths:
               collection:
                 $ref: "#/definitions/Collection"
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -1403,25 +1275,13 @@ paths:
                 required:
                   - code
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -1458,6 +1318,14 @@ paths:
       responses:
         200:
           description: OK
+        500:
+          $ref: '#/responses/ServerError'
+        502:
+          $ref: '#/responses/BadGateway'
+        503:
+          $ref: '#/responses/ServiceUnavailable'
+        504:
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -1471,26 +1339,6 @@ paths:
                     enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found, read_only]
                 required:
                   - code
-        500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
-        502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
-        503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
-        504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
   /bundles/{uuid}:
     get:
       summary: Retrieve a bundle given a UUID and optionally a version.
@@ -1604,12 +1452,7 @@ paths:
                 required:
                   - code
         500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
+          description: Server error
           schema:
             allOf:
               - $ref: '#/definitions/Error'
@@ -1629,17 +1472,9 @@ paths:
                 required:
                   - code
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description: Service unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
+          description: Service unavailable
           schema:
             allOf:
               - $ref: '#/definitions/Error'
@@ -1657,10 +1492,7 @@ paths:
                 required:
                   - code
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
     put:
       security:
         - dcpAuth: []
@@ -1814,25 +1646,13 @@ paths:
                 required:
                   - code
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -1926,25 +1746,13 @@ paths:
                 required:
                   - code
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -2080,25 +1888,13 @@ paths:
                 required:
                   - code
         500:
-          description:
-            $ref: '#/definitions/retry_defaults/500/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/500/headers'
+          $ref: '#/responses/ServerError'
         502:
-          description:
-            $ref: '#/definitions/retry_defaults/502/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/502/headers'
+          $ref: '#/responses/BadGateway'
         503:
-          description:
-            $ref: '#/definitions/retry_defaults/503/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/503/headers'
+          $ref: '#/responses/ServiceUnavailable'
         504:
-          description:
-            $ref: '#/definitions/retry_defaults/504/description'
-          headers:
-            $ref: '#/definitions/retry_defaults/504/headers'
+          $ref: '#/responses/GatewayTimeout'
         default:
           description: Unexpected error
           schema:
@@ -2479,32 +2275,33 @@ definitions:
     properties:
       files:
         type: string
-  retry_defaults:
-    500:
-      description: Server error.
-      headers:
-        Retry-After:
-          description: Delay in seconds, downstream users should retry after the delay.
-          type: integer
-          format: int64
-    502:
-      description: Bad Gateway.
-      headers:
-        Retry-After:
-          description: Delay in seconds, downstream users should retry after the delay.
-          type: integer
-          format: int64
-    503:
-      description: Service Unavailable.
-      headers:
-        Retry-After:
-          description: Delay in seconds, downstream users should retry after the delay.
-          type: integer
-          format: int64
-    504:
-      description: Gateway Timeout.
-      headers:
-        Retry-After:
-          description: Delay in seconds, downstream users should retry after the delay.
-          type: integer
-          format: int64
+
+responses:
+  ServerError:
+    description: Server error.
+    headers:
+      Retry-After:
+        description: Delay in seconds, downstream users should retry after the delay.
+        type: integer
+        format: int64
+  BadGateway:
+    description: Bad Gateway.
+    headers:
+      Retry-After:
+        description: Delay in seconds, downstream users should retry after the delay.
+        type: integer
+        format: int64
+  ServiceUnavailable:
+    description: Service Unavailable.
+    headers:
+      Retry-After:
+        description: Delay in seconds, downstream users should retry after the delay.
+        type: integer
+        format: int64
+  GatewayTimeout:
+    description: Gateway Timeout.
+    headers:
+      Retry-After:
+        description: Delay in seconds, downstream users should retry after the delay.
+        type: integer
+        format: int64

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -124,36 +124,35 @@ securityDefinitions:
       email: This scope value requests access to the email and email_verified Claims.
       openid: see http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
       offline_access: see http://openid.net/specs/openid-connect-core-1_0.html#OfflineAccessPrivacy
-retry_defaults: &retry_defaults
-  responses:
-    500:
-      description: Server error.
-      headers:
-        Retry-After:
-          description: Delay in seconds, downstream users should retry after the delay.
-          type: integer
-          format: int64
-    502:
-      description: Bad Gateway.
-      headers:
-        Retry-After:
-          description: Delay in seconds, downstream users should retry after the delay.
-          type: integer
-          format: int64
-    503:
-      description: Service Unavailable.
-      headers:
-        Retry-After:
-          description: Delay in seconds, downstream users should retry after the delay.
-          type: integer
-          format: int64
-    504:
-      description: Gateway Timeout.
-      headers:
-        Retry-After:
-          description: Delay in seconds, downstream users should retry after the delay.
-          type: integer
-          format: int64
+retry_defaults:
+  500:
+    description: Server error.
+    headers:
+      Retry-After:
+        description: Delay in seconds, downstream users should retry after the delay.
+        type: integer
+        format: int64
+  502:
+    description: Bad Gateway.
+    headers:
+      Retry-After:
+        description: Delay in seconds, downstream users should retry after the delay.
+        type: integer
+        format: int64
+  503:
+    description: Service Unavailable.
+    headers:
+      Retry-After:
+        description: Delay in seconds, downstream users should retry after the delay.
+        type: integer
+        format: int64
+  504:
+    description: Gateway Timeout.
+    headers:
+      Retry-After:
+        description: Delay in seconds, downstream users should retry after the delay.
+        type: integer
+        format: int64
 paths:
   /search:
     post:
@@ -277,8 +276,7 @@ paths:
             directly; it should instead directly fetch the URL given in the `Link` header.
           required: false
           type: string
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: All results retrieved.
           schema:
@@ -291,6 +289,14 @@ paths:
             Link:
               type: string
               description: URL to retrieve the next page of results.
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -321,8 +327,7 @@ paths:
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
           required: false
           type: string
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: Returns metadata
           headers:
@@ -389,8 +394,7 @@ paths:
           description: Token to manage retries.  End users constructing queries should not set this parameter.
           required: false
           type: string
-      <<: *retry_defaults
-      responses+:
+      responses:
         301:
           description: Handle asynchronously, downstream users are expected to retry later.
           headers:
@@ -449,6 +453,14 @@ paths:
                     enum: [illegal_token]
                 required:
                   - code
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -512,8 +524,7 @@ paths:
             required:
               - source_url
               - creator_uid
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: Returned when the file is already present and is identical to the file being uploaded.
           schema:
@@ -599,6 +610,14 @@ paths:
                     enum: [missing_checksum]
                 required:
                 - code
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -627,15 +646,14 @@ paths:
           required: true
           type: string
           enum: [aws, gcp]
-        - name: subscription_type 
+        - name: subscription_type
           in: query
           description: type of subscriptions to fetch (elasticsearch or jmespath)
           required: false
           default: jmespath
           type: string
           enum: [elasticsearch, jmespath]
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: OK
           schema:
@@ -647,6 +665,14 @@ paths:
                   $ref: "#/definitions/Subscription"
             required:
               - subscriptions
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -836,8 +862,7 @@ paths:
             required:
               - callback_url
             additionalProperties: false
-      <<: *retry_defaults
-      responses+:
+      responses:
         201:
           description: OK
           schema:
@@ -849,6 +874,14 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -893,15 +926,14 @@ paths:
           required: true
           type: string
           enum: [aws, gcp]
-        - name: subscription_type 
+        - name: subscription_type
           in: query
           description: type of subscriptions to fetch (elasticsearch or jmespath)
           required: false
           default: jmespath
           type: string
           enum: [elasticsearch, jmespath]
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: OK
           schema:
@@ -909,6 +941,14 @@ paths:
             properties:
               subscription:
                 $ref: "#/definitions/Subscription"
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -942,15 +982,14 @@ paths:
           required: true
           type: string
           enum: [aws, gcp]
-        - name: subscription_type 
+        - name: subscription_type
           in: query
           description: type of subscriptions to fetch (elasticsearch or jmespath)
           required: false
           default: jmespath
           type: string
           enum: [elasticsearch, jmespath]
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: OK
           schema:
@@ -962,6 +1001,14 @@ paths:
                 format: DSS_VERSION
             required:
               - timeDeleted
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1020,8 +1067,7 @@ paths:
           required: true
           schema:
             $ref: "#/definitions/Collection"
-      <<: *retry_defaults
-      responses+:
+      responses:
         201:
           description: OK
           schema:
@@ -1033,6 +1079,14 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1087,6 +1141,14 @@ paths:
             properties:
               collection:
                 $ref: "#/definitions/Collection"
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1158,8 +1220,7 @@ paths:
               details:
                 type: object
                 description: New details for the collection.
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: OK
           schema:
@@ -1242,6 +1303,14 @@ paths:
                     enum: [invalid_link]
                 required:
                   - code
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1275,8 +1344,7 @@ paths:
           required: true
           type: string
           enum: [aws, gcp]
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: OK
         default:
@@ -1292,6 +1360,14 @@ paths:
                     enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found, read_only]
                 required:
                   - code
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
   /bundles/{uuid}:
     get:
       summary: Retrieve a bundle given a UUID and optionally a version.
@@ -1350,8 +1426,7 @@ paths:
             directly; it should instead directly fetch the URL given in the `Link` header.
           required: false
           type: integer
-      <<: *retry_defaults
-      responses+:&&&&&&&&&&&&&&
+      responses:
         200:
           description: OK
           schema:
@@ -1406,7 +1481,7 @@ paths:
                 required:
                   - code
         500:
-          description: Server error
+          description: Server error.
           headers:
             Retry-After:
               description: Delay in seconds, downstream users should retry after the delay.
@@ -1430,8 +1505,10 @@ paths:
                     enum: [unhandled_exception, checkout_error]
                 required:
                   - code
+        502:
+          $ref: '#/retry_defaults/502'
         503:
-          description: Service unavailable
+          description: Service unavailable.
           headers:
             Retry-After:
               description: Delay in seconds, downstream users should retry after the delay.
@@ -1453,6 +1530,8 @@ paths:
                     enum: [service_unavailable]
                 required:
                   - code
+        504:
+          $ref: '#/retry_defaults/504'
     put:
       security:
         - dcpAuth: []
@@ -1540,8 +1619,7 @@ paths:
             required:
               - files
               - creator_uid
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: OK
           schema:
@@ -1606,6 +1684,14 @@ paths:
                     enum: [bundle_already_exists]
                 required:
                   - code
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1654,8 +1740,7 @@ paths:
                 type: string
             required:
               - reason
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: OK
           schema:
@@ -1699,6 +1784,14 @@ paths:
                     enum: [bundle_tombstone_already_exists]
                 required:
                   - code
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1798,8 +1891,7 @@ paths:
           pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
           required: true
           type: string
-      <<: *retry_defaults
-      responses+:
+      responses:
         200:
           description: Returned when a checkout request for the checkout job id exists.
           schema:
@@ -1834,6 +1926,14 @@ paths:
                     description: Detailed error message.
                 required:
                   - code
+        500:
+          $ref: '#/retry_defaults/500'
+        502:
+          $ref: '#/retry_defaults/502'
+        503:
+          $ref: '#/retry_defaults/503'
+        504:
+          $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -260,10 +260,14 @@ paths:
             Link:
               type: string
               description: URL to retrieve the next page of results.
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -329,10 +333,14 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: >
@@ -424,10 +432,14 @@ paths:
                     enum: [illegal_token]
                 required:
                   - code
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -577,10 +589,14 @@ paths:
                     enum: [missing_checksum]
                 required:
                 - code
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -628,10 +644,14 @@ paths:
                   $ref: "#/definitions/Subscription"
             required:
               - subscriptions
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -833,10 +853,14 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -896,10 +920,14 @@ paths:
             properties:
               subscription:
                 $ref: "#/definitions/Subscription"
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -952,10 +980,14 @@ paths:
                 format: DSS_VERSION
             required:
               - timeDeleted
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1026,10 +1058,14 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1084,10 +1120,14 @@ paths:
             properties:
               collection:
                 $ref: "#/definitions/Collection"
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1242,10 +1282,14 @@ paths:
                     enum: [invalid_link]
                 required:
                   - code
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1295,10 +1339,14 @@ paths:
                     enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found, read_only]
                 required:
                   - code
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
   /bundles/{uuid}:
     get:
       summary: Retrieve a bundle given a UUID and optionally a version.
@@ -1613,10 +1661,14 @@ paths:
                     enum: [bundle_already_exists]
                 required:
                   - code
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1709,10 +1761,14 @@ paths:
                     enum: [bundle_tombstone_already_exists]
                 required:
                   - code
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1847,10 +1903,14 @@ paths:
                     description: Detailed error message.
                 required:
                   - code
-        $ref: '#/definitions/retry_defaults/500'
-        $ref: '#/definitions/retry_defaults/502'
-        $ref: '#/definitions/retry_defaults/503'
-        $ref: '#/definitions/retry_defaults/504'
+        500:
+          $ref: '#/definitions/retry_defaults/500'
+        502:
+          $ref: '#/definitions/retry_defaults/502'
+        503:
+          $ref: '#/definitions/retry_defaults/503'
+        504:
+          $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -261,13 +261,25 @@ paths:
               type: string
               description: URL to retrieve the next page of results.
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -334,13 +346,25 @@ paths:
               type: string
               pattern: "^[a-z0-9]{64}$"
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: >
@@ -433,13 +457,25 @@ paths:
                 required:
                   - code
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -590,13 +626,25 @@ paths:
                 required:
                 - code
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -645,13 +693,25 @@ paths:
             required:
               - subscriptions
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -854,13 +914,25 @@ paths:
             required:
               - uuid
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -921,13 +993,25 @@ paths:
               subscription:
                 $ref: "#/definitions/Subscription"
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -981,13 +1065,25 @@ paths:
             required:
               - timeDeleted
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -1059,13 +1155,25 @@ paths:
             required:
               - uuid
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -1121,13 +1229,25 @@ paths:
               collection:
                 $ref: "#/definitions/Collection"
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -1283,13 +1403,25 @@ paths:
                 required:
                   - code
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -1340,13 +1472,25 @@ paths:
                 required:
                   - code
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
   /bundles/{uuid}:
     get:
       summary: Retrieve a bundle given a UUID and optionally a version.
@@ -1484,7 +1628,11 @@ paths:
                     enum: [unhandled_exception, checkout_error]
                 required:
                   - code
-        $ref: '#/definitions/retry_defaults/502'
+        502:
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
           description: Service unavailable.
           headers:
@@ -1508,7 +1656,11 @@ paths:
                     enum: [service_unavailable]
                 required:
                   - code
-        $ref: '#/definitions/retry_defaults/504'
+        504:
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
     put:
       security:
         - dcpAuth: []
@@ -1662,13 +1814,25 @@ paths:
                 required:
                   - code
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -1762,13 +1926,25 @@ paths:
                 required:
                   - code
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:
@@ -1904,13 +2080,25 @@ paths:
                 required:
                   - code
         500:
-          $ref: '#/definitions/retry_defaults/500'
+          description:
+            $ref: '#/definitions/retry_defaults/500/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/500/headers'
         502:
-          $ref: '#/definitions/retry_defaults/502'
+          description:
+            $ref: '#/definitions/retry_defaults/502/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/502/headers'
         503:
-          $ref: '#/definitions/retry_defaults/503'
+          description:
+            $ref: '#/definitions/retry_defaults/503/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/503/headers'
         504:
-          $ref: '#/definitions/retry_defaults/504'
+          description:
+            $ref: '#/definitions/retry_defaults/504/description'
+          headers:
+            $ref: '#/definitions/retry_defaults/504/headers'
         default:
           description: Unexpected error
           schema:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -289,14 +289,10 @@ paths:
             Link:
               type: string
               description: URL to retrieve the next page of results.
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -362,6 +358,10 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: >
@@ -453,14 +453,10 @@ paths:
                     enum: [illegal_token]
                 required:
                   - code
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -610,14 +606,10 @@ paths:
                     enum: [missing_checksum]
                 required:
                 - code
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -665,14 +657,10 @@ paths:
                   $ref: "#/definitions/Subscription"
             required:
               - subscriptions
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -874,14 +862,10 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -941,14 +925,10 @@ paths:
             properties:
               subscription:
                 $ref: "#/definitions/Subscription"
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1001,14 +981,10 @@ paths:
                 format: DSS_VERSION
             required:
               - timeDeleted
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1079,14 +1055,10 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1141,14 +1113,10 @@ paths:
             properties:
               collection:
                 $ref: "#/definitions/Collection"
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1303,14 +1271,10 @@ paths:
                     enum: [invalid_link]
                 required:
                   - code
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1360,14 +1324,10 @@ paths:
                     enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found, read_only]
                 required:
                   - code
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
   /bundles/{uuid}:
     get:
       summary: Retrieve a bundle given a UUID and optionally a version.
@@ -1505,8 +1465,7 @@ paths:
                     enum: [unhandled_exception, checkout_error]
                 required:
                   - code
-        502:
-          $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/502'
         503:
           description: Service unavailable.
           headers:
@@ -1530,8 +1489,7 @@ paths:
                     enum: [service_unavailable]
                 required:
                   - code
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/504'
     put:
       security:
         - dcpAuth: []
@@ -1684,14 +1642,10 @@ paths:
                     enum: [bundle_already_exists]
                 required:
                   - code
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1784,14 +1738,10 @@ paths:
                     enum: [bundle_tombstone_already_exists]
                 required:
                   - code
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1926,14 +1876,10 @@ paths:
                     description: Detailed error message.
                 required:
                   - code
-        500:
-          $ref: '#/retry_defaults/500'
-        502:
-          $ref: '#/retry_defaults/502'
-        503:
-          $ref: '#/retry_defaults/503'
-        504:
-          $ref: '#/retry_defaults/504'
+        $ref: '#/retry_defaults/500'
+        $ref: '#/retry_defaults/502'
+        $ref: '#/retry_defaults/503'
+        $ref: '#/retry_defaults/504'
         default:
           description: Unexpected error
           schema:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -124,6 +124,36 @@ securityDefinitions:
       email: This scope value requests access to the email and email_verified Claims.
       openid: see http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
       offline_access: see http://openid.net/specs/openid-connect-core-1_0.html#OfflineAccessPrivacy
+retry_defaults: &retry_defaults
+  responses:
+    500:
+      description: Server error.
+      headers:
+        Retry-After:
+          description: Delay in seconds, downstream users should retry after the delay.
+          type: integer
+          format: int64
+    502:
+      description: Bad Gateway.
+      headers:
+        Retry-After:
+          description: Delay in seconds, downstream users should retry after the delay.
+          type: integer
+          format: int64
+    503:
+      description: Service Unavailable.
+      headers:
+        Retry-After:
+          description: Delay in seconds, downstream users should retry after the delay.
+          type: integer
+          format: int64
+    504:
+      description: Gateway Timeout.
+      headers:
+        Retry-After:
+          description: Delay in seconds, downstream users should retry after the delay.
+          type: integer
+          format: int64
 paths:
   /search:
     post:
@@ -247,7 +277,8 @@ paths:
             directly; it should instead directly fetch the URL given in the `Link` header.
           required: false
           type: string
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: All results retrieved.
           schema:
@@ -260,34 +291,6 @@ paths:
             Link:
               type: string
               description: URL to retrieve the next page of results.
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -318,7 +321,8 @@ paths:
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
           required: false
           type: string
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: Returns metadata
           headers:
@@ -353,34 +357,6 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: >
@@ -413,7 +389,8 @@ paths:
           description: Token to manage retries.  End users constructing queries should not set this parameter.
           required: false
           type: string
-      responses:
+      <<: *retry_defaults
+      responses+:
         301:
           description: Handle asynchronously, downstream users are expected to retry later.
           headers:
@@ -472,34 +449,6 @@ paths:
                     enum: [illegal_token]
                 required:
                   - code
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -563,7 +512,8 @@ paths:
             required:
               - source_url
               - creator_uid
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: Returned when the file is already present and is identical to the file being uploaded.
           schema:
@@ -649,34 +599,6 @@ paths:
                     enum: [missing_checksum]
                 required:
                 - code
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -712,7 +634,8 @@ paths:
           default: jmespath
           type: string
           enum: [elasticsearch, jmespath]
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: OK
           schema:
@@ -724,34 +647,6 @@ paths:
                   $ref: "#/definitions/Subscription"
             required:
               - subscriptions
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -941,7 +836,8 @@ paths:
             required:
               - callback_url
             additionalProperties: false
-      responses:
+      <<: *retry_defaults
+      responses+:
         201:
           description: OK
           schema:
@@ -953,34 +849,6 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1032,7 +900,8 @@ paths:
           default: jmespath
           type: string
           enum: [elasticsearch, jmespath]
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: OK
           schema:
@@ -1040,34 +909,6 @@ paths:
             properties:
               subscription:
                 $ref: "#/definitions/Subscription"
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1108,7 +949,8 @@ paths:
           default: jmespath
           type: string
           enum: [elasticsearch, jmespath]
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: OK
           schema:
@@ -1120,34 +962,6 @@ paths:
                 format: DSS_VERSION
             required:
               - timeDeleted
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1206,7 +1020,8 @@ paths:
           required: true
           schema:
             $ref: "#/definitions/Collection"
-      responses:
+      <<: *retry_defaults
+      responses+:
         201:
           description: OK
           schema:
@@ -1218,34 +1033,6 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1300,34 +1087,6 @@ paths:
             properties:
               collection:
                 $ref: "#/definitions/Collection"
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1399,7 +1158,8 @@ paths:
               details:
                 type: object
                 description: New details for the collection.
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: OK
           schema:
@@ -1482,34 +1242,6 @@ paths:
                     enum: [invalid_link]
                 required:
                   - code
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1543,37 +1275,10 @@ paths:
           required: true
           type: string
           enum: [aws, gcp]
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: OK
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -1645,7 +1350,8 @@ paths:
             directly; it should instead directly fetch the URL given in the `Link` header.
           required: false
           type: integer
-      responses:
+      <<: *retry_defaults
+      responses+:&&&&&&&&&&&&&&
         200:
           description: OK
           schema:
@@ -1700,56 +1406,7 @@ paths:
                 required:
                   - code
         500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-          schema:
-            allOf:
-              - $ref: '#/definitions/Error'
-              - type: object
-                properties:
-                  code:
-                    type: string
-                    description: >
-                      Machine-readable error code.  The types of return values should not be changed lightly.
-                      The code `unhandled_exception` is returned when an unexpected exception is encountered.
-                      The code `checkout_error` is returned when the checkout fails.
-                    enum: [unhandled_exception, checkout_error]
-                required:
-                  - code
-        503:
-          description: Service unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-          schema:
-            allOf:
-              - $ref: '#/definitions/Error'
-              - type: object
-                properties:
-                  code:
-                    type: string
-                    description: >
-                      Machine-readable error code.  The types of return values should not be changed lightly.
-                      The code `service_unavailable` is returned when service is unavailable because of unusually high
-                      load/latency
-                    enum: [service_unavailable]
-                required:
-                  - code
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
+          description: Server error
           headers:
             Retry-After:
               description: Delay in seconds, downstream users should retry after the delay.
@@ -1775,6 +1432,11 @@ paths:
                   - code
         503:
           description: Service unavailable
+          headers:
+            Retry-After:
+              description: Delay in seconds, downstream users should retry after the delay.
+              type: integer
+              format: int64
           schema:
             allOf:
               - $ref: '#/definitions/Error'
@@ -1878,7 +1540,8 @@ paths:
             required:
               - files
               - creator_uid
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: OK
           schema:
@@ -1943,34 +1606,6 @@ paths:
                     enum: [bundle_already_exists]
                 required:
                   - code
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -2019,7 +1654,8 @@ paths:
                 type: string
             required:
               - reason
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: OK
           schema:
@@ -2063,34 +1699,6 @@ paths:
                     enum: [bundle_tombstone_already_exists]
                 required:
                   - code
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:
@@ -2190,7 +1798,8 @@ paths:
           pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
           required: true
           type: string
-      responses:
+      <<: *retry_defaults
+      responses+:
         200:
           description: Returned when a checkout request for the checkout job id exists.
           schema:
@@ -2225,34 +1834,6 @@ paths:
                     description: Detailed error message.
                 required:
                   - code
-        500:
-          description: Server error.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        502:
-          description: Bad Gateway.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        503:
-          description: Service Unavailable.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
-        504:
-          description: Gateway Timeout.
-          headers:
-            Retry-After:
-              description: Delay in seconds, downstream users should retry after the delay.
-              type: integer
-              format: int64
         default:
           description: Unexpected error
           schema:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -124,35 +124,6 @@ securityDefinitions:
       email: This scope value requests access to the email and email_verified Claims.
       openid: see http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
       offline_access: see http://openid.net/specs/openid-connect-core-1_0.html#OfflineAccessPrivacy
-retry_defaults:
-  500:
-    description: Server error.
-    headers:
-      Retry-After:
-        description: Delay in seconds, downstream users should retry after the delay.
-        type: integer
-        format: int64
-  502:
-    description: Bad Gateway.
-    headers:
-      Retry-After:
-        description: Delay in seconds, downstream users should retry after the delay.
-        type: integer
-        format: int64
-  503:
-    description: Service Unavailable.
-    headers:
-      Retry-After:
-        description: Delay in seconds, downstream users should retry after the delay.
-        type: integer
-        format: int64
-  504:
-    description: Gateway Timeout.
-    headers:
-      Retry-After:
-        description: Delay in seconds, downstream users should retry after the delay.
-        type: integer
-        format: int64
 paths:
   /search:
     post:
@@ -289,10 +260,10 @@ paths:
             Link:
               type: string
               description: URL to retrieve the next page of results.
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -358,10 +329,10 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
     get:
       summary: Retrieve a file given a UUID and optionally a version.
       description: >
@@ -453,10 +424,10 @@ paths:
                     enum: [illegal_token]
                 required:
                   - code
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -606,10 +577,10 @@ paths:
                     enum: [missing_checksum]
                 required:
                 - code
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -657,10 +628,10 @@ paths:
                   $ref: "#/definitions/Subscription"
             required:
               - subscriptions
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -862,10 +833,10 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -925,10 +896,10 @@ paths:
             properties:
               subscription:
                 $ref: "#/definitions/Subscription"
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -981,10 +952,10 @@ paths:
                 format: DSS_VERSION
             required:
               - timeDeleted
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1055,10 +1026,10 @@ paths:
                 pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1113,10 +1084,10 @@ paths:
             properties:
               collection:
                 $ref: "#/definitions/Collection"
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1271,10 +1242,10 @@ paths:
                     enum: [invalid_link]
                 required:
                   - code
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1324,10 +1295,10 @@ paths:
                     enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found, read_only]
                 required:
                   - code
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
   /bundles/{uuid}:
     get:
       summary: Retrieve a bundle given a UUID and optionally a version.
@@ -1465,7 +1436,7 @@ paths:
                     enum: [unhandled_exception, checkout_error]
                 required:
                   - code
-        $ref: '#/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/502'
         503:
           description: Service unavailable.
           headers:
@@ -1489,7 +1460,7 @@ paths:
                     enum: [service_unavailable]
                 required:
                   - code
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/504'
     put:
       security:
         - dcpAuth: []
@@ -1642,10 +1613,10 @@ paths:
                     enum: [bundle_already_exists]
                 required:
                   - code
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1738,10 +1709,10 @@ paths:
                     enum: [bundle_tombstone_already_exists]
                 required:
                   - code
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -1876,10 +1847,10 @@ paths:
                     description: Detailed error message.
                 required:
                   - code
-        $ref: '#/retry_defaults/500'
-        $ref: '#/retry_defaults/502'
-        $ref: '#/retry_defaults/503'
-        $ref: '#/retry_defaults/504'
+        $ref: '#/definitions/retry_defaults/500'
+        $ref: '#/definitions/retry_defaults/502'
+        $ref: '#/definitions/retry_defaults/503'
+        $ref: '#/definitions/retry_defaults/504'
         default:
           description: Unexpected error
           schema:
@@ -2260,3 +2231,32 @@ definitions:
     properties:
       files:
         type: string
+  retry_defaults:
+    500:
+      description: Server error.
+      headers:
+        Retry-After:
+          description: Delay in seconds, downstream users should retry after the delay.
+          type: integer
+          format: int64
+    502:
+      description: Bad Gateway.
+      headers:
+        Retry-After:
+          description: Delay in seconds, downstream users should retry after the delay.
+          type: integer
+          format: int64
+    503:
+      description: Service Unavailable.
+      headers:
+        Retry-After:
+          description: Delay in seconds, downstream users should retry after the delay.
+          type: integer
+          format: int64
+    504:
+      description: Gateway Timeout.
+      headers:
+        Retry-After:
+          description: Delay in seconds, downstream users should retry after the delay.
+          type: integer
+          format: int64


### PR DESCRIPTION
This PR explicitly adds Retry-After headers to [500, 502, 503, 504] responses for all methods except `POST /bundles/{uuid}/checkout`.

This allows the client to know which codes to retry on, even if it is a POST request (currently there is a desire to retry on POST search, see: https://github.com/HumanCellAtlas/dcp-cli/issues/222 ).

*Current CLI behavior:*
Do not retry on POST methods.  Retry on 500, 502, 503, & 504 for all non-POST methods.

*Updating the swagger would:*
Allow changes in the `dcp-cli` to retry on POST search but not `POST /bundles/{uuid}/checkout`.