### PR TITLE
[Easy] Centralize SECURITY.md, and delete security.txt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,5 +396,8 @@ AWS Xray tracing is used for profiling the performance of deployed lambdas. This
 setting the lambda environment variable `DSS_XRAY_TRACE=1`. For all other daemons you must also check
 "Enable active tracking" under "Debugging and error handling" in the AWS Lambda console.
 
+## Security Policy
+See our [Security Policy](https://github.com/HumanCellAtlas/dcp/blob/master/SECURITY.md).
+
 ## Contributing
 External contributions are welcome. Please review the [Contributing Guidelines](CONTRIBUTING.md)

--- a/security.txt
+++ b/security.txt
@@ -1,3 +1,0 @@
-If you'd like to report a security issue please contact us.
-
-Contact: security-leads@data.humancellatlas.org


### PR DESCRIPTION
Links to the centralized policy at `dcp`, based on the conversation here: https://github.com/HumanCellAtlas/dcp/issues/274 .