### PR TITLE
Change how content-type is propagated when caching.

### DIFF
--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -60,6 +60,7 @@ def copy_worker(event, lambda_context):
             state = self.get_state_copy()
             src_blob = self.gcp_client.bucket(self.source_bucket).get_blob(self.source_key)
             dst_blob = self.gcp_client.bucket(self.destination_bucket).blob(self.destination_key)
+            src_blob.reload()
             content_type = src_blob.content_type
 
             # Files can be checked out to a user bucket or the standard dss checkout bucket.

--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -60,7 +60,6 @@ def copy_worker(event, lambda_context):
             state = self.get_state_copy()
             src_blob = self.gcp_client.bucket(self.source_bucket).get_blob(self.source_key)
             dst_blob = self.gcp_client.bucket(self.destination_bucket).blob(self.destination_key)
-            src_blob.reload()
             content_type = src_blob.content_type
 
             # Files can be checked out to a user bucket or the standard dss checkout bucket.

--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -60,7 +60,7 @@ def copy_worker(event, lambda_context):
             state = self.get_state_copy()
             src_blob = self.gcp_client.bucket(self.source_bucket).get_blob(self.source_key)
             dst_blob = self.gcp_client.bucket(self.destination_bucket).blob(self.destination_key)
-            content_type = src_blob._get_content_type(None)
+            content_type = src_blob.content_type
 
             # Files can be checked out to a user bucket or the standard dss checkout bucket.
             # If a user bucket, files should be unmodified by either the object tagging (AWS)


### PR DESCRIPTION
Hopefully addresses intermittent failures like this one: https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/data-store/-/jobs/31047 .