### PR TITLE
Remove Babel lib from requirements.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,6 @@ awscli==1.16.154
 azure-common==1.1.20
 azure-nspkg==3.0.2
 azure-storage==0.36.0
-Babel==2.6.0
 bcrypt==3.1.6
 boto3==1.9.144
 botocore==1.12.144


### PR DESCRIPTION
Lambdas are held up on `master` because the size of our libraries exceeds their limit.

Main offenders seem to be:
```
(v3nv) quokka@qcore:~/delete/data-store$ du --max-depth=1 v3nv/lib/python3.6/site-packages | sort -n -r | head -n 10
276024    v3nv/lib/python3.6/site-packages
40812    v3nv/lib/python3.6/site-packages/botocore
27120    v3nv/lib/python3.6/site-packages/babel
13156    v3nv/lib/python3.6/site-packages/mypy
11052    v3nv/lib/python3.6/site-packages/awscli
10516    v3nv/lib/python3.6/site-packages/faker
9160    v3nv/lib/python3.6/site-packages/google
8736    v3nv/lib/python3.6/site-packages/pip
8160    v3nv/lib/python3.6/site-packages/PyInstaller
7168    v3nv/lib/python3.6/site-packages/cryptography
```
So this cuts out Babel since it appears to be unused.  Also MyPy should probably not be deployed to lambdas but that's possibly a separate PR.