### PR TITLE
[EZ] Update lambda-iam for accessing resource by tag

### DIFF
--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -71,6 +71,15 @@
         ],
         "Resource": "arn:aws:dynamodb:*:$account_id:table/dss-async-state-$stage",
         "Resource": "arn:aws:dynamodb:*:$account_id:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetTagKeys",
+        "tag:GetResources",
+        "tag:GetTagValues"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Addresses issue where Lambda does not have privileges to list resource by tag type. 