### PR TITLE
Async state convenience methods and bug fixes

### DIFF
--- a/dss/util/async_state.py
+++ b/dss/util/async_state.py
@@ -21,6 +21,7 @@ class AsyncStateItem:
 
     def __init__(self, key: str, body: dict) -> None:
         self.key = key
+        body = body.copy()
         if not body.get('_type'):
             body['_type'] = type(self).__name__
         self.body = body
@@ -28,9 +29,15 @@ class AsyncStateItem:
     def _put(self) -> typing.Any:
         return put_item(table=self.table, value=json.dumps(self.body), hash_key=self.key)
 
+    @property
+    def data(self):
+        data = self.body.copy()
+        del data['_type']
+        return data
+
     @classmethod
     def put(cls, key: str, body: dict = None) -> typing.Any:
-        item = cls(key, body if body else dict())
+        item = cls(key, body or dict())
         item._put()
         return item
 

--- a/tests/test_async_state.py
+++ b/tests/test_async_state.py
@@ -30,10 +30,12 @@ class TestAsyncState(unittest.TestCase):
 
         # insert item
         put_item = AsyncStateItem.put(key, {'message': msg})
+        self.assertEqual(put_item.data, {'message': msg})
 
         # test get item
         item = AsyncStateItem.get(key)
         self.assertEqual(item.body['message'], put_item.body['message'])
+        self.assertEqual(item.data, {'message': msg})
 
         # test delete item
         item.delete_item()


### PR DESCRIPTION
This:
  1. Adds convenience method to async state to capture state absent private keys
  2. Prevents accidental modification of state data before putting into database
