### PR TITLE
Increase GS client connection pool to 20

### DIFF
--- a/dss/config.py
+++ b/dss/config.py
@@ -13,6 +13,8 @@ from cloud_blobstore.gs import GSBlobStore
 from google.cloud.storage import Client
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2 import service_account
+from requests.adapters import HTTPAdapter, DEFAULT_POOLSIZE
+from requests.packages.urllib3.util.retry import Retry
 
 from dss.storage.hcablobstore import HCABlobStore
 from dss.storage.hcablobstore.s3 import S3HCABlobStore
@@ -159,23 +161,18 @@ class Config:
 
             # _http is a "private" parameter, and we may need to re-visit GCP timeout retry
             # strategies in the future.
-            client = Client(
-                _http=SessionWithTimeouts(credentials),
-                credentials=credentials
-            )
+            client = Client(_http=SessionWithTimeouts(credentials), credentials=credentials)
 
+        adapter_kwargs = dict(pool_maxsize=max(DEFAULT_POOLSIZE, 20))
         if Config.BLOBSTORE_RETRIES is not None:
-            from requests.adapters import HTTPAdapter
-            from requests.packages.urllib3.util.retry import Retry
-            retry = Retry(total=Config.BLOBSTORE_RETRIES,
-                          backoff_factor=0.3,
-                          status_forcelist=(500, 502, 504)
-                          )
-            adapter = HTTPAdapter(max_retries=retry, pool_maxsize=20)
-            # _http is a "private" parameter, and we may need to re-visit GCP timeout retry
-            # strategies in the future.
-            client._http.mount('https://', adapter)
-            client._http.mount('http://', adapter)
+            adapter_kwargs['max_retries'] = Retry(total=Config.BLOBSTORE_RETRIES,
+                                                  backoff_factor=0.3,
+                                                  status_forcelist=(500, 502, 504))
+        adapter = HTTPAdapter(**adapter_kwargs)
+        # _http is a "private" parameter, and we may need to re-visit GCP timeout retry
+        # strategies in the future.
+        client._http.mount('https://', adapter)
+        client._http.mount('http://', adapter)
         return client
 
     @staticmethod

--- a/dss/config.py
+++ b/dss/config.py
@@ -171,7 +171,7 @@ class Config:
                           backoff_factor=0.3,
                           status_forcelist=(500, 502, 504)
                           )
-            adapter = HTTPAdapter(max_retries=retry)
+            adapter = HTTPAdapter(max_retries=retry, pool_maxsize=20)
             # _http is a "private" parameter, and we may need to re-visit GCP timeout retry
             # strategies in the future.
             client._http.mount('https://', adapter)


### PR DESCRIPTION
This matches S3 connection pool

Also addresses `WARNING:urllib3.connectionpool:Connection pool is full, discarding connection: www.googleapis.com`:
https://travis-ci.com/HumanCellAtlas/data-store/jobs/195750957