### PR TITLE
Specify replicas in sync test content-type

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -278,7 +278,9 @@ class TestSyncDaemon(unittest.TestCase, DSSSyncMixin):
             test_key = "{}/s3-to-gs/{}".format(self.test_blob_prefix, uuid.uuid4())
             src_blob = self.s3_bucket.Object(test_key)
             gs_dest_blob = self.gs_bucket.blob(test_key)
-            src_blob.put(Body=payload, Metadata=test_metadata, ContentType="binary/octet-stream; dss-s3-to-gs-sync-test")
+            src_blob.put(Body=payload,
+                         Metadata=test_metadata,
+                         ContentType="binary/octet-stream; dss-s3-to-gs-sync-test")
 
             @eventually(timeout=60, interval=1, errors={Exception})
             def check_gs_dest():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -278,7 +278,7 @@ class TestSyncDaemon(unittest.TestCase, DSSSyncMixin):
             test_key = "{}/s3-to-gs/{}".format(self.test_blob_prefix, uuid.uuid4())
             src_blob = self.s3_bucket.Object(test_key)
             gs_dest_blob = self.gs_bucket.blob(test_key)
-            src_blob.put(Body=payload, Metadata=test_metadata)
+            src_blob.put(Body=payload, Metadata=test_metadata, ContentType="binary/octet-stream; dss-s3-to-gs-sync-test")
 
             @eventually(timeout=60, interval=1, errors={Exception})
             def check_gs_dest():
@@ -295,6 +295,8 @@ class TestSyncDaemon(unittest.TestCase, DSSSyncMixin):
             dest_blob = self.s3_bucket.Object(test_key)
             src_blob.metadata = test_metadata
             src_blob.upload_from_string(payload)
+            src_blob.content_type = "binary/octet-stream; dss-gs-to-s3-sync-test"
+            src_blob.patch()
 
             @eventually(timeout=60, interval=1, errors={Exception})
             def check_s3_dest(dest_blob):


### PR DESCRIPTION
Specify replication information in blob content type during sync tests.

This will either fix intermittent errors in sync, or elucidate them.

addresses #2159