### PR TITLE
Direct URLs for Files

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -368,7 +368,7 @@ paths:
         - name: directurl
           in: query
           required: false
-          description: When set to true, the response will contain API-specific URLs that are tied to the specified replica
+          description: When set to true, the response will contain API-specific URLs that are tied to the specified replica, for example `gs://bucket/object` or `s3://bucket/object`
           type: boolean
       responses:
         301:
@@ -1452,7 +1452,7 @@ paths:
         - name: directurls
           in: query
           description: >
-            Include API-specific direct-access URLs in the response.  This is mutually exclusive with the presignedurls parameter.
+            When set to true, the response will contain API-specific URLs that are tied to the specified replica, for example `gs://bucket/object` or `s3://bucket/object`. This parameter is mutually exclusive with the presigned urls parameter.
           required: false
           type: boolean
         - name: presignedurls

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -368,11 +368,13 @@ paths:
         - name: directurl
           in: query
           required: false
-          description: When set to true, the response will contain API-specific URLs that are tied to the specified
-            replica, for example `gs://bucket/object` or `s3://bucket/object`. The use of presigned URLs is recommended
-            for data access. Cloud native URLs are currently provided for a limited set of use cases and may not be
-            provided in the future. If cloud native URLs are required, please contact the data store team regarding the
-            credentials necessary to use them.
+          description: >
+            When set to true, the response will contain API-specific URLs that are tied to the specified replica,
+            for example `gs://bucket/object` or `s3://bucket/object`.
+
+            The use of presigned URLs is recommended for data access. Cloud native URLs are currently provided for a
+            limited set of use cases and may not be provided in the future. If cloud native URLs are required, please
+            contact the data store team regarding the credentials necessary to use them.
           type: boolean
       responses:
         301:
@@ -1457,10 +1459,12 @@ paths:
           in: query
           description: >
             When set to true, the response will contain API-specific URLs that are tied to the specified replica,
-            for example `gs://bucket/object` or `s3://bucket/object`. This parameter is mutually exclusive with the
-            presigned urls parameter. The use of presigned URLs is recommended for data access. Cloud native URLs are
-            currently provided for a limited set of use cases and may not be provided in the future. If cloud native
-            URLs are required, please contact the data store team regarding the credentials necessary to use them.
+            for example `gs://bucket/object` or `s3://bucket/object`.
+
+            This parameter is mutually exclusive with the presigned urls parameter. The use of presigned URLs is
+            recommended for data access. Cloud native URLs are currently provided for a limited set of use cases and
+            may not be provided in the future. If cloud native URLs are required, please contact the data store team
+            regarding the credentials necessary to use them.
           required: false
           type: boolean
         - name: presignedurls

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -368,7 +368,10 @@ paths:
         - name: directurl
           in: query
           required: false
-          description: When set to true, the response will contain API-specific URLs that are tied to the specified replica, for example `gs://bucket/object` or `s3://bucket/object`
+          description: When set to true, the response will contain API-specific URLs that are tied to the specified replica,
+            for example `gs://bucket/object` or `s3://bucket/object`
+            The use of presigned URLs is recommended for data access. Cloud native URLs are currently provided for a limited set of use cases and may not be provided in the future.
+            If cloud native URLs are required, please contact the data store team regarding the credentials necessary to use them.
           type: boolean
       responses:
         301:
@@ -1452,7 +1455,11 @@ paths:
         - name: directurls
           in: query
           description: >
-            When set to true, the response will contain API-specific URLs that are tied to the specified replica, for example `gs://bucket/object` or `s3://bucket/object`. This parameter is mutually exclusive with the presigned urls parameter.
+            When set to true, the response will contain API-specific URLs that are tied to the specified replica,
+             for example `gs://bucket/object` or `s3://bucket/object`. This parameter is mutually exclusive with the presigned urls parameter.
+            The use of presigned URLs is recommended for data access.
+             Cloud native URLs are currently provided for a limited set of use cases and may not be provided in the future.
+              If cloud native URLs are required, please contact the data store team regarding the credentials necessary to use them.
           required: false
           type: boolean
         - name: presignedurls

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -368,13 +368,11 @@ paths:
         - name: directurl
           in: query
           required: false
