### PR TITLE
Add paging to collections.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1019,6 +1019,23 @@ paths:
           required: true
           type: string
           enum: [aws, gcp]
+        - name: per_page
+          in: query
+          description: Max number of results to return per page.
+          required: false
+          type: integer
+          format: int32
+          minimum: 50
+          maximum: 100
+          default: 100
+        - name: start_at
+          in: query
+          description: >
+            An internal state pointer parameter for use with pagination. This parameter is referenced by the `Link`
+            header as described in the "Pagination" section. The API client should not need to set this parameter
+            directly; it should instead directly fetch the URL given in the `Link` header.
+          required: false
+          type: integer
       responses:
         200:
           description: OK
@@ -1030,6 +1047,23 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/CollectionOfCollectionsItem'
+        206:
+          description: A single page of results was retrieved.
+          schema:
+            type: object
+            properties:
+              collections:
+                description: A user's collections.
+                type: array
+                items:
+                  $ref: '#/definitions/CollectionOfCollectionsItem'
+          headers:
+            Link:
+              type: string
+              description: >
+                URL to retrieve the next page of results, conforming to [RFC 5988](https://tools.ietf.org/html/rfc5988)
+                The URL in the header refers to the next page of the results to be fetched; if no `Link rel="next"` URL is
+                included, then all results have been fetched.
         500:
           $ref: '#/responses/ServerError'
         502:

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -1,12 +1,12 @@
 import json, logging, datetime, io, functools
-from typing import List, Dict, Any
+from typing import List
 from uuid import uuid4
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from collections import OrderedDict
 
 import requests
-from flask import jsonify, request
+from flask import jsonify, request, make_response
 import jsonpointer
 
 from dss import Config, Replica
@@ -14,7 +14,7 @@ from dss.error import DSSException, dss_handler
 from dss.storage.blobstore import test_object_exists
 from dss.storage.hcablobstore import BlobStore, compose_blob_key
 from dss.storage.identifiers import CollectionFQID, CollectionTombstoneID
-from dss.util import security, hashabledict
+from dss.util import security, hashabledict, UrlBuilder
 from dss.util.version import datetime_to_version_format
 from dss.api.bundles import _idempotent_save
 
@@ -46,23 +46,43 @@ def get_impl(uuid: str, replica: str, version: str = None):
         raise DSSException(404, "not_found", "Could not find collection for UUID {}".format(uuid))
     return json.loads(collection_blob)
 
+def fetch_collections(handle, bucket, collection_keys):
+    authenticated_user_email = security.get_token_email(request.token_info)
+
+    all_collections = []
+    for key in collection_keys:
+        uuid, version = key[len('collections/'):].split('.', 1)
+        assert version != 'dead'
+        collection = json.loads(handle.get(bucket, key))
+        if collection['owner'] == authenticated_user_email:
+            all_collections.append({'collection_uuid': uuid,
+                                    'collection_version': version,
+                                    'collection': collection})
+    return all_collections
+
 @dss_handler
 @security.authorized_group_required(['hca'])
-def listcollections(replica: str):
-    authenticated_user_email = security.get_token_email(request.token_info)
+def listcollections(replica: str, per_page: int, start_at: int = 0):
     bucket = Replica[replica].bucket
     handle = Config.get_blobstore_handle(Replica[replica])
 
-    collections = []
-    for key in handle.list(bucket, prefix='collections'):
-        uuid, version = key[len('collections/'):].split('.', 1)
-        if version != 'dead':
-            collection = json.loads(handle.get(bucket, key))
-            if collection['owner'] == authenticated_user_email:
-                collections.append({'collection_uuid': uuid,
-                                    'collection_version': version,
-                                    'collection': collection})
-    return jsonify({'collections': collections}), requests.codes.ok
+    # expensively list every collection file in the bucket, even those not belonging to the user (possibly 1000's... )
+    collection_keys = [i for i in handle.list(bucket, prefix='collections') if not i.endswith('dead')]
+
+    # paged response
+    if len(collection_keys) - start_at > per_page:
+        next_url = UrlBuilder(request.url)
+        next_url.replace_query("start_at", str(start_at + per_page))
+        # each chunk will be searched for collections belonging to that user (even more expensive; per bucket file)
+        # hits returned will vary between zero and the "per_page" size of the chunk
+        collections = fetch_collections(handle, bucket, collection_keys[start_at:start_at + per_page])
+        response = make_response(jsonify({'collections': collections}), requests.codes.partial)
+        response.headers['Link'] = f"<{next_url}>; rel='next'"
+        return response
+    # single response returning all collections (or those remaining)
+    else:
+        collections = fetch_collections(handle, bucket, collection_keys[start_at:])
+        return jsonify({'collections': collections}), requests.codes.ok
 
 @dss_handler
 @security.authorized_group_required(['hca'])

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -133,7 +133,7 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
                 self._test_bundle_get_paging(replica, list(), 501, codes=requests.codes.bad_request)
 
     def _test_bundle_get_paging(self,
-                                replica: str,
+                                replica,
                                 expected_files: list,
                                 per_page: int,
                                 codes={requests.codes.ok, requests.codes.partial},

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -105,7 +105,7 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
             ))
             expected_files = manifest['files']
 
