### PR TITLE
Truncate ci-cd.json to get around the file size restriction AWS imposes.

### DIFF
--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -109,12 +109,9 @@
         "arn:aws:dynamodb:*:$account_id:table/dss-async-state-dev",
         "arn:aws:dynamodb:*:$account_id:table/dss-async-state-integration",
         "arn:aws:dynamodb:*:$account_id:table/dss-async-state-staging",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-aws-dev",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-aws-integration",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-aws-staging",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-gcp-dev",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-gcp-integration",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-gcp-staging"
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-dev",
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-integration",
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-staging"
       ]
     },
     {

--- a/iam/policy-templates/ci-cd.json
+++ b/iam/policy-templates/ci-cd.json
@@ -3,7 +3,6 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "hcaDssCiCdS3WriteAccess",
       "Effect": "Allow",
       "Action": [
         "s3:AbortMultipartUpload",
@@ -27,7 +26,6 @@
       ]
     },
     {
-      "Sid": "hcaDssCiCdS3ConfigAccess",
       "Effect": "Allow",
       "Action": [
         "s3:PutAccelerateConfiguration",
@@ -47,7 +45,6 @@
       ]
     },
     {
-      "Sid": "hcaDssCiCdS3ReadOnlyAccess",
       "Effect": "Allow",
       "Action": [
         "s3:Get*",
@@ -67,38 +64,19 @@
       ]
     },
     {
-      "Sid": "hcaDssCiCdLambdaReadAccess",
-      "Action": [
-        "lambda:List*",
-        "lambda:CreateEventSourceMapping",
-        "lambda:GetEventSourceMapping",
-        "lambda:TagResource",
-        "apigateway:*"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    },
-    {
-      "Sid": "hcaDssCiCdIamListRolesAccess",
       "Effect": "Allow",
-      "Action": [
-        "iam:ListRoles"
-      ],
+      "Action": "iam:ListRoles",
       "Resource": "arn:aws:iam::$account_id:role/"
     },
     {
-      "Sid": "hcaDssCiCdTestLogging",
       "Effect": "Allow",
-      "Action": [
-        "logs:*"
-      ],
+      "Action": "logs:*",
       "Resource": [
         "arn:aws:logs:*:$account_id:log-group:dss-*-$DSS_DEPLOYMENT_STAGE*",
         "arn:aws:logs:*:$account_id:log-group:dss-test-logging*"
       ]
     },
     {
-      "Sid": "hcaDssCiCdLambdaElasticsearchSNSAdminAccess",
       "Action": [
         "lambda:*",
         "es:*",
@@ -117,7 +95,6 @@
       "Effect": "Allow"
     },
     {
-      "Sid": "hcaDssCiCdAllowStateMachineAccess",
       "Action": "states:ListStateMachines",
       "Resource": "arn:aws:states:*:$account_id:*",
       "Effect": "Allow"
@@ -132,17 +109,26 @@
         "arn:aws:dynamodb:*:$account_id:table/dss-async-state-dev",
         "arn:aws:dynamodb:*:$account_id:table/dss-async-state-integration",
         "arn:aws:dynamodb:*:$account_id:table/dss-async-state-staging",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-dev",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-integration",
-        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-*-staging"
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-aws-dev",
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-aws-integration",
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-aws-staging",
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-gcp-dev",
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-gcp-integration",
+        "arn:aws:dynamodb:*:$account_id:table/dss-subscriptions-v2-gcp-staging"
       ]
     },
     {
       "Effect": "Allow",
       "Action": [
+        "lambda:List*",
+        "lambda:CreateEventSourceMapping",
+        "lambda:GetEventSourceMapping",
+        "lambda:TagResource",
+        "apigateway:*",
         "dynamodb:ListTables",
         "dynamodb:Query",
-        "dynamodb:DescribeTable"
+        "dynamodb:DescribeTable",
+        "sqs:ListQueues"
 	],
       "Resource": "*"
     },
@@ -159,15 +145,10 @@
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "sqs:*"
-      ],
-      "Resource": [
-        "arn:aws:sqs:*:$account_id:dss-dlq-*"
-      ]
+      "Action": "sqs:*",
+      "Resource": "arn:aws:sqs:*:$account_id:dss-dlq-*"
     },
     {
-      "Sid": "hcaDssCiCdSqsReadWriteQueues",
       "Effect": "Allow",
       "Action": [
         "sqs:CreateQueue",
@@ -188,23 +169,9 @@
       ]
     },
     {
-      "Sid": "hcaDssCiCdSqsReadListAllQueues",
       "Effect": "Allow",
-      "Action": [
-        "sqs:ListQueues"
-      ],
-      "Resource": [
-        "arn:aws:sqs:*:$account_id:*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "secretsmanager:Get*"
-      ],
-      "Resource": [
-        "arn:aws:secretsmanager:*:$account_id:secret:$DSS_SECRETS_STORE/*"
-      ]
+      "Action": "secretsmanager:Get*",
+      "Resource": "arn:aws:secretsmanager:*:$account_id:secret:$DSS_SECRETS_STORE/*"
     }
   ]
 }


### PR DESCRIPTION
We ran into a file size limit on our ci-cd group policy.  See #1963.