### PR TITLE
[Spike] Prevent multiple concurrent checkout jobs

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -360,11 +360,6 @@ paths:
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
           required: false
           type: string
-        - name: token
-          in: query
-          description: Token to manage retries.  End users constructing queries should not set this parameter.
-          required: false
-          type: string
       responses:
         301:
           description: >
@@ -410,22 +405,6 @@ paths:
               description: SHA-256 (in hex format) of the file contents in hex.
               type: string
               pattern: "^[a-z0-9]{64}$"
-        400:
-          description: Bad request
-          schema:
-            allOf:
-              - $ref: '#/definitions/Error'
-              - type: object
-                properties:
-                  code:
-                    type: string
-                    description: >
-                      Machine-readable error code.  The types of return values should not be changed lightly.
-
-                      The code `illegal_token` is returned when the token parameter cannot be understood.
-                    enum: [illegal_token]
-                required:
-                  - code
         500:
           $ref: '#/responses/ServerError'
         502:
@@ -1526,12 +1505,10 @@ paths:
                       match the requirements in the specification.
 
 
-                      The code `illegal_token` is returned when the token parameter cannot be understood.
-
 
                       The code `only_one_urltype` is returned when more than one url type (`directurls` and
                       `presignedurls`) is requested.
-                    enum: [illegal_arguments, illegal_token, only_one_urltype]
+                    enum: [illegal_arguments, only_one_urltype]
                 required:
                   - code
         500:

--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -3,7 +3,7 @@ import logging
 from dss import Config, Replica
 from dss.stepfunctions.lambdaexecutor import TimedThread
 from dss.storage.files import write_file_metadata
-from dss.util.async_state import AsyncStateError
+from dss.util.async_state import AsyncStateItem, AsyncStateError
 from dss.storage.checkout.cache_flow import should_cache_file, is_dss_bucket
 from dss.storage.hcablobstore import FileMetadata
 
@@ -84,6 +84,8 @@ def copy_worker(event, lambda_context):
                 response = dst_blob.rewrite(src_blob, token=state.get(_Key.TOKEN, None))
                 if response[0] is None:
                     state[Key.FINISHED] = True
+                    async_key = f"{Replica.gcp.name}/{self.destination_key}"
+                    AsyncStateItem.delete(async_key)
                     return state
                 else:
                     state[_Key.TOKEN] = response[0]


### PR DESCRIPTION
This is an experimental solution to the following problem: If multiple clients initiate GET requests against the same file, a checkout job will be initiated for each client.

This mechanism:
  1. Places a marker in a DynamoDB table when a file checkout job is started
  2. On subsequent requests:
    - If object exists in checkout bucket, return as usual
    - If not, check for marker. If marker exists, do not start new checkout job
  3. Marker is deleted upon checkout success.
  4. If checkout fails, marker contains the exception.