-          description: >
+          description: |
             When set to true, the response will contain API-specific URLs that are tied to the specified replica,
-            for example `gs://bucket/object` or `s3://bucket/object`.
+            for example `gs://bucket/object` or `s3://bucket/object`
 
-            The use of presigned URLs is recommended for data access. Cloud native URLs are currently provided for a
-            limited set of use cases and may not be provided in the future. If cloud native URLs are required, please
-            contact the data store team regarding the credentials necessary to use them.
+            The use of presigned URLs is recommended for data access. Cloud native URLs are currently provided for a limited set of use cases and may not be provided in the future. If cloud native URLs are required, please contact the data store team regarding the credentials necessary to use them.
           type: boolean
       responses:
         301:
@@ -1457,14 +1455,10 @@ paths:
           enum: [aws, gcp]
         - name: directurls
           in: query
-          description: >
-            When set to true, the response will contain API-specific URLs that are tied to the specified replica,
-            for example `gs://bucket/object` or `s3://bucket/object`.
+          description: |
+            When set to true, the response will contain API-specific URLs that are tied to the specified replica, for example `gs://bucket/object` or `s3://bucket/object`
 
-            This parameter is mutually exclusive with the presigned urls parameter. The use of presigned URLs is
-            recommended for data access. Cloud native URLs are currently provided for a limited set of use cases and
-            may not be provided in the future. If cloud native URLs are required, please contact the data store team
-            regarding the credentials necessary to use them.
+            This parameter is mutually exclusive with the presigned urls parameter. The use of presigned URLs is recommended for data access. Cloud native URLs are currently provided for a limited set of use cases and may not be provided in the future. If cloud native URLs are required, please contact the data store team regarding the credentials necessary to use them.
           required: false
           type: boolean
         - name: presignedurls

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -365,6 +365,11 @@ paths:
           description: Token to manage retries.  End users constructing queries should not set this parameter.
           required: false
           type: string
+        - name: directurl
+          in: query
+          required: false
+          description: When set to true, the response will contain API-specific URLs that are tied to the specified replica
+          type: boolean
       responses:
         301:
           description: >
@@ -1447,7 +1452,7 @@ paths:
         - name: directurls
           in: query
           description: >
-            Include direct-access URLs in the response.  This is mutually exclusive with the presignedurls parameter.
+            Include API-specific direct-access URLs in the response.  This is mutually exclusive with the presignedurls parameter.
           required: false
           type: boolean
         - name: presignedurls

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -369,8 +369,7 @@ paths:
           in: query
           required: false
           description: |
-            When set to true, the response will contain API-specific URLs that are tied to the specified replica,
-            for example `gs://bucket/object` or `s3://bucket/object`
+            When set to true, the response will contain API-specific URLs that are tied to the specified replica, for example `gs://bucket/object` or `s3://bucket/object`
 
             The use of presigned URLs is recommended for data access. Cloud native URLs are currently provided for a limited set of use cases and may not be provided in the future. If cloud native URLs are required, please contact the data store team regarding the credentials necessary to use them.
           type: boolean

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -368,10 +368,11 @@ paths:
         - name: directurl
           in: query
           required: false
-          description: When set to true, the response will contain API-specific URLs that are tied to the specified replica,
-            for example `gs://bucket/object` or `s3://bucket/object`
-            The use of presigned URLs is recommended for data access. Cloud native URLs are currently provided for a limited set of use cases and may not be provided in the future.
-            If cloud native URLs are required, please contact the data store team regarding the credentials necessary to use them.
+          description: When set to true, the response will contain API-specific URLs that are tied to the specified
+            replica, for example `gs://bucket/object` or `s3://bucket/object`. The use of presigned URLs is recommended
+            for data access. Cloud native URLs are currently provided for a limited set of use cases and may not be
+            provided in the future. If cloud native URLs are required, please contact the data store team regarding the
+            credentials necessary to use them.
           type: boolean
       responses:
         301:
