### PR TITLE
Bundle manifest memcaching

### DIFF
--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -16,7 +16,7 @@ from dss.storage.hcablobstore import BlobStore, compose_blob_key
 from dss.storage.identifiers import CollectionFQID, CollectionTombstoneID
 from dss.util import security, hashabledict, UrlBuilder
 from dss.util.version import datetime_to_version_format
-from dss.api.bundles import _idempotent_save
+from dss.storage.bundles import idempotent_save
 
 from cloud_blobstore import BlobNotFoundError
 
@@ -165,7 +165,7 @@ def delete(uuid: str, replica: str):
 
     blobstore = Config.get_blobstore_handle(Replica[replica])
     bucket = Replica[replica].bucket
-    created, idempotent = _idempotent_save(blobstore, bucket, tombstone_key, tombstone_object_data)
+    created, idempotent = idempotent_save(blobstore, bucket, tombstone_key, tombstone_object_data)
     if not idempotent:
         raise DSSException(requests.codes.conflict,
                            f"collection_tombstone_already_exists",

--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -117,7 +117,8 @@ def idempotent_save(blobstore: BlobStore, bucket: str, key: str, data: dict) -> 
         else:
             blobstore.upload_file_handle(bucket, key, io.BytesIO(_d))
 
-        _bundle_manifest_cache[key] = data
+        if DSS_BUNDLE_KEY_REGEX.match(key) is not None:
+            _bundle_manifest_cache[key] = data
 
         return True, True
 

--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -1,16 +1,39 @@
+import io
 from functools import lru_cache
 import json
 import typing
+import time
 
-from cloud_blobstore import BlobNotFoundError
+import cachetools
+from cloud_blobstore import BlobNotFoundError, BlobStore
+from cloud_blobstore.s3 import S3BlobStore
 
 from dss import Config, Replica
 from dss.storage.identifiers import DSS_BUNDLE_KEY_REGEX, DSS_BUNDLE_TOMBSTONE_REGEX, BundleTombstoneID, BundleFQID
 from dss.storage.blobstore import test_object_exists
+from dss.util import multipart_parallel_upload
 
 
-@lru_cache(maxsize=32)
+_bundle_manifest_cache = cachetools.LRUCache(maxsize=4)
+
+
 def get_bundle_manifest(
+        uuid: str,
+        replica: Replica,
+        version: typing.Optional[str],
+        *,
+        bucket: typing.Optional[str] = None) -> typing.Optional[dict]:
+    key = BundleFQID(uuid, version).to_key()
+    if key in _bundle_manifest_cache:
+        return _bundle_manifest_cache[key]
+    else:
+        bundle = _get_bundle_manifest(uuid, replica, version)
+        if bundle is not None:
+            _bundle_manifest_cache[key] = bundle
+        return bundle
+
+
+def _get_bundle_manifest(
         uuid: str,
         replica: Replica,
         version: typing.Optional[str],
@@ -59,6 +82,44 @@ def get_bundle_manifest(
         return json.loads(bundle_manifest_blob)
     except BlobNotFoundError:
         return None
+
+
+def idempotent_save(blobstore: BlobStore, bucket: str, key: str, data: dict) -> typing.Tuple[bool, bool]:
+    """
+    idempotent_save attempts to save an object to the BlobStore. Its return values indicate whether the save was made
+    successfully and whether the operation could be completed idempotently. If the data in the blobstore does not match
+    the data parameter, the data in the blobstore is _not_ overwritten.
+
+    :param blobstore: the blobstore to save the data to
+    :param bucket: the bucket in the blobstore to save the data to
+    :param key: the key of the object to save
+    :param data: the data to save
+    :return: a tuple of booleans (was the data saved?, was the save idempotent?)
+    """
+    if test_object_exists(blobstore, bucket, key):
+        # fetch the file metadata, compare it to what we have.
+        existing_data = json.loads(blobstore.get(bucket, key).decode("utf-8"))
+        return False, existing_data == data
+    else:
+        # write manifest to persistent store
+        _d = json.dumps(data).encode("utf-8")
+        part_size = 16 * 1024 * 1024
+        if isinstance(blobstore, S3BlobStore) and len(_d) > part_size:
+            with io.BytesIO(_d) as fh:
+                multipart_parallel_upload(
+                    blobstore.s3_client,
+                    bucket,
+                    key,
+                    fh,
+                    part_size=part_size,
+                    parallelization_factor=20
+                )
+        else:
+            blobstore.upload_file_handle(bucket, key, io.BytesIO(_d))
+
+        _bundle_manifest_cache[key] = data
+
+        return True, True
 
 
 def _latest_version_from_object_names(object_names: typing.Iterator[str]) -> str:


### PR DESCRIPTION
Previously, bundle manifests were cached in memory during GET. This extends that functionality to PUT and PATCH /bundle, improving PATCH performance.

closes #2011 