-        for replica in Replica:
+        for replica in (Replica.aws, Replica.gcp):
             for pass_version in [True, False]:
                 for per_page in [11, 33]:
                     with self.subTest(replica=replica, per_page=per_page, pass_version=pass_version):
@@ -120,7 +120,7 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
         """
         Should NOT be able to use a too-small per_page
         """
-        for replica in Replica:
+        for replica in (Replica.aws, Replica.gcp):
             with self.subTest(replica):
                 self._test_bundle_get_paging(replica, list(), 9, codes=requests.codes.bad_request)
 
@@ -128,17 +128,16 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
         """
         Should NOT be able to use a too-large per_page
         """
-        for replica in Replica:
+        for replica in (Replica.aws, Replica.gcp):
             with self.subTest(replica):
-                self._test_bundle_get_paging(Replica.aws, list(), 501, codes=requests.codes.bad_request)
+                self._test_bundle_get_paging(replica, list(), 501, codes=requests.codes.bad_request)
 
     def _test_bundle_get_paging(self,
-                                replica: Replica,
+                                replica: str,
                                 expected_files: list,
                                 per_page: int,
                                 codes={requests.codes.ok, requests.codes.partial},
                                 pass_version: bool = True):
-        replica = Replica.aws
         bundle_uuid = "7f8c686d-a439-4376-b367-ac93fc28df43"
         version = "2019-02-21T184000.899031Z"
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,24 +1,29 @@
 #!/usr/bin/env python3
 import typing
-
 import itertools
-import os, sys, unittest, io, json
+import os
+import sys
+import unittest
+import io
+import json
+import boto3
+
 from uuid import uuid4
 from datetime import datetime
-
-import boto3
+from requests.utils import parse_header_links
 from botocore.vendored import requests
 from dcplib.s3_multipart import get_s3_multipart_chunk_size
+from urllib.parse import parse_qsl, urlparse, urlsplit
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 from tests import get_auth_header
-from tests.infra import generate_test_key, get_env, DSSAssertMixin, DSSUploadMixin
+from tests.infra import generate_test_key, get_env, DSSAssertMixin, DSSUploadMixin, testmode
+from tests.infra.server import ThreadedLocalServer
 from tests.fixtures.cloud_uploader import ChecksummingSink
 from dss.util.version import datetime_to_version_format
 from dss.util import UrlBuilder
-from tests.infra.server import ThreadedLocalServer
 
 
 class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
@@ -30,9 +35,16 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         cls.file_uuid, cls.file_version = cls.upload_file(cls.app, {"foo": 1})
         cls.col_file_item = dict(type="file", uuid=cls.file_uuid, version=cls.file_version)
         cls.col_ptr_item = dict(type="foo", uuid=cls.file_uuid, version=cls.file_version, fragment="/foo")
+
         cls.contents = [cls.col_file_item] * 8 + [cls.col_ptr_item] * 8
         cls.uuid, cls.version = cls._put(cls, cls.contents)
         cls.invalid_ptr = dict(type="foo", uuid=cls.file_uuid, version=cls.file_version, fragment="/xyz")
+        cls.replicas = ('aws', 'gcp')
+
+    @classmethod
+    def teardownClass(cls):
+        cls._delete_collection(cls, cls.uuid)
+        cls.app.shutdown()
 
     @staticmethod
     def upload_file(app, contents):
@@ -64,11 +76,64 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         resp_obj.raise_for_status()
         return file_uuid, resp_obj.json()["version"]
 
