### PR TITLE
Add a root collections endpoint.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -996,6 +996,58 @@ paths:
                 required:
                   - code
   /collections:
+    get:
+      operationId: dss.api.collections.list
+      security:
+        - dcpAuth: []
+      summary: Retrieve a user's collections.
+      description: >
+        Return a list of associated collections.
+      parameters:
+        - name: replica
+          in: query
+          description: Replica to fetch from.
+          required: true
+          type: string
+          enum: [aws, gcp]
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              collections:
+                type: array
+                items:
+                  $ref: "#/definitions/Collection"
+        500:
+          $ref: '#/responses/ServerError'
+        502:
+          $ref: '#/responses/BadGateway'
+        503:
+          $ref: '#/responses/ServiceUnavailable'
+        504:
+          $ref: '#/responses/GatewayTimeout'
+        default:
+          description: Unexpected error
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    description: >
+                      Machine-readable error code.  The types of return values should not be changed lightly.
+
+
+                      The code `invalid_link` indicates that an item listed in the collection contents field of the
+                      input could not be resolved (either because the file, bundle, or collection does not exist on the
+                      replica specified, or because the JSON Pointer reference could not be resolved within the
+                      specified file).
+                    enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found, invalid_link, read_only]
+                required:
+                  - code
     put:
       security:
         - dcpAuth: []

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -997,12 +997,21 @@ paths:
                   - code
   /collections:
     get:
-      operationId: dss.api.collections.list
+      operationId: dss.api.collections.listc
       security:
         - dcpAuth: []
       summary: Retrieve a user's collections.
       description: >
-        Return a list of associated collections.
+        Return a list of a user's collections.
+
+        Collections are sets of links to files, bundles, other collections, or fragments of JSON metadata files. Each
+        entry in the input set of links is checked for referential integrity (the link target must exist in the replica
+        referenced). Up to 1000 items can be referenced in a new collection, or added or removed using
+        `PATCH /collections`. New collections are private to the authenticated user.
+
+        Collection items are de-duplicated (if an identical item is given multiple times, it will only be added once).
+
+        Collections are replicated across storage replicas similarly to files and bundles.
       parameters:
         - name: replica
           in: query
@@ -1017,9 +1026,10 @@ paths:
             type: object
             properties:
               collections:
+                description: A user's collections.
                 type: array
                 items:
-                  $ref: "#/definitions/Collection"
+                  $ref: '#/definitions/CollectionOfCollectionsItem'
         500:
           $ref: '#/responses/ServerError'
         502:
@@ -1037,15 +1047,8 @@ paths:
                 properties:
                   code:
                     type: string
-                    description: >
-                      Machine-readable error code.  The types of return values should not be changed lightly.
-
-
-                      The code `invalid_link` indicates that an item listed in the collection contents field of the
-                      input could not be resolved (either because the file, bundle, or collection does not exist on the
-                      replica specified, or because the JSON Pointer reference could not be resolved within the
-                      specified file).
-                    enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found, invalid_link, read_only]
+                    description: Machine-readable error code.  The types of return values should not be changed lightly.
+                    enum: [unhandled_exception, Forbidden, Unauthorized, OAuthResponseProblem, not_found]
                 required:
                   - code
     put:
@@ -1055,15 +1058,12 @@ paths:
       description: >
         Create a new collection.
 
-
         Collections are sets of links to files, bundles, other collections, or fragments of JSON metadata files. Each
         entry in the input set of links is checked for referential integrity (the link target must exist in the replica
         referenced). Up to 1000 items can be referenced in a new collection, or added or removed using
         `PATCH /collections`. New collections are private to the authenticated user.
 
-
         Collection items are de-duplicated (if an identical item is given multiple times, it will only be added once).
-
 
         Collections are replicated across storage replicas similarly to files and bundles.
       parameters:
@@ -2415,6 +2415,22 @@ definitions:
         description: The total number of matching results found.
         type: integer
       #TODO add next page
+  CollectionOfCollectionsItem:
+    type: object
+    properties:
+      collection_uuid:
+        type: string
+        description: A UUID identifying the collection.
+        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+      collection_version:
+        type: string
+        description: The version of the UUID identifying the collection.
+      collection:
+        $ref: '#/definitions/Collection'
+    required:
+      - collection_uuid
+      - collection_version
+      - collection
   Collection:
     type: object
     properties:
@@ -2456,7 +2472,7 @@ definitions:
       path:
         type: string
         description: >
-          JSON Pointer indexing into the JSON conents of the file containing a metadata fragment.
+          JSON Pointer indexing into the JSON contents of the file containing a metadata fragment.
           Required for links of type other than file, bundle, or collection. Ignored otherwise.
     required:
       - type

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -997,7 +997,7 @@ paths:
                   - code
   /collections:
     get:
-      operationId: dss.api.collections.listc
+      operationId: dss.api.collections.listcollections
       security:
         - dcpAuth: []
       summary: Retrieve a user's collections.

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -48,7 +48,7 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 @dss_handler
 @security.authorized_group_required(['hca'])
-def listc(replica: str):
+def listcollections(replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     bucket = Replica[replica].bucket
     handle = Config.get_blobstore_handle(Replica[replica])

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -48,6 +48,20 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 @dss_handler
 @security.authorized_group_required(['hca'])
+def list(replica: str):
+    authenticated_user_email = security.get_token_email(request.token_info)
+    bucket = Replica[replica].bucket
+    handle = Config.get_blobstore_handle(Replica[replica])
+    collections = []
+    for key in handle.list(bucket):
+        collection_blob = handle.get(bucket, CollectionFQID.from_key(key))
+        collection = json.loads(collection_blob)
+        if collection['owner'] == authenticated_user_email:
+            collections.append(collection)
+    return jsonify(collections), requests.codes.ok
+
+@dss_handler
+@security.authorized_group_required(['hca'])
 def get(uuid: str, replica: str, version: str = None):
     authenticated_user_email = security.get_token_email(request.token_info)
     collection_body = get_impl(uuid=uuid, replica=replica, version=version)

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -1,5 +1,5 @@
 import json, logging, datetime, io, functools
-from typing import List
+from typing import List, Dict, Any
 from uuid import uuid4
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
@@ -48,17 +48,21 @@ def get_impl(uuid: str, replica: str, version: str = None):
 
 @dss_handler
 @security.authorized_group_required(['hca'])
-def list(replica: str):
+def listc(replica: str):
     authenticated_user_email = security.get_token_email(request.token_info)
     bucket = Replica[replica].bucket
     handle = Config.get_blobstore_handle(Replica[replica])
+
     collections = []
-    for key in handle.list(bucket):
-        collection_blob = handle.get(bucket, CollectionFQID.from_key(key))
-        collection = json.loads(collection_blob)
-        if collection['owner'] == authenticated_user_email:
-            collections.append(collection)
-    return jsonify(collections), requests.codes.ok
+    for key in handle.list(bucket, prefix='collections'):
+        uuid, version = key[len('collections/'):].split('.', 1)
+        if version != 'dead':
+            collection = json.loads(handle.get(bucket, key))
+            if collection['owner'] == authenticated_user_email:
+                collections.append({'collection_uuid': uuid,
+                                    'collection_version': version,
+                                    'collection': collection})
+    return jsonify({'collections': collections}), requests.codes.ok
 
 @dss_handler
 @security.authorized_group_required(['hca'])

--- a/scripts/swagger_auth.py
+++ b/scripts/swagger_auth.py
@@ -12,7 +12,7 @@ sys.path.insert(0, pkg_root)  # noqa
 default_auth = {"/files/{uuid}": ["put"],
                 "/subscriptions": ["get", "put"],
                 "/subscriptions/{uuid}": ["get", "delete"],
-                "/collections": ["put"],
+                "/collections": ["get", "put"],
                 "/collections/{uuid}": ["get", "patch", "delete"],
                 "/bundles/{uuid}": ["put", "patch", "delete"]
                }
@@ -22,7 +22,7 @@ full_auth = {"/search": ["post"],
              "/files/{uuid}": ["head", "get", "put"],
              "/subscriptions": ["get", "put"],
              "/subscriptions/{uuid}": ["get", "delete"],
-             "/collections": ["put"],
+             "/collections": ["get", "put"],
              "/collections/{uuid}": ["get", "patch", "delete"],
              "/bundles/{uuid}": ["get", "put", "patch", "delete"],
              "/bundles/{uuid}/checkout": ["post"],

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -88,6 +88,14 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                                params=dict(replica="aws"))
             self.assertEqual(res.json()["contents"], [self.col_file_item, self.col_ptr_item])
 
+    def test_list(self):
+        "GET collections belonging to user"
+        res = self.app.get('/v1/collections',
+                           headers=get_auth_header(authorized=True),
+                           params=dict(replica='aws'))
+        res.raise_for_status()
+        self.assertEqual(len(res.json()), 1)
+
     def test_get(self):
         "GET created collection"
         res = self.app.get("/v1/collections/{}".format(self.uuid),

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -69,8 +69,16 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         cls._delete_collection(cls, cls.uuid)
         cls.app.shutdown()
 
+    def test_get(self):
+        """GET a list of all collections belonging to the user."""
+        res = self.app.get('/v1/collections',
+                           headers=get_auth_header(authorized=True),
+                           params=dict(replica='aws'))
+        res.raise_for_status()
+        self.assertIn('collections', res.json())
+
     def test_put(self):
-        "PUT new collection"
+        """PUT new collection."""
         with self.subTest("with unique contents"):
             contents = [self.col_file_item, self.col_ptr_item]
             uuid, _ = self._put(contents)
@@ -88,24 +96,16 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                                params=dict(replica="aws"))
             self.assertEqual(res.json()["contents"], [self.col_file_item, self.col_ptr_item])
 
-    def test_list(self):
-        "GET collections belonging to user"
-        res = self.app.get('/v1/collections',
-                           headers=get_auth_header(authorized=True),
-                           params=dict(replica='aws'))
-        res.raise_for_status()
-        self.assertEqual(len(res.json()), 1)
-
-    def test_get(self):
-        "GET created collection"
+    def test_get_uuid(self):
+        """GET created collection."""
         res = self.app.get("/v1/collections/{}".format(self.uuid),
                            headers=get_auth_header(authorized=True),
                            params=dict(version=self.version, replica="aws"))
         res.raise_for_status()
         self.assertEqual(res.json()["contents"], [self.col_file_item, self.col_ptr_item])
 
-    def test_get_latest(self):
-        "GET latest version of collection."
+    def test_get_uuid_latest(self):
+        """GET latest version of collection."""
         res = self.app.get("/v1/collections/{}".format(self.uuid),
                            headers=get_auth_header(authorized=True),
                            params=dict(replica="aws"))
@@ -113,14 +113,14 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self.assertEqual(res.json()["contents"], [self.col_file_item, self.col_ptr_item])
 
     def test_get_version_not_found(self):
-        "NOT FOUND is returned when version does not exist."
+        """NOT FOUND is returned when version does not exist."""
         res = self.app.get("/v1/collections/{}".format(self.uuid),
                            headers=get_auth_header(authorized=True),
                            params=dict(replica="aws", version="9000"))
         self.assertEqual(res.status_code, requests.codes.not_found)
 
     def test_patch_no_version(self):
-        "BAD REQUEST is returned when patching without the version."
+        """BAD REQUEST is returned when patching without the version."""
         res = self.app.patch("/v1/collections/{}".format(self.uuid),
                              headers=get_auth_header(authorized=True),
                              params=dict(replica="aws"),
@@ -167,7 +167,7 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                 self.assertEqual(collection, expected_contents)
 
     def test_put_invalid_fragment(self):
-        "PUT invalid fragment reference"
+        """PUT invalid fragment reference."""
         uuid = str(uuid4())
         self.addCleanup(self._delete_collection, uuid)
         res = self.app.put("/v1/collections",
@@ -177,7 +177,7 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self.assertEqual(res.status_code, requests.codes.unprocessable_entity)
 
     def test_patch_invalid_fragment(self):
-        "PATCH invalid fragment reference"
+        """PATCH invalid fragment reference."""
         res = self.app.patch("/v1/collections/{}".format(self.uuid),
                              headers=get_auth_header(authorized=True),
                              params=dict(version=self.version, replica="aws"),
@@ -185,7 +185,7 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self.assertEqual(res.status_code, requests.codes.unprocessable_entity)
 
     def test_patch_excessive(self):
-        "PATCH excess payload"
+        """PATCH excess payload."""
         res = self.app.patch("/v1/collections/{}".format(self.uuid),
                              headers=get_auth_header(authorized=True),
                              params=dict(version=self.version, replica="aws"),


### PR DESCRIPTION
Addresses #1932.

This endpoint adds the `GET /collections` root endpoint which allows a user to retrieve all of their collections without knowing the UUID for each one.

For example:
```
res = self.app.get('/v1/collections',
                    headers=get_auth_header(authorized=True),
                    params=dict(replica='aws'))
print(res.json())
```
Should return something like this:
```
{
  "collections": [
    {
      "collection": {
        "contents": [
          {
            "type": "file",
            "uuid": "29aad27a-536a-42c3-92df-e7c5a14df22d",
            "version": "2019-04-02T165421.995240Z"
          },
          {
            "fragment": "/foo",
            "type": "foo",
            "uuid": "29aad27a-536a-42c3-92df-e7c5a14df22d",
            "version": "2019-04-02T165421.995240Z"
          }
        ],
        "description": "d",
        "details": {},
        "name": "n",
        "owner": "service-account@b.gserviceaccount.com"
      },
      "collection_uuid": "69649f49-595e-4d88-897b-430a904ae491",
      "collection_version": "2019-04-02T095424.559988Z"
    },
    {
      "collection": {
        "contents": [
          {
            "type": "file",
            "uuid": "29aad27a-536a-42c3-92df-e7c5a14df22d",
            "version": "2019-04-02T165421.995240Z"
          },
          {
            "fragment": "/foo",
            "type": "foo",
            "uuid": "29aad27a-536a-42c3-92df-e7c5a14df22d",
            "version": "2019-04-02T165421.995240Z"
          }
        ],
        "description": "d",
        "details": {},
        "name": "n",
        "owner": "service-account@b.gserviceaccount.com"
      },
      "collection_uuid": "8fedec52-b528-4d88-9d1b-83dab039ea69",
      "collection_version": "2019-04-02T095423.287298Z"
    }
  ]
}
```
A follow-up PR will be made to add paging to this once this is merged.