### PR TITLE
Add operation to trigger sync

### DIFF
--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -87,7 +87,7 @@ def launch_from_forwarded_event(event, context):
     return executions
 
 # This entry point is for operator initiated replication
-@app.sqs_queue_subscriber("dss-sync-operation-" + os.environ['DSS_DEPLOYMENT_STAGE'], batch_size=1)
+@app.sqs_queue_subscriber("dss-sync-operation-" + os.environ['DSS_DEPLOYMENT_STAGE'])
 def launch_from_operator_queue(event, context):
     executions = {}
     for event_record in event['Records']:

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -7,6 +7,7 @@ from urllib.parse import unquote
 from concurrent.futures import ThreadPoolExecutor
 
 import domovoi
+from cloud_blobstore import BlobNotFoundError
 
 from dcplib.s3_multipart import AWS_MIN_CHUNK_SIZE
 
@@ -83,6 +84,37 @@ def launch_from_forwarded_event(event, context):
                 executions[exec_name] = app.state_machine.start_execution(**exec_input)["executionArn"]
         else:
             raise NotImplementedError()
+    return executions
+
+# This entry point is for operator initiated replication
+@app.sqs_queue_subscriber("dss-sync-operation-" + os.environ['DSS_DEPLOYMENT_STAGE'], batch_size=1)
+def launch_from_operator_queue(event, context):
+    executions = {}
+    for event_record in event['Records']:
+        message = json.loads(event_record['body'])
+        try:
+            source_replica = Replica[message['source_replica']]
+            dest_replica = Replica[message['dest_replica']]
+            key = message['key']
+            assert source_replica != dest_replica
+        except (KeyError, AssertionError):
+            logger.error("Inoperable operation sync message %s", message)
+            continue
+        bucket = source_replica.bucket
+        if exists(dest_replica, key):
+            logger.info("Key %s already exists in %s, skipping sync", key, dest_replica)
+            continue
+        try:
+            size = Config.get_blobstore_handle(source_replica).get_size(bucket, key)
+        except BlobNotFoundError:
+            logger.error("Key %s does not exist on source replica %s", key, source_replica)
+            continue
+        exec_name = bucket + "/" + key + ":" + source_replica.name + ":" + dest_replica.name
+        exec_input = dict(source_replica=source_replica.name,
+                          dest_replica=dest_replica.name,
+                          source_key=key,
+                          source_obj_metadata=dict(size=size))
+        executions[exec_name] = app.state_machine.start_execution(**exec_input)["executionArn"]
     return executions
 
 retry_config = [

--- a/dss/operations/sync.py
+++ b/dss/operations/sync.py
@@ -11,7 +11,7 @@ from collections import namedtuple
 from cloud_blobstore import BlobNotFoundError
 
 from dss import Config, Replica
-from dss.sqs import MessageQueuer, get_queue_url
+from dcplib.aws.sqs import SQSMessenger, get_queue_url
 from dss.storage.hcablobstore import compose_blob_key
 from dss.operations import dispatch
 from dss.storage.identifiers import BLOB_PREFIX, FILE_PREFIX, BUNDLE_PREFIX
@@ -64,12 +64,12 @@ def trigger_sync(argv: typing.List[str], args: argparse.Namespace):
     Invoke the sync daemon on a set of keys via sqs.
     """
     sync_queue_url = get_queue_url("dss-sync-operation-" + os.environ['DSS_DEPLOYMENT_STAGE'])
-    with MessageQueuer(sync_queue_url) as mq:
+    with SQSMessenger(sync_queue_url) as sqsm:
         for key in args.keys:
             msg = json.dumps(dict(source_replica=args.source_replica,
                                   dest_replica=args.destination_replica,
                                   key=key))
-            mq.send(msg)
+            sqsm.send(msg)
 
 def verify_blob_replication(src_handle, dst_handle, src_bucket, dst_bucket, key):
     """

--- a/dss/operations/sync.py
+++ b/dss/operations/sync.py
@@ -1,6 +1,7 @@
 """
 Replication consistency checks: verify and repair synchronization across replicas
 """
+import os
 import json
 import typing
 import logging
@@ -10,6 +11,7 @@ from collections import namedtuple
 from cloud_blobstore import BlobNotFoundError
 
 from dss import Config, Replica
+from dss.sqs import MessageQueuer, get_queue_url
 from dss.storage.hcablobstore import compose_blob_key
 from dss.operations import dispatch
 from dss.storage.identifiers import BLOB_PREFIX, FILE_PREFIX, BUNDLE_PREFIX
@@ -51,6 +53,20 @@ def verify_entity_replication(argv: typing.List[str], args: argparse.Namespace):
             raise ValueError(f"cannot handle key {key}")
         for anomaly in verify(src_handle, dst_handle, src_replica.bucket, dst_replica.bucket, key):
             _log_warning(ReplicationAnomaly=dict(key=anomaly.key, anomaly=anomaly.anomaly))
+
+
+@sync.action("sync",
+             arguments={"--source-replica": dict(choices=[r.name for r in Replica], required=True),
+                        "--destination-replica": dict(choices=[r.name for r in Replica], required=True),
+                        "--keys": dict(default=None, nargs="*", help="keys to check.")})
+def trigger_sync(argv: typing.List[str], args: argparse.Namespace):
+    sync_queue_url = get_queue_url("dss-sync-operation-" + os.environ['DSS_DEPLOYMENT_STAGE'])
+    with MessageQueuer(sync_queue_url) as mq:
+        for key in args.keys:
+            msg = json.dumps(dict(source_replica=args.source_replica,
+                                  dest_replica=args.destination_replica,
+                                  key=key))
+            mq.send(msg)
 
 def verify_blob_replication(src_handle, dst_handle, src_bucket, dst_bucket, key):
     """

--- a/dss/operations/sync.py
+++ b/dss/operations/sync.py
@@ -55,11 +55,14 @@ def verify_entity_replication(argv: typing.List[str], args: argparse.Namespace):
             _log_warning(ReplicationAnomaly=dict(key=anomaly.key, anomaly=anomaly.anomaly))
 
 
-@sync.action("sync",
+@sync.action("trigger-sync",
              arguments={"--source-replica": dict(choices=[r.name for r in Replica], required=True),
                         "--destination-replica": dict(choices=[r.name for r in Replica], required=True),
                         "--keys": dict(default=None, nargs="*", help="keys to check.")})
 def trigger_sync(argv: typing.List[str], args: argparse.Namespace):
+    """
+    Invoke the sync daemon on a set of keys via sqs.
+    """
     sync_queue_url = get_queue_url("dss-sync-operation-" + os.environ['DSS_DEPLOYMENT_STAGE'])
     with MessageQueuer(sync_queue_url) as mq:
         for key in args.keys:


### PR DESCRIPTION
This allows DSS operators to initiate sync for replica repair, and eventually replica standup.

The new functionality is:
  1. Adding an operational SQS queue entry point to the sync daemon, and
  2. Pushing sqs messages to the operational queue

This has been tested manually.

closes #2171 