### PR TITLE
Fix multipart sync completion criteria

### DIFF
--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -273,7 +273,7 @@ def copy_parts(event, context):
 
     event.update(last_completed_part=part_index)
     event.setdefault("finished", False)
-    if part_index >= object_size // part_size:
+    if (part_index + 1) * part_size >= object_size:
         event.update(finished=True)
     return event
 

--- a/dss/events/handlers/sync.py
+++ b/dss/events/handlers/sync.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import math
 from contextlib import closing
 from string import ascii_letters
 
@@ -209,7 +210,7 @@ def get_sync_work_state(event: dict):
                 dest_bucket=dest_replica.bucket,
                 dest_key=event["source_key"],
                 mpu=event.get("mpu_id"),
-                total_parts=(object_size // part_size) + 1)
+                total_parts=math.ceil(object_size / part_size))
 
 def exists(replica: Replica, key: str):
     if replica == Replica.aws:


### PR DESCRIPTION
When object size is an integer multiple of part size, `object_size // part_size) + 1` evaluates to the incorrect number of parts.