### PR TITLE
Use one keyword for iterables.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1036,7 +1036,7 @@ paths:
           schema:
             type: object
             properties:
-              collections:
+              contents:
                 description: A user's collection UUIDs and versions.
                 type: array
                 items:
@@ -1046,7 +1046,7 @@ paths:
           schema:
             type: object
             properties:
-              collections:
+              contents:
                 description: A user's collection UUIDs and versions.
                 type: array
                 items:
@@ -1482,15 +1482,43 @@ paths:
           schema:
             type: object
             properties:
-              bundle:
-                $ref: "#/definitions/bundle_version"
+              contents:
+                type: array
+                items:
+                  $ref: "#/definitions/file_version"
+              uuid:
+                type: string
+                description: Bundle unique ID
+                pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+              version:
+                type: string
+                format: DSS_VERSION
+                description: Timestamp of bundle creation in DSS_VERSION format.
+              creator_uid:
+                type: integer
+                format: int
+                description: User ID who created this bundle manifest.
         206:
           description: A single page of results was retrieved.
           schema:
             type: object
             properties:
-              bundle:
-                $ref: "#/definitions/bundle_version"
+              contents:
+                type: array
+                items:
+                  $ref: "#/definitions/file_version"
+              uuid:
+                type: string
+                description: Bundle unique ID
+                pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+              version:
+                type: string
+                format: DSS_VERSION
+                description: Timestamp of bundle creation in DSS_VERSION format.
+              creator_uid:
+                type: integer
+                format: int
+                description: User ID who created this bundle manifest.
           headers:
             Link:
               type: string
@@ -2435,7 +2463,7 @@ definitions:
       es_query:
         description: Elasticsearch query used to produce the results.
         type: object
-      results:
+      contents:
         description: Results matching the `es_query`.
         type: array
         items:


### PR DESCRIPTION
PR is for discussion.

@hannes-ucsc @kislyuk There would obviously have to be corresponding code changes if the swagger doc changes in this PR were to go through, but would it make sense to just have one keyword (`contents`) and return each item in that array rather than the current behavior of using several hard-coded keywords (only `contents` would be hard-coded into the CLI with this change, though we could comment in the swagger that this is its intended usage)?

For reference, the current CLI iterator returns: https://github.com/HumanCellAtlas/dcp-cli/commit/a84fae932fe96770a88501aeae9eb31d40ff2785

Which would change to simply:
```
for item in page.json()["contents"]:
    yield item
```

Hannes's comment: https://github.com/HumanCellAtlas/dcp-cli/issues/331