@@ -1456,10 +1457,10 @@ paths:
           in: query
           description: >
             When set to true, the response will contain API-specific URLs that are tied to the specified replica,
-             for example `gs://bucket/object` or `s3://bucket/object`. This parameter is mutually exclusive with the presigned urls parameter.
-            The use of presigned URLs is recommended for data access.
-             Cloud native URLs are currently provided for a limited set of use cases and may not be provided in the future.
-              If cloud native URLs are required, please contact the data store team regarding the credentials necessary to use them.
+            for example `gs://bucket/object` or `s3://bucket/object`. This parameter is mutually exclusive with the
+            presigned urls parameter. The use of presigned URLs is recommended for data access. Cloud native URLs are
+            currently provided for a limited set of use cases and may not be provided in the future. If cloud native
+            URLs are required, please contact the data store team regarding the credentials necessary to use them.
           required: false
           type: boolean
         - name: presignedurls

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -62,7 +62,7 @@ def get_helper(uuid: str, replica: Replica, version: str = None, token: str = No
 
     if version is None:
         # no matches!
-        raise DSSException(404, "not_found", f"Cannot find file! UUID: {uuid} Version: {version}")
+        raise DSSException(404, "not_found", f"Cannot find file!")
 
     # retrieve the file metadata.
     try:

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -62,7 +62,7 @@ def get_helper(uuid: str, replica: Replica, version: str = None, token: str = No
 
     if version is None:
         # no matches!
-        raise DSSException(404, "not_found", f"Cannot find file!")
+        raise DSSException(404, "not_found", "Cannot find file!")
 
     # retrieve the file metadata.
     try:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -420,12 +420,12 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
 
             verify_headers = ['X-DSS-VERSION', 'X-DSS-CREATOR-UID', 'X-DSS-S3-ETAG', 'X-DSS-SHA256',
                               'X-DSS-SHA1', 'X-DSS-CRC32C']
-            native_headers_verify = {k: v for k,v in native_resp_obj.response.headers.items() if k in verify_headers}
-            presigned_headers_verify = {k: v for k,v in resp_obj.response.headers.items() if k in verify_headers}
+            native_headers_verify = {k: v for k, v in native_resp_obj.response.headers.items() if k in verify_headers}
+            presigned_headers_verify = {k: v for k, v in resp_obj.response.headers.items() if k in verify_headers}
             self.assertDictEqual(native_headers_verify, presigned_headers_verify)
 
             blob_path = native_resp_obj.response.headers['Location'].split('/blobs/')[1]
-            native_size = handle.get_size(replica.checkout_bucket,f'blobs/{blob_path}')
+            native_size = handle.get_size(replica.checkout_bucket, f'blobs/{blob_path}')
             self.assertGreater(native_size, 0)
             self.assertEqual(native_size, resp_obj.response.headers['Content-Size'])
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -391,7 +391,6 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
         Verify that the direct URL option works for GET/ file
         """
         file_uuid = "ce55fd51-7833-469b-be0b-5da88ebebfcd"
-        handle = Config.get_blobstore_handle(replica)
 
         native_url = str(UrlBuilder()
                          .set(path="/v1/files/" + file_uuid)
@@ -418,12 +417,11 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
                 override_retry_interval=1,
             )
 
-            verify_headers = ['X-DSS-VERSION', 'X-DSS-CREATOR-UID', 'X-DSS-S3-ETAG',  'X-DSS-SHA256',
+            verify_headers = ['X-DSS-VERSION', 'X-DSS-CREATOR-UID', 'X-DSS-S3-ETAG', 'X-DSS-SHA256',
                               'X-DSS-SHA1', 'X-DSS-CRC32C']
             native_headers_verify = [x for x in native_resp_obj.response.headers if x in verify_headers]
             presigned_headers_verify = [x for x in resp_obj.response.headers if x in verify_headers]
             self.assertListEqual(native_headers_verify, presigned_headers_verify)
-
 
     def test_file_get_not_found(self):
         """

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -424,8 +424,10 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
             presigned_headers_verify = {k: v for k, v in resp_obj.response.headers.items() if k in verify_headers}
             self.assertDictEqual(native_headers_verify, presigned_headers_verify)
 
-            self.assertTrue(native_resp_obj.response.headers['Location'].split('//')[0].startswith(replica.storage_schema))
-            self.assertTrue(native_resp_obj.response.headers['Location'].split('//')[1].startswith(replica.checkout_bucket))
+            self.assertTrue(
+                native_resp_obj.response.headers['Location'].split('//')[0].startswith(replica.storage_schema))
+            self.assertTrue(
+                native_resp_obj.response.headers['Location'].split('//')[1].startswith(replica.checkout_bucket))
             blob_path = native_resp_obj.response.headers['Location'].split('/blobs/')[1]
             native_size = handle.get_size(replica.checkout_bucket, f'blobs/{blob_path}')
             self.assertGreater(native_size, 0)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -391,7 +391,9 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
         Verify that the direct URL option works for GET/ file
         """
         file_uuid = "ce55fd51-7833-469b-be0b-5da88ebebfcd"
+        handle = Config.get_blobstore_handle(replica)
 
+        # TODO variable name
         native_url = str(UrlBuilder()
                          .set(path="/v1/files/" + file_uuid)
                          .add_query("replica", replica.name)
@@ -419,9 +421,16 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
 
             verify_headers = ['X-DSS-VERSION', 'X-DSS-CREATOR-UID', 'X-DSS-S3-ETAG', 'X-DSS-SHA256',
                               'X-DSS-SHA1', 'X-DSS-CRC32C']
+            # TODO verify that values are compared
             native_headers_verify = [x for x in native_resp_obj.response.headers if x in verify_headers]
             presigned_headers_verify = [x for x in resp_obj.response.headers if x in verify_headers]
             self.assertListEqual(native_headers_verify, presigned_headers_verify)
+
+            handle.get_size(replica.checkout_bucket,)
+            # TODO verify url
+            # TODO cloud blob store sizes get_size()
+            # TODO fallback compare what we think the URL should be to what we got.
+            #
 
     def test_file_get_not_found(self):
         """

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -424,6 +424,8 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
             presigned_headers_verify = {k: v for k, v in resp_obj.response.headers.items() if k in verify_headers}
             self.assertDictEqual(native_headers_verify, presigned_headers_verify)
 
+            self.assertTrue(native_resp_obj.response.headers['Location'].split('//')[0].startswith(replica.storage_schema))
+            self.assertTrue(native_resp_obj.response.headers['Location'].split('//')[1].startswith(replica.checkout_bucket))
             blob_path = native_resp_obj.response.headers['Location'].split('/blobs/')[1]
             native_size = handle.get_size(replica.checkout_bucket, f'blobs/{blob_path}')
             self.assertGreater(native_size, 0)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -427,7 +427,7 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
             blob_path = native_resp_obj.response.headers['Location'].split('/blobs/')[1]
             native_size = handle.get_size(replica.checkout_bucket, f'blobs/{blob_path}')
             self.assertGreater(native_size, 0)
-            self.assertEqual(native_size, resp_obj.response.headers['Content-Size'])
+            self.assertEqual(native_size, int(resp_obj.response.headers['X-DSS-SIZE']))
 
     def test_file_get_not_found(self):
         """


### PR DESCRIPTION
Return direct url option for `GET /file/{uuid}` endpoint

Addresses: #2045
This PR returns a cloud native URL with the same path as is currently used for the presigned URL, the blob key path (with checksums), and refers to the same object in the checkout bucket.
There is a current question regarding whether that is the best/right path to return going forward, yet this current change is sufficient to unblock the HCA handoff to Terra effort.