### PR TITLE
Use s3 multipart upload for large bundle manifests

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -352,16 +352,14 @@ def _idempotent_save(blobstore: BlobStore, bucket: str, key: str, data: dict) ->
     else:
         # write manifest to persistent store
         _d = json.dumps(data).encode("utf-8")
-        size = len(_d)
         part_size = 16 * 1024 * 1024
-        if isinstance(blobstore, S3BlobStore) and size > part_size:
+        if isinstance(blobstore, S3BlobStore) and len(_d) > part_size:
             with io.BytesIO(_d) as fh:
                 multipart_parallel_upload(
                     blobstore.s3_client,
                     bucket,
                     key,
                     fh,
-                    size=size,
                     part_size=part_size,
                     parallelization_factor=20
                 )

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -287,6 +287,7 @@ def build_bundle_file_metadata(replica: Replica, user_supplied_files: dict):
                 return json.loads(file_metadata)
         return None
 
+    # TODO: Consider scaling parallelization with Lambda size
     with ThreadPoolExecutor(max_workers=20) as e:
         futures = {e.submit(_get_file_metadata, _file): _file
                    for _file in files}

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -8,6 +8,7 @@ import datetime
 import nestedcontext
 import requests
 from cloud_blobstore import BlobNotFoundError, BlobStore, BlobStoreTimeoutError
+from cloud_blobstore.s3 import S3BlobStore
 from flask import jsonify, redirect, request, make_response
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -19,7 +20,7 @@ from dss.storage.checkout import CheckoutError, TokenError
 from dss.storage.checkout.bundle import get_dst_bundle_prefix, verify_checkout
 from dss.storage.identifiers import BundleTombstoneID, BundleFQID, FileFQID
 from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, FileMetadata
-from dss.util import UrlBuilder, security, hashabledict
+from dss.util import UrlBuilder, security, hashabledict, multipart_parallel_upload
 from dss.util.version import datetime_to_version_format
 
 """The retry-after interval in seconds. Sets up downstream libraries / users to
@@ -350,11 +351,22 @@ def _idempotent_save(blobstore: BlobStore, bucket: str, key: str, data: dict) ->
         return False, existing_data == data
     else:
         # write manifest to persistent store
-        blobstore.upload_file_handle(
-            bucket,
-            key,
-            io.BytesIO(json.dumps(data).encode("utf-8")),
-        )
+        _d = json.dumps(data).encode("utf-8")
+        size = len(_d)
+        part_size = 16 * 1024 * 1024
+        if isinstance(blobstore, S3BlobStore) and size > part_size:
+            with io.BytesIO(_d) as fh:
+                multipart_parallel_upload(
+                    blobstore.s3_client,
+                    bucket,
+                    key,
+                    fh,
+                    size=size,
+                    part_size=part_size,
+                    parallelization_factor=20
+                )
+        else:
+            blobstore.upload_file_handle(bucket, key, io.BytesIO(_d))
         return True, True
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import io
 import os
 import sys
 import unittest
@@ -10,8 +11,9 @@ sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 from dss import DSSException, DSSForbiddenException, Config
+from dss.config import Replica
 from dss.logging import configure_test_logging
-from dss.util import UrlBuilder, security
+from dss.util import UrlBuilder, security, multipart_parallel_upload
 from dss.util.aws import ARN
 from tests import UNAUTHORIZED_GCP_CREDENTIALS, get_service_jwt
 from tests.infra import testmode
@@ -216,6 +218,48 @@ class TestSecurity(unittest.TestCase):
                 security.get_token_email({})
             self.assertEqual(ex.exception.status, 401)
             self.assertEqual(ex.exception.message, 'Authorization token is missing email claims.')
+    def test_multipart_parallel_upload(self):
+        size = 7 * 1024 * 1024
+        data = os.urandom(size)
+        metadata = {'something': "foolish"}
+        part_size = 5 * 1024 * 1024
+        s3_client = Config.get_native_handle(Replica.aws)
+        bucket = os.environ['DSS_S3_BUCKET_TEST']
+        with self.subTest("copy multiple parts"):
+            with io.BytesIO(data) as fh:
+                multipart_parallel_upload(
+                    s3_client,
+                    bucket,
+                    "fake_key",
+                    fh,
+                    size=size,
+                    part_size=part_size,
+                    metadata=metadata,
+                    content_type="application/octet-stream",
+                )
+        part_size = 14 * 1024 * 1024
+        with self.subTest("should work with single part"):
+            with io.BytesIO(data) as fh:
+                multipart_parallel_upload(
+                    s3_client,
+                    bucket,
+                    "fake_key",
+                    fh,
+                    size=size,
+                    part_size=part_size,
+                )
+        part_size = 5 * 1024 * 1024
+        with self.subTest("should work parallelization factor of 1"):
+            with io.BytesIO(data) as fh:
+                multipart_parallel_upload(
+                    s3_client,
+                    bucket,
+                    "fake_key",
+                    fh,
+                    size=size,
+                    part_size=part_size,
+                    parallelization_factor=1,
+                )
 
     @staticmethod
     def restore_email_claims(old):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -218,9 +218,9 @@ class TestSecurity(unittest.TestCase):
                 security.get_token_email({})
             self.assertEqual(ex.exception.status, 401)
             self.assertEqual(ex.exception.message, 'Authorization token is missing email claims.')
+
     def test_multipart_parallel_upload(self):
-        size = 7 * 1024 * 1024
-        data = os.urandom(size)
+        data = os.urandom(7 * 1024 * 1024)
         metadata = {'something': "foolish"}
         part_size = 5 * 1024 * 1024
         s3_client = Config.get_native_handle(Replica.aws)
@@ -232,7 +232,6 @@ class TestSecurity(unittest.TestCase):
                     bucket,
                     "fake_key",
                     fh,
-                    size=size,
                     part_size=part_size,
                     metadata=metadata,
                     content_type="application/octet-stream",
@@ -245,20 +244,7 @@ class TestSecurity(unittest.TestCase):
                     bucket,
                     "fake_key",
                     fh,
-                    size=size,
                     part_size=part_size,
-                )
-        part_size = 5 * 1024 * 1024
-        with self.subTest("should work parallelization factor of 1"):
-            with io.BytesIO(data) as fh:
-                multipart_parallel_upload(
-                    s3_client,
-                    bucket,
-                    "fake_key",
-                    fh,
-                    size=size,
-                    part_size=part_size,
-                    parallelization_factor=1,
                 )
 
     @staticmethod


### PR DESCRIPTION
This improves PATCH /bundle performance by uploading large manifests in parallel, presumably saturating the Lambda-S3 network connection.

Incidentally, it may be possible to improve manifest paging performance by downloading individual parts from s3 multipart manifest objects.

closes #2012 