### PR TITLE
[Easy] PATCH /bundle sets version correctly

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -217,6 +217,7 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
 
     timestamp = datetime.datetime.utcnow()
     new_bundle_version = datetime_to_version_format(timestamp)
+    bundle['version'] = new_bundle_version
     _save_bundle(handle, Replica[replica].bucket, uuid, new_bundle_version, bundle)
     return jsonify(dict(uuid=uuid, version=new_bundle_version)), requests.codes.ok
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -936,8 +936,9 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
                 res = self.app.get(
                     f"/v1/bundles/{bundle_uuid}",
                     headers=get_auth_header(authorized=True),
-                    params=dict(version=res.json()['version'], replica="aws"),
+                    params=dict(version=bundle_version, replica="aws"),
                 )
+                self.assertEqual(bundle_version, res.json()['bundle']['version'])
                 self.assertEqual(
                     set([bundle_file_id_metadata(f) for f in expected_files]),
                     set([bundle_file_id_metadata(f) for f in res.json()['bundle']['files']])


### PR DESCRIPTION
This fixes a bug wherePATCH /bundle was not updating bundle version in the manifest, and adds tests.

fixes #2015 