### PR TITLE
[WIP] Add enumeration endpoint for collections (closes #1932)

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -995,6 +995,7 @@ paths:
                   - code
   /collections:
     get:
+      operationId: dss.api.collections.list
       security:
         - dcpAuth: []
       summary: Retrieve a user's collections.

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -994,6 +994,57 @@ paths:
                 required:
                   - code
   /collections:
+    get:
+      security:
+        - dcpAuth: []
+      summary: Retrieve a user's collections.
+      description: >
+        Return a list of associated collections.
+      parameters:
+        - name: replica
+          in: query
+          description: Replica to fetch from.
+          required: true
+          type: string
+          enum: [aws, gcp]
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              collections:
+                type: array
+                items:
+                  $ref: "#/definitions/Collection"
+        500:
+          $ref: '#/responses/ServerError'
+        502:
+          $ref: '#/responses/BadGateway'
+        503:
+          $ref: '#/responses/ServiceUnavailable'
+        504:
+          $ref: '#/responses/GatewayTimeout'
+        default:
+          description: Unexpected error
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+
+
+                      The code `invalid_link` indicates that an item listed in the collection contents field of the
+                      input could not be resolved (either because the file, bundle, or collection does not exist on the
+                      replica specified, or because the JSON Pointer reference could not be resolved within the
+                      specified file).
+                    enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found, invalid_link, read_only]
+                required:
+                  - code
     put:
       security:
         - dcpAuth: []

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -48,7 +48,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 @dss_handler
 @security.authorized_group_required(['hca'])
-def list(replica: str):
+def find(replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     bucket = Replica[replica].bucket
     handle = Config.get_blobstore_handle(Replica[replica])

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -48,7 +48,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 @dss_handler
 @security.authorized_group_required(['hca'])
-def find(replica: str):
+def list(replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     bucket = Replica[replica].bucket
     handle = Config.get_blobstore_handle(Replica[replica])

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -48,6 +48,20 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 @dss_handler
 @security.authorized_group_required(['hca'])
+def list(replica: str):
+    authenticated_user_email = security.get_token_email(request.token_info)
+    bucket = Replica[replica].bucket
+    handle = Config.get_blobstore_handle(Replica[replica])
+    collections = []
+    for key in handle.list(bucket):
+        collection_blob = handle.get(bucket, CollectionFQID.from_key(key))
+        collection = json.loads(collection_blob)
+        if collection['owner'] == authenticated_user_email:
+            collections.append(collection)
+    return jsonify(collections), requests.codes.ok
+
+@dss_handler
+@security.authorized_group_required(['hca'])
 def get(uuid: str, replica: str, version: str = None):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)

--- a/scripts/swagger_auth.py
+++ b/scripts/swagger_auth.py
@@ -12,7 +12,7 @@ sys.path.insert(0, pkg_root)  # noqa
 default_auth = {"/files/{uuid}": ["put"],
                 "/subscriptions": ["get", "put"],
                 "/subscriptions/{uuid}": ["get", "delete"],
-                "/collections": ["put"],
+                "/collections": ["get", "put"],
                 "/collections/{uuid}": ["get", "patch", "delete"],
                 "/bundles/{uuid}": ["put", "delete"]
                }
@@ -22,7 +22,7 @@ full_auth = {"/search": ["post"],
              "/files/{uuid}": ["head", "get", "put"],
              "/subscriptions": ["get", "put"],
              "/subscriptions/{uuid}": ["get", "delete"],
-             "/collections": ["put"],
+             "/collections": ["get", "put"],
              "/collections/{uuid}": ["get", "patch", "delete"],
              "/bundles/{uuid}": ["get", "put", "delete"],
              "/bundles/{uuid}/checkout": ["post"],

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -88,6 +88,14 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                                params=dict(replica="aws"))
             self.assertEqual(res.json()["contents"], [self.col_file_item, self.col_ptr_item])
 
+    def test_list(self):
+        "GET collections belonging to user"
+        res = self.app.get('/v1/collections',
+                           headers=get_auth_header(authorized=True),
+                           params=dict(replica='aws'))
+        res.raise_for_status()
+        self.assertEqual(len(res.json()), 1)
+
     def test_get(self):
         "GET created collection"
         res = self.app.get("/v1/collections/{}".format(self.uuid),


### PR DESCRIPTION
This PR adds support for listing the collections that a user owns (`GET /collections`). Collection metadata isn't yet indexed, so the method will list all collections in a replica, which is expensive.

This should be considered a work in progress:
* I am still working with @amarjandu to test this more thoroughly locally (waiting on platform-hca setup)
* The added unit test is insufficient to test the entirety of the PR (ideally, should also test that the method does *not* present a bundle that the requester is not authorized to see)