### PR TITLE
[Easy] improve bucket mapping operations utility

### DIFF
--- a/dss/operations/util.py
+++ b/dss/operations/util.py
@@ -33,7 +33,7 @@ class CommandForwarder(AbstractContextManager):
         if len(self.chunk):
             _enqueue_command_batch(self.chunk)
 
-def map_bucket(func: typing.Callable, handle: BlobStore, bucket: str, base_pfx: str, parallelization=16):
+def map_bucket_results(func: typing.Callable, handle: BlobStore, bucket: str, base_pfx: str, parallelization=16):
     """
     Call `func` on an iterable of keys
     func is expected to be thread safe.
@@ -48,6 +48,10 @@ def map_bucket(func: typing.Callable, handle: BlobStore, bucket: str, base_pfx: 
                 yield f.result()
             except Exception:
                 traceback.print_exc()
+
+def map_bucket(*args, **kwargs):
+    for _ in map_bucket_results(*args, **kwargs):
+        pass
 
 def _enqueue_command_batch(commands: typing.List[str]):
     assert 10 >= len(commands)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -13,7 +13,7 @@ sys.path.insert(0, pkg_root)  # noqa
 import dss
 from tests.infra import testmode
 from dss.operations import DSSOperationsCommandDispatch
-from dss.operations.util import map_bucket, CommandForwarder
+from dss.operations.util import map_bucket_results, CommandForwarder
 from dss.logging import configure_test_logging
 from dss.config import BucketConfig, Config, Replica, override_bucket_config
 
@@ -75,7 +75,7 @@ class TestOperations(unittest.TestCase):
                         return count
 
                     total = 0
-                    for count in map_bucket(counter, handle, replica.bucket, "bundles/", 2):
+                    for count in map_bucket_results(counter, handle, replica.bucket, "bundles/", 2):
                         total += count
 
                     self.assertGreater(count_list, 0)


### PR DESCRIPTION
This makes `map_bucket` easier to use.