### PR TITLE
Forward GCP object deletion events

### DIFF
--- a/daemons/dss-gs-event-relay/main.py
+++ b/daemons/dss-gs-event-relay/main.py
@@ -75,9 +75,7 @@ class GRTCClient(GCPAPIClient):
 grtc_client = GRTCClient()
 
 def dss_gs_event_relay(data, context):
-    if data["resourceState"] == "not_exists":
-        print("Ignoring object deletion event")
-    elif data["metageneration"] == 1:
+    if data["metageneration"] == 1:
         # Metageneration is updated on metadata changes and starts at 1
         print("Ignoring object metadata update event")
     elif re.match(r".+\.part\d+$", data["name"]):

--- a/daemons/dss-index/app.py
+++ b/daemons/dss-index/app.py
@@ -43,8 +43,11 @@ def dispatch_gs_indexer_event(event, context):
     This handler receives GS events via the Google Cloud Function deployed from daemons/dss-gs-event-relay.
     """
     for event_record in event["Records"]:
-        gs_event = json.loads(json.loads(event_record["body"])["Message"])
-        _handle_event(Replica.gcp, gs_event, context)
+        message = json.loads(json.loads(event_record["body"])["Message"])
+        if message['resourceState'] == "not_exists":
+            logger.info("Ignoring object deletion event")
+        else:
+            _handle_event(Replica.gcp, message, context)
 
 
 def _handle_event(replica, event, context):

--- a/daemons/dss-notify-v2/app.py
+++ b/daemons/dss-notify-v2/app.py
@@ -61,7 +61,9 @@ def launch_from_forwarded_event(event, context):
     replica = Replica.gcp
     for event_record in event['Records']:
         message = json.loads(json.loads(event_record['body'])['Message'])
-        if message['selfLink'].startswith("https://www.googleapis.com/storage"):
+        if message['resourceState'] == "not_exists":
+            logger.info("Ignoring object deletion event")
+        elif message['selfLink'].startswith("https://www.googleapis.com/storage"):
             key = message['name']
             if key.startswith("bundles"):
                 _notify_subscribers(replica, key)

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -65,7 +65,9 @@ def launch_from_forwarded_event(event, context):
     executions = {}
     for event_record in event["Records"]:
         message = json.loads(json.loads(event_record["body"])["Message"])
-        if message["selfLink"].startswith("https://www.googleapis.com/storage"):
+        if message['resourceState'] == "not_exists":
+            logger.info("Ignoring object deletion event")
+        elif message["selfLink"].startswith("https://www.googleapis.com/storage"):
             source_replica = Replica.gcp
             source_key = message["name"]
             bucket = source_replica.bucket


### PR DESCRIPTION
This is needed for the JMESPath notification daemon to handle deletion events.

connected to #2003 