### PR TITLE
Increase Lambda mem+cpu

### DIFF
--- a/chalice/.chalice/config.json
+++ b/chalice/.chalice/config.json
@@ -13,5 +13,5 @@
     }
   },
   "lambda_timeout": 300,
-  "lambda_memory_size": 256
+  "lambda_memory_size": 1280
 }


### PR DESCRIPTION
Adding 1000 files to a collection or bundle currently tends to time out.

With this change, and some forthcoming parallelization changes, adding 1000 files to a collection takes ~12 seconds, and adding 1000 files to a bundle takes ~5 seconds.

API Lambda costs are increased by a factor of 5 (from 0.000000417/100ms to 0.000002084/100ms).

connects to #1901