### PR TITLE
Exclude very large bundle manifests from ES document

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1633,8 +1633,7 @@ paths:
                   - The "name" of the file. This can be most anything, and is the name the file will have when downloaded.
                   - The "indexed" field, which specifies whether a file should be indexed or not.
 
-                  Bundles containing 20,000 files or more will not be indexed due to current limitations in our indexer
-                  and will not be searchable.  The user will be warned upon upload.
+                  Bundle manifests exceeding 20,000 files will not be indexed.
 
                   Example representing 2 files with dummy values:
                   [{'uuid': 'ce55fd51-7833-469b-be0b-5da88ebebfcd',
@@ -1749,8 +1748,7 @@ paths:
         Add or remove files from a bundle. A specific version of the bundle to update must be provided, and a
         new version will be written.
 
-        Bundles that now exceed 20,000 files will not be indexed due to current limitations in our indexer
-        and will not be searchable.  The user will be warned if their patch exceeds this limit.
+        Bundles manifests exceeding 20,000 files will not be indexed.
       parameters:
         - name: uuid
           in: path

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1633,7 +1633,7 @@ paths:
                   - The "name" of the file. This can be most anything, and is the name the file will have when downloaded.
                   - The "indexed" field, which specifies whether a file should be indexed or not.
 
-                  Bundle manifests exceeding 20,000 files will not be indexed.
+                  Bundle manifests exceeding 20,000 files will not be included in the Elasticsearch index document.
 
                   Example representing 2 files with dummy values:
                   [{'uuid': 'ce55fd51-7833-469b-be0b-5da88ebebfcd',
@@ -1748,7 +1748,7 @@ paths:
         Add or remove files from a bundle. A specific version of the bundle to update must be provided, and a
         new version will be written.
 
-        Bundles manifests exceeding 20,000 files will not be indexed.
+        Bundles manifests exceeding 20,000 files will not be included in the Elasticsearch index document.
       parameters:
         - name: uuid
           in: path

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1633,8 +1633,6 @@ paths:
                   - The "name" of the file. This can be most anything, and is the name the file will have when downloaded.
                   - The "indexed" field, which specifies whether a file should be indexed or not.
 
-                  There is a limit of 20,000 items per bundle.
-
                   Example representing 2 files with dummy values:
                   [{'uuid': 'ce55fd51-7833-469b-be0b-5da88ebebfcd',
                     'version': '2017-06-16T193604.240704Z',
@@ -1645,8 +1643,6 @@ paths:
                     'name': 'dragon_dna.fa',
                     'indexed': False}]
                 type: array
-                minItems: 1
-                maxItems: 20000
                 items:
                   $ref: '#/definitions/BundleFile'
               creator_uid:

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1633,6 +1633,9 @@ paths:
                   - The "name" of the file. This can be most anything, and is the name the file will have when downloaded.
                   - The "indexed" field, which specifies whether a file should be indexed or not.
 
+                  Bundles containing 20,000 files or more will not be indexed due to current limitations in our indexer
+                  and will not be searchable.  The user will be warned upon upload.
+
                   Example representing 2 files with dummy values:
                   [{'uuid': 'ce55fd51-7833-469b-be0b-5da88ebebfcd',
                     'version': '2017-06-16T193604.240704Z',
@@ -1745,6 +1748,9 @@ paths:
       description: >
         Add or remove files from a bundle. A specific version of the bundle to update must be provided, and a
         new version will be written.
+
+        Bundles that now exceed 20,000 files will not be indexed due to current limitations in our indexer
+        and will not be searchable.  The user will be warned if their patch exceeds this limit.
       parameters:
         - name: uuid
           in: path

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1633,6 +1633,8 @@ paths:
                   - The "name" of the file. This can be most anything, and is the name the file will have when downloaded.
                   - The "indexed" field, which specifies whether a file should be indexed or not.
 
+                  There is a limit of 20,000 items per bundle.
+
                   Example representing 2 files with dummy values:
                   [{'uuid': 'ce55fd51-7833-469b-be0b-5da88ebebfcd',
                     'version': '2017-06-16T193604.240704Z',
@@ -1643,6 +1645,8 @@ paths:
                     'name': 'dragon_dna.fa',
                     'indexed': False}]
                 type: array
+                minItems: 1
+                maxItems: 20000
                 items:
                   $ref: '#/definitions/BundleFile'
               creator_uid:

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -4,7 +4,6 @@ import json
 import time
 import typing
 import datetime
-import logging
 
 import nestedcontext
 import requests
@@ -218,7 +217,6 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     new_bundle_version = datetime_to_version_format(timestamp)
     bundle['version'] = new_bundle_version
     _save_bundle(handle, Replica[replica].bucket, uuid, new_bundle_version, bundle)
-
     return jsonify(dict(uuid=uuid, version=new_bundle_version)), requests.codes.ok
 
 

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -151,13 +151,6 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str):
     bucket = Replica[replica].bucket
 
     files = build_bundle_file_metadata(Replica[replica], json_request_body['files'])
-
-    if len(files) < 20000:
-        raise DSSException(
-            requests.codes.requested_range_not_satisfiable,
-            "File count in bundle exceeds the 20,000 file limit."
-        )
-
     detect_filename_collisions(files)
 
     # build a manifest consisting of all the files.
@@ -218,12 +211,6 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     bundle['files'] = [f for f in bundle['files'] if bundle_file_id_metadata(f) not in remove_files_set]
     add_files = json_request_body.get("add_files", [])
     bundle['files'].extend(build_bundle_file_metadata(Replica[replica], add_files))
-
-    if len(bundle['files']) < 20000:
-        raise DSSException(
-            requests.codes.requested_range_not_satisfiable,
-            "File count in bundle exceeds the 20,000 file limit."
-        )
     detect_filename_collisions(bundle['files'])
 
     timestamp = datetime.datetime.utcnow()

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -171,8 +171,8 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str):
     status_code = _save_bundle(handle, bucket, uuid, version, bundle_metadata)
 
     if len(files) > BUNDLE_FILE_INDEX_LIMIT:
-        log.warning('PUT /bundle/{uuid} request exceeds 20,000 file limit.  '
-                    'Files will not be indexed and will not be queryable.')
+        log.warning(f'PUT /bundle request exceeds {str(BUNDLE_FILE_INDEX_LIMIT)} file limit.  '
+                    f'Files will not be indexed and will not be queryable.')
 
     return jsonify(dict(version=bundle_metadata['version'], manifest=bundle_metadata)), status_code
 
@@ -230,8 +230,8 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     _save_bundle(handle, Replica[replica].bucket, uuid, new_bundle_version, bundle)
 
     if len(bundle['files']) > BUNDLE_FILE_INDEX_LIMIT:
-        log.warning('PUT /bundle/{uuid} request exceeds 20,000 file limit.  '
-                    'Files will not be indexed and will not be queryable.')
+        log.warning(f'PATCH /bundle request exceeds {str(BUNDLE_FILE_INDEX_LIMIT)} file limit.  '
+                    f'Files will not be indexed and will not be queryable.')
 
     return jsonify(dict(uuid=uuid, version=new_bundle_version)), requests.codes.ok
 

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -23,8 +23,6 @@ from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, FileMet
 from dss.util import UrlBuilder, security, hashabledict
 from dss.util.version import datetime_to_version_format
 
-log = logging.getLogger(__name__)
-
 """The retry-after interval in seconds. Sets up downstream libraries / users to
 retry request after the specified interval."""
 RETRY_AFTER_INTERVAL = 10
@@ -34,10 +32,6 @@ PUT_TIME_ALLOWANCE_SECONDS = 10
 """This is the minimum amount of time remaining on the lambda for us to retry on a PUT /bundles request."""
 
 ADMIN_USER_EMAILS = set(os.environ['ADMIN_USER_EMAILS'].split(','))
-
-# AWS managed elasticsearch limits us to 100mb files or it pipe fails, so
-# bundles containing this many files are allowed but will not be indexed.
-BUNDLE_FILE_INDEX_LIMIT = 20000
 
 
 @dss_handler
@@ -170,10 +164,6 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str):
 
     status_code = _save_bundle(handle, bucket, uuid, version, bundle_metadata)
 
-    if len(files) > BUNDLE_FILE_INDEX_LIMIT:
-        log.warning(f'PUT /bundle request exceeds {str(BUNDLE_FILE_INDEX_LIMIT)} file limit.  '
-                    f'Files will not be indexed and will not be queryable.')
-
     return jsonify(dict(version=bundle_metadata['version'], manifest=bundle_metadata)), status_code
 
 def _save_bundle(handle, bucket, uuid, version, bundle_metadata):
@@ -228,10 +218,6 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     new_bundle_version = datetime_to_version_format(timestamp)
     bundle['version'] = new_bundle_version
     _save_bundle(handle, Replica[replica].bucket, uuid, new_bundle_version, bundle)
-
-    if len(bundle['files']) > BUNDLE_FILE_INDEX_LIMIT:
-        log.warning(f'PATCH /bundle request exceeds {str(BUNDLE_FILE_INDEX_LIMIT)} file limit.  '
-                    f'Files will not be indexed and will not be queryable.')
 
     return jsonify(dict(uuid=uuid, version=new_bundle_version)), requests.codes.ok
 

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -174,7 +174,6 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str):
         log.warning('PUT /bundle/{uuid} request exceeds 20,000 file limit.  '
                     'Files will not be indexed and will not be queryable.')
 
-
     return jsonify(dict(version=bundle_metadata['version'], manifest=bundle_metadata)), status_code
 
 def _save_bundle(handle, bucket, uuid, version, bundle_metadata):

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -151,6 +151,13 @@ def put(uuid: str, replica: str, json_request_body: dict, version: str):
     bucket = Replica[replica].bucket
 
     files = build_bundle_file_metadata(Replica[replica], json_request_body['files'])
+
+    if len(files) < 20000:
+        raise DSSException(
+            requests.codes.requested_range_not_satisfiable,
+            "File count in bundle exceeds the 20,000 file limit."
+        )
+
     detect_filename_collisions(files)
 
     # build a manifest consisting of all the files.
@@ -211,6 +218,12 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
     bundle['files'] = [f for f in bundle['files'] if bundle_file_id_metadata(f) not in remove_files_set]
     add_files = json_request_body.get("add_files", [])
     bundle['files'].extend(build_bundle_file_metadata(Replica[replica], add_files))
+
+    if len(bundle['files']) < 20000:
+        raise DSSException(
+            requests.codes.requested_range_not_satisfiable,
+            "File count in bundle exceeds the 20,000 file limit."
+        )
     detect_filename_collisions(bundle['files'])
 
     timestamp = datetime.datetime.utcnow()

--- a/dss/index/es/document.py
+++ b/dss/index/es/document.py
@@ -22,11 +22,6 @@ from dss.util import reject
 
 logger = logging.getLogger(__name__)
 
-#
-# AWS managed elasticsearch limits us to 100mb files or it pipe fails, so
-# bundles containing this many files are allowed but will not be indexed.
-BUNDLE_FILE_INDEX_LIMIT = 20000
-
 
 class IndexDocument(dict):
     """
@@ -101,11 +96,11 @@ class BundleDocument(IndexDocument):
         self = cls(bundle.replica, bundle.fqid)
         self['manifest'] = bundle.manifest
         number_of_manifest_files = len(self['manifest']['files'])
-        if number_of_manifest_files > os.environ['BUNDLE_FILE_INDEX_LIMIT']:
+        if number_of_manifest_files > int(os.environ['DSS_BUNDLE_MANIFEST_INDEX_LIMIT']):
             self['manifest']['files'] = []
             logger.warning("Bundle manifest with %s>%s files not indexed. uuid=%s, version=%s",
                            str(number_of_manifest_files),
-                           str(os.environ['BUNDLE_FILE_INDEX_LIMIT']),
+                           str(os.environ['DSS_BUNDLE_MANIFEST_INDEX_LIMIT']),
                            self.fqid.uuid,
                            self.fqid.version)
         self['state'] = 'new'

--- a/dss/index/es/document.py
+++ b/dss/index/es/document.py
@@ -98,7 +98,7 @@ class BundleDocument(IndexDocument):
         number_of_manifest_files = len(self['manifest']['files'])
         if number_of_manifest_files > int(os.environ['DSS_BUNDLE_MANIFEST_INDEX_LIMIT']):
             self['manifest']['files'] = []
-            logger.warning("Bundle manifest with %s>%s files not indexed. uuid=%s, version=%s",
+            logger.warning("Bundle manifest with %s>%s files not included in index document. uuid=%s, version=%s",
                            str(number_of_manifest_files),
                            str(os.environ['DSS_BUNDLE_MANIFEST_INDEX_LIMIT']),
                            self.fqid.uuid,

--- a/dss/index/es/document.py
+++ b/dss/index/es/document.py
@@ -17,6 +17,7 @@ from dss.index.es import ElasticsearchClient, elasticsearch_retry, refresh_perco
 from dss.index.es.manager import IndexManager
 from dss.index.es.validator import scrub_index_data
 from dss.index.es.schemainfo import SchemaInfo
+from dss.api.bundles import BUNDLE_FILE_INDEX_LIMIT
 from dss.storage.identifiers import BundleFQID, ObjectIdentifier
 from dss.util import reject
 
@@ -96,10 +97,11 @@ class BundleDocument(IndexDocument):
         self = cls(bundle.replica, bundle.fqid)
         self['manifest'] = bundle.manifest
         number_of_manifest_files = len(self['manifest']['files'])
-        if number_of_manifest_files > 20000:
+        if number_of_manifest_files > BUNDLE_FILE_INDEX_LIMIT:
             self['manifest']['files'] = []
-            logger.warning("Bundle with %s>20000 files not indexed. uuid=%s, version=%s",
-                           number_of_manifest_files,
+            logger.warning("Bundle with %s>%s files not indexed. uuid=%s, version=%s",
+                           str(number_of_manifest_files),
+                           str(BUNDLE_FILE_INDEX_LIMIT),
                            self.fqid.uuid,
                            self.fqid.version)
         self['state'] = 'new'

--- a/dss/index/es/document.py
+++ b/dss/index/es/document.py
@@ -1,3 +1,4 @@
+import os
 import json
 import string
 import logging
@@ -94,6 +95,13 @@ class BundleDocument(IndexDocument):
     def from_bundle(cls, bundle: Bundle):
         self = cls(bundle.replica, bundle.fqid)
         self['manifest'] = bundle.manifest
+        number_of_manifest_files = len(self['manifest']['files'])
+        if number_of_manifest_files > 20000:
+            self['manifest']['files'] = []
+            logger.warning("Bundle with %s>20000 files not indexed. uuid=%s, version=%s",
+                           number_of_manifest_files,
+                           self.fqid.uuid,
+                           self.fqid.version)
         self['state'] = 'new'
 
         # There are two reasons in favor of not using dot in the name of the individual files in the index document,

--- a/environment
+++ b/environment
@@ -139,9 +139,10 @@ DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS="serviceAccount:619310558212-compute@develope
 
 AWS_SDK_LOAD_CONFIG=1 # Needed for Terraform to correctly use AWS assumed roles
 
-#
 # AWS managed elasticsearch limits us to 100mb files or it pipe fails, so
-# bundles containing this many files are allowed but will not be indexed.
+# bundles manifests exceeding this many files are not included in the index document.
+# https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html#network-limits
+# https://stackoverflow.com/questions/55541625/aws-elasticsearch-cluster-method-to-update-http-max-content-length
 DSS_BUNDLE_MANIFEST_INDEX_LIMIT="20000"
 set +a
 

--- a/environment
+++ b/environment
@@ -20,6 +20,7 @@ EXPORT_ENV_VARS_TO_LAMBDA_ARRAY=(
     DSS_AUTHORIZED_DOMAINS
     DSS_BLOB_PUBLIC_TTL_DAYS
     DSS_BLOB_TTL_DAYS
+    DSS_BUNDLE_MANIFEST_INDEX_LIMIT,
     DSS_DEBUG
     DSS_DEPLOYMENT_STAGE
     DSS_GS_BUCKET
@@ -138,6 +139,10 @@ DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS="serviceAccount:619310558212-compute@develope
 
 AWS_SDK_LOAD_CONFIG=1 # Needed for Terraform to correctly use AWS assumed roles
 
+#
+# AWS managed elasticsearch limits us to 100mb files or it pipe fails, so
+# bundles containing this many files are allowed but will not be indexed.
+DSS_BUNDLE_MANIFEST_INDEX_LIMIT="20000"
 set +a
 
 if [[ -f "${DSS_HOME}/environment.local" ]]; then

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -34,6 +34,7 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss import BucketConfig, Config, DeploymentStage
 from dss.config import Replica
+from dss.api.bundles import BUNDLE_FILE_INDEX_LIMIT
 from dss.index import DEFAULT_BACKENDS
 import dss.index.es.backend
 from dss.index.backend import CompositeIndexBackend
@@ -693,7 +694,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             'format': '0.0.1',
             'version': '2019-04-05T174905.443832Z',
             'creator_uid': 0,
-            'files': [_file_metadata() for _ in range(20001)]
+            'files': [_file_metadata() for _ in range(BUNDLE_FILE_INDEX_LIMIT + 1)]
         }
         fqid = BundleFQID.from_key("bundles/012d89aa-98e2-46aa-ab46-65540e08ec4d.2019-04-05T174905.443832Z")
         bundle = Bundle(Replica.aws, fqid, manifest, [])

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -34,7 +34,6 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from dss import BucketConfig, Config, DeploymentStage
 from dss.config import Replica
-from dss.api.bundles import BUNDLE_FILE_INDEX_LIMIT
 from dss.index import DEFAULT_BACKENDS
 import dss.index.es.backend
 from dss.index.backend import CompositeIndexBackend
@@ -694,7 +693,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
             'format': '0.0.1',
             'version': '2019-04-05T174905.443832Z',
             'creator_uid': 0,
-            'files': [_file_metadata() for _ in range(BUNDLE_FILE_INDEX_LIMIT + 1)]
+            'files': [_file_metadata() for _ in range(int(os.environ['DSS_BUNDLE_MANIFEST_INDEX_LIMIT']) + 1)]
         }
         fqid = BundleFQID.from_key("bundles/012d89aa-98e2-46aa-ab46-65540e08ec4d.2019-04-05T174905.443832Z")
         bundle = Bundle(Replica.aws, fqid, manifest, [])

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -673,6 +673,34 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         self.delete_subscription(subscription_id)
 
     @testmode.standalone
+    def test_too_large_manifest(self):
+        def _file_metadata():
+            uuid_name = str(uuid.uuid4())
+            return {
+                "name": uuid_name,
+                "uuid": uuid_name,
+                "version": "2019-04-05T174905.443832Z",
+                "content-type": "gzip",
+                "size": 23675941,
+                "indexed": False,
+                "crc32c": "942cd9d6",
+                "s3-etag": "fb9bbafee8a92ced414b3658b1bb9517",
+                "sha1": "bb5c8a68c155bad257cb7b93faef71a116cecba2",
+                "sha256": "c0d11199740a66150b8bb70a0474d8de9819e77f3f77b55dd04790e3fe6fb53c"
+            }
+
+        manifest = {
+            'format': '0.0.1',
+            'version': '2019-04-05T174905.443832Z',
+            'creator_uid': 0,
+            'files': [_file_metadata() for _ in range(20001)]
+        }
+        fqid = BundleFQID.from_key("bundles/012d89aa-98e2-46aa-ab46-65540e08ec4d.2019-04-05T174905.443832Z")
+        bundle = Bundle(Replica.aws, fqid, manifest, [])
+        index_document = BundleDocument.from_bundle(bundle)
+        self.assertEqual([], index_document['manifest']['files'])
+
+    @testmode.standalone
     def test_get_shape_descriptor(self):
 
         def describedBy(schema_type, schema_version):


### PR DESCRIPTION
Elasticsearch document size limits prevent inclusion of large bundle manifests into the indexed document:
  - https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html#network-limits
  - https://stackoverflow.com/questions/55541625/aws-elasticsearch-cluster-method-to-update-http-max-content-length