### PR TITLE
Resume unfinished GS copies

### DIFF
--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -88,7 +88,7 @@ def copy_worker(event, lambda_context):
                     state[_Key.TOKEN] = response[0]
                     self.save_state(state)
 
-    return CopyWorkerTimedThread(lambda_context.get_remaining_time_in_millis() / 1000, event).start()
+    return CopyWorkerTimedThread(lambda_context.get_remaining_time_in_millis() / 1000 - 10, event).start()
 
 
 def fail(event, lambda_context):
@@ -139,6 +139,19 @@ def _sfn():
                 "Resource": copy_worker,
                 "Retry": _retry_default(),
                 "Catch": _catch_default(),
+                "Next": "TestFinished",
+            },
+            f"TestFinished": {
+                "Type": "Choice",
+                "Choices": [{
+                    "Variable": "$.finished",
+                    "BooleanEquals": True,
+                    "Next": "Finish"
+                }],
+                "Default": "Copy",
+            },
+            "Finish": {
+                "Type": "Pass",
                 "End": True,
             },
             "FailTask": {
@@ -180,8 +193,8 @@ def write_metadata(event, lambda_context):
 copy_write_metadata_sfn = _sfn()
 
 # tweak to add one more state.
-del copy_write_metadata_sfn['States']['Copy']['End']
-copy_write_metadata_sfn['States']['Copy']['Next'] = "WriteMetadata"
+# del copy_write_metadata_sfn['States']['Copy']['End']
+copy_write_metadata_sfn['States']['TestFinished']['Choices'][0]['Next'] = "WriteMetadata"
 copy_write_metadata_sfn['States']['WriteMetadata'] = {
     "Type": "Task",
     "Resource": write_metadata,

--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -141,7 +141,7 @@ def _sfn():
                 "Catch": _catch_default(),
                 "Next": "TestFinished",
             },
-            f"TestFinished": {
+            "TestFinished": {
                 "Type": "Choice",
                 "Choices": [{
                     "Variable": "$.finished",
@@ -193,7 +193,6 @@ def write_metadata(event, lambda_context):
 copy_write_metadata_sfn = _sfn()
 
 # tweak to add one more state.
-# del copy_write_metadata_sfn['States']['Copy']['End']
 copy_write_metadata_sfn['States']['TestFinished']['Choices'][0]['Next'] = "WriteMetadata"
 copy_write_metadata_sfn['States']['WriteMetadata'] = {
     "Type": "Task",

--- a/tests/test_checkout_caching.py
+++ b/tests/test_checkout_caching.py
@@ -28,7 +28,7 @@ class TestCheckoutCaching(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
     class SpoofContext:
         @staticmethod
         def get_remaining_time_in_millis():
-            return 2000
+            return 11000  # This should be longer than 10 seconds to satisfy timing logic GS copy client sfn
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This:
  1. Avoids lost state by adding choice step to SFN flow
  2. Provides 10 seconds of padding for thread to time out before Lambda times out