### PR TITLE
Fetch content type from blobstore.

### DIFF
--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -62,7 +62,7 @@ def copy_worker(event, lambda_context):
             dst_blob = self.gcp_client.bucket(self.destination_bucket).blob(self.destination_key)
 
             # get content-type
-            gs_blobstore = GSBlobStore.from_environment()
+            gs_blobstore = GSBlobStore(self.gcp_client)
             content_type = gs_blobstore.get_content_type(self.source_bucket, self.source_key)
 
             # Files can be checked out to a user bucket or the standard dss checkout bucket.

--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -63,8 +63,7 @@ def copy_worker(event, lambda_context):
 
             # get content-type
             gs_blobstore = GSBlobStore.from_environment()
-            blobinfo = gs_blobstore.get_all_metadata(self.source_bucket, self.source_key)
-            content_type = blobinfo['ContentType']
+            content_type = gs_blobstore.get_content_type(self.source_bucket, self.source_key)
 
             # Files can be checked out to a user bucket or the standard dss checkout bucket.
             # If a user bucket, files should be unmodified by either the object tagging (AWS)

--- a/dss/stepfunctions/gscopyclient/implementation.py
+++ b/dss/stepfunctions/gscopyclient/implementation.py
@@ -60,7 +60,7 @@ def copy_worker(event, lambda_context):
             state = self.get_state_copy()
             src_blob = self.gcp_client.bucket(self.source_bucket).get_blob(self.source_key)
             dst_blob = self.gcp_client.bucket(self.destination_bucket).blob(self.destination_key)
-            content_type = src_blob._get_content_type(None)
+            content_type = src_blob.content_type
 
             # Files can be checked out to a user bucket or the standard dss checkout bucket.
             # If a user bucket, files should be unmodified by either the object tagging (AWS)


### PR DESCRIPTION
Blobs can't be relied upon to already have `content-type` apparently.