-    @classmethod
-    def teardownClass(cls):
-        cls._delete_collection(cls, cls.uuid)
-        cls.app.shutdown()
+    def _test_collection_get_paging(self, codes, replica: str, per_page: int, fetch_all: bool=False):
+        """
+        Attempts to ensure that a GET /collections call responds with a 206.
 
+        If unsuccessful on the first attempt, temp collections will be added for the user to ensure a response
+        and the GET /collections will be reattempted.
+        """
+        paging_res = self._fetch_collection_get_paging_responses(codes, replica, per_page, fetch_all)
+
+        # only create a ton of collections when not enough collections exist in the bucket to elicit a paging response
+        if not paging_res:
+            self.create_temp_user_collections(num=per_page + 1)  # guarantee a paging response
+            paging_res = self._fetch_collection_get_paging_responses(codes, replica, per_page, fetch_all)
+            self.assertTrue(paging_res)
+
+    def create_temp_user_collections(self, num: int):
+        for i in range(num):
+            contents = [self.col_file_item, self.col_ptr_item]
+            uuid, _ = self._put(contents)
+            self.addCleanup(self._delete_collection, uuid)
+
+    def _fetch_collection_get_paging_responses(self, codes, replica: str, per_page: int, fetch_all: bool):
+        """
+        GET /collections and iterate through the paging responses containing all of a user's collections.
+
+        If fetch_all is not True, this will return as soon as it gets one successful 206 paging reply.
+        """
+        url = UrlBuilder().set(path="/v1/collections/")
+        url.add_query("replica", replica)
+        url.add_query("per_page", str(per_page))
+        resp_obj = self.assertGetResponse(str(url), codes, headers=get_auth_header(authorized=True))
+        link_header = resp_obj.response.headers.get('Link')
+
+        paging_res, normal_res = None, None
+        while link_header:
+            link = parse_header_links(link_header)[0]
+            self.assertEquals(link['rel'], 'next')
+            parsed = urlsplit(link['url'])
+            url = str(UrlBuilder().set(path=parsed.path, query=parse_qsl(parsed.query), fragment=parsed.fragment))
+            resp_obj = self.assertGetResponse(url,
+                                              expected_code=codes,
+                                              headers=get_auth_header(authorized=True))
+            link_header = resp_obj.response.headers.get('Link')
+
+            # Make sure we're getting the expected response status code
+            if link_header:
+                self.assertEqual(resp_obj.response.status_code, requests.codes.partial)
+                paging_res = True
+                if not fetch_all:
+                    return paging_res
+            else:
+                self.assertEqual(resp_obj.response.status_code, requests.codes.ok)
+                normal_res = True
+        if fetch_all:
+            self.assertTrue(normal_res)
+        return paging_res
+
+    @testmode.standalone
     def test_get(self):
         """GET a list of all collections belonging to the user."""
         res = self.app.get('/v1/collections',
@@ -76,6 +141,36 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                            params=dict(replica='aws'))
         res.raise_for_status()
         self.assertIn('collections', res.json())
+
+    @testmode.standalone
+    def test_collection_paging(self):
+        # seems to take about 15 seconds per page when "per_page" == 100
+        # so this scales linearly with the total number of collections in the bucket
+        # slow because the collection API has to open ALL collections files in the bucket
+        # since it cannot determine the owner without opening the file
+        # TODO collections desperately need indexing to run in a reasonable amount of time
+        codes = {requests.codes.ok, requests.codes.partial}
+        for replica in ['aws']:  # TODO: change ['aws'] to self.replicas when GET collections is faster (indexed)
+            for per_page in [50, 100]:
+                with self.subTest(replica=replica, per_page=per_page):
+                    # only check a full run if per_page == 100 because it takes forever
+                    fetch_all = True if per_page == 100 else False
+                    self._test_collection_get_paging(codes=codes,
+                                                     replica=replica,
+                                                     per_page=per_page,
+                                                     fetch_all=fetch_all)
+
+    def test_collection_paging_too_small(self):
+        """Should NOT be able to use a too-small per_page."""
+        for replica in self.replicas:
+            with self.subTest(replica):
+                self._test_collection_get_paging(replica=replica, per_page=49, codes=requests.codes.bad_request)
+
+    def test_collection_paging_too_large(self):
+        """Should NOT be able to use a too-large per_page."""
+        for replica in self.replicas:
+            with self.subTest(replica):
+                self._test_collection_get_paging(replica=replica, per_page=101, codes=requests.codes.bad_request)
 
     def test_put(self):
         """PUT new collection."""

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -114,8 +114,8 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             link = parse_header_links(link_header)[0]
             self.assertEquals(link['rel'], 'next')
             parsed = urlsplit(link['url'])
-            url = str(UrlBuilder().set(path=parsed.path, query=parse_qsl(parsed.query), fragment=parsed.fragment))
-            resp_obj = self.assertGetResponse(url,
+            url = UrlBuilder().set(path=parsed.path, query=parse_qsl(parsed.query), fragment=parsed.fragment)
+            resp_obj = self.assertGetResponse(str(url),
                                               expected_code=codes,
                                               headers=get_auth_header(authorized=True))
             link_header = resp_obj.response.headers.get('Link')

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -109,6 +109,9 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         resp_obj = self.assertGetResponse(str(url), codes, headers=get_auth_header(authorized=True))
         link_header = resp_obj.response.headers.get('Link')
 
+        if codes == requests.codes.bad_request:
+            return True
+
         paging_res, normal_res = None, None
         while link_header:
             link = parse_header_links(link_header)[0]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -142,7 +142,6 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         res.raise_for_status()
         self.assertIn('collections', res.json())
 
-    @testmode.standalone
     def test_collection_paging(self):
         # seems to take about 15 seconds per page when "per_page" == 100
         # so this scales linearly with the total number of collections in the bucket


### PR DESCRIPTION
Addresses #1920.

This adds paging to the new `GET /collections` root endpoint, with some caveats.

Right now this is really expensive as all collections in a bucket need to be searched and opened to determine ownership before returning the information to the user.

To prevent timing out, I've put in a max paging size of 100 (min 50).  This will check each chunk of 100 `collection` files in the bucket and return any belonging to the user per page (takes about 15s per page when the bucket contains about 2000 collections).

This means instead of returning 100 collections per page, it will return between 0 and 100 collections per page since it needs to check them all, but only some will belong to the user.

Collections need to be indexed to make this scalable.