### PR TITLE
[easy] Use the same regex for all uuids.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -348,7 +348,7 @@ paths:
           description: A RFC4122-compliant ID for the file.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -483,7 +483,7 @@ paths:
           description: A RFC4122-compliant ID for the file.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: version
           in: query
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
@@ -542,7 +542,7 @@ paths:
               task_id:
                 description: ID for the task responsible for managing the copy.
                 type: string
-                pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
             required:
               - version
         400:
@@ -855,7 +855,7 @@ paths:
               uuid:
                 description: A RFC4122-compliant ID for the subscription.
                 type: string
-                pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
             required:
               - uuid
         500:
@@ -903,7 +903,7 @@ paths:
           description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -959,7 +959,7 @@ paths:
           description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: replica
           in: query
           description: Replica to delete from.
@@ -1117,7 +1117,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: version
           in: query
           description: Timestamp of collection creation in DSS_VERSION format.
@@ -1138,7 +1138,7 @@ paths:
               uuid:
                 description: A RFC4122-compliant ID for the collection.
                 type: string
-                pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
             required:
               - uuid
         500:
@@ -1181,7 +1181,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -1236,7 +1236,7 @@ paths:
           description: A RFC4122-compliant ID of the collection to update.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: replica
           in: query
           description: Replica to update the collection on. Updates are propagated to other replicas.
@@ -1398,7 +1398,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: replica
           in: query
           description: Replica to delete from.
@@ -1441,7 +1441,7 @@ paths:
           description: Bundle unique ID.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: version
           in: query
           description: Timestamp of bundle creation in DSS_VERSION format.
@@ -1610,7 +1610,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: version
           in: query
           description: Timestamp of bundle creation in DSS_VERSION format.
@@ -1759,7 +1759,7 @@ paths:
           description: A RFC4122-compliant ID of the bundle to update.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: replica
           in: query
           description: Replica to update the bundle on. Updates are propagated to other replicas.
@@ -1904,7 +1904,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: replica
           in: query
           description: Replica to write to.
@@ -2008,7 +2008,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
         - name: version
           in: query
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
@@ -2041,7 +2041,7 @@ paths:
             properties:
               checkout_job_id:
                 description: A RFC4122-compliant ID for the checkout job request.
-                pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
                 type: string
             required:
               - checkout_job_id
@@ -2075,7 +2075,7 @@ paths:
         - name: checkout_job_id
           in: path
           description: A RFC4122-compliant ID for the checkout job request.
-          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
           required: true
           type: string
       responses:
@@ -2145,7 +2145,7 @@ definitions:
       uuid:
         type: string
         description: File unique ID
-        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
       name:
         type: string
         description: Filename (unique within a bundle)
@@ -2177,7 +2177,7 @@ definitions:
       uuid:
         type: string
         description: A RFC4122-compliant ID for the file.
-        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
       version:
         type: string
         format: DSS_VERSION
@@ -2219,7 +2219,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
       versions:
         type: array
         items:
@@ -2235,7 +2235,7 @@ definitions:
       uuid:
         description: A RFC4122-compliant ID for the file.
         type: string
-        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
       version:
         description: Timestamp of file creation in DSS_VERSION format.
         type: string
@@ -2265,7 +2265,7 @@ definitions:
       uuid:
         type: string
         description: Uniquely identifies this subscription.
-        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
       replica:
         description: >
           The DSS replica to subscribe. When a new bundle is indexed in a particular replica, only subscriptions for
@@ -2429,7 +2429,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
       version:
         type: string
         format: DSS_VERSION
@@ -2463,7 +2463,7 @@ definitions:
       uuid:
         type: string
         description: A UUID identifying the collection.
-        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
       version:
         description: The version of the UUID identifying the collection.
         type: string
@@ -2503,7 +2503,7 @@ definitions:
       uuid:
         type: string
         description: Unique ID of the file, bundle, collection, or file containing a metadata fragment.
-        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
       version:
         type: string
         format: DSS_VERSION

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -348,7 +348,7 @@ paths:
           description: A RFC4122-compliant ID for the file.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -483,7 +483,7 @@ paths:
           description: A RFC4122-compliant ID for the file.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: version
           in: query
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
@@ -542,7 +542,7 @@ paths:
               task_id:
                 description: ID for the task responsible for managing the copy.
                 type: string
-                pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - version
         400:
@@ -855,7 +855,7 @@ paths:
               uuid:
                 description: A RFC4122-compliant ID for the subscription.
                 type: string
-                pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
         500:
@@ -903,7 +903,7 @@ paths:
           description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -959,7 +959,7 @@ paths:
           description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: replica
           in: query
           description: Replica to delete from.
@@ -1117,7 +1117,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: version
           in: query
           description: Timestamp of collection creation in DSS_VERSION format.
@@ -1138,7 +1138,7 @@ paths:
               uuid:
                 description: A RFC4122-compliant ID for the collection.
                 type: string
-                pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
             required:
               - uuid
         500:
@@ -1181,7 +1181,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -1236,7 +1236,7 @@ paths:
           description: A RFC4122-compliant ID of the collection to update.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: replica
           in: query
           description: Replica to update the collection on. Updates are propagated to other replicas.
@@ -1398,7 +1398,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: replica
           in: query
           description: Replica to delete from.
@@ -1441,7 +1441,7 @@ paths:
           description: Bundle unique ID.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: version
           in: query
           description: Timestamp of bundle creation in DSS_VERSION format.
@@ -1610,7 +1610,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: version
           in: query
           description: Timestamp of bundle creation in DSS_VERSION format.
@@ -1759,7 +1759,7 @@ paths:
           description: A RFC4122-compliant ID of the bundle to update.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: replica
           in: query
           description: Replica to update the bundle on. Updates are propagated to other replicas.
@@ -1904,7 +1904,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: replica
           in: query
           description: Replica to write to.
@@ -2008,7 +2008,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
         - name: version
           in: query
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
@@ -2041,7 +2041,7 @@ paths:
             properties:
               checkout_job_id:
                 description: A RFC4122-compliant ID for the checkout job request.
-                pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
                 type: string
             required:
               - checkout_job_id
@@ -2075,7 +2075,7 @@ paths:
         - name: checkout_job_id
           in: path
           description: A RFC4122-compliant ID for the checkout job request.
-          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
           required: true
           type: string
       responses:
@@ -2145,7 +2145,7 @@ definitions:
       uuid:
         type: string
         description: File unique ID
-        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
       name:
         type: string
         description: Filename (unique within a bundle)
@@ -2177,7 +2177,7 @@ definitions:
       uuid:
         type: string
         description: A RFC4122-compliant ID for the file.
-        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
       version:
         type: string
         format: DSS_VERSION
@@ -2219,7 +2219,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
       versions:
         type: array
         items:
@@ -2235,7 +2235,7 @@ definitions:
       uuid:
         description: A RFC4122-compliant ID for the file.
         type: string
-        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
       version:
         description: Timestamp of file creation in DSS_VERSION format.
         type: string
@@ -2265,7 +2265,7 @@ definitions:
       uuid:
         type: string
         description: Uniquely identifies this subscription.
-        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
       replica:
         description: >
           The DSS replica to subscribe. When a new bundle is indexed in a particular replica, only subscriptions for
@@ -2429,7 +2429,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
       version:
         type: string
         format: DSS_VERSION
@@ -2463,7 +2463,7 @@ definitions:
       uuid:
         type: string
         description: A UUID identifying the collection.
-        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
       version:
         description: The version of the UUID identifying the collection.
         type: string
@@ -2503,7 +2503,7 @@ definitions:
       uuid:
         type: string
         description: Unique ID of the file, bundle, collection, or file containing a metadata fragment.
-        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
       version:
         type: string
         format: DSS_VERSION

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -348,7 +348,7 @@ paths:
           description: A RFC4122-compliant ID for the file.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -483,7 +483,7 @@ paths:
           description: A RFC4122-compliant ID for the file.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: version
           in: query
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
@@ -542,7 +542,7 @@ paths:
               task_id:
                 description: ID for the task responsible for managing the copy.
                 type: string
-                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+                pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
             required:
               - version
         400:
@@ -855,7 +855,7 @@ paths:
               uuid:
                 description: A RFC4122-compliant ID for the subscription.
                 type: string
-                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+                pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
             required:
               - uuid
         500:
@@ -903,7 +903,7 @@ paths:
           description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -959,7 +959,7 @@ paths:
           description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: replica
           in: query
           description: Replica to delete from.
@@ -1117,7 +1117,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: version
           in: query
           description: Timestamp of collection creation in DSS_VERSION format.
@@ -1138,7 +1138,7 @@ paths:
               uuid:
                 description: A RFC4122-compliant ID for the collection.
                 type: string
-                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+                pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
             required:
               - uuid
         500:
@@ -1181,7 +1181,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -1236,7 +1236,7 @@ paths:
           description: A RFC4122-compliant ID of the collection to update.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: replica
           in: query
           description: Replica to update the collection on. Updates are propagated to other replicas.
@@ -1398,7 +1398,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: replica
           in: query
           description: Replica to delete from.
@@ -1441,7 +1441,7 @@ paths:
           description: Bundle unique ID.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: version
           in: query
           description: Timestamp of bundle creation in DSS_VERSION format.
@@ -1610,7 +1610,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: version
           in: query
           description: Timestamp of bundle creation in DSS_VERSION format.
@@ -1759,7 +1759,7 @@ paths:
           description: A RFC4122-compliant ID of the bundle to update.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: replica
           in: query
           description: Replica to update the bundle on. Updates are propagated to other replicas.
@@ -1904,7 +1904,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: replica
           in: query
           description: Replica to write to.
@@ -2008,7 +2008,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         - name: version
           in: query
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
@@ -2041,7 +2041,7 @@ paths:
             properties:
               checkout_job_id:
                 description: A RFC4122-compliant ID for the checkout job request.
-                pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+                pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
                 type: string
             required:
               - checkout_job_id
@@ -2075,7 +2075,7 @@ paths:
         - name: checkout_job_id
           in: path
           description: A RFC4122-compliant ID for the checkout job request.
-          pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+          pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
           required: true
           type: string
       responses:
@@ -2145,7 +2145,7 @@ definitions:
       uuid:
         type: string
         description: File unique ID
-        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
       name:
         type: string
         description: Filename (unique within a bundle)
@@ -2177,7 +2177,7 @@ definitions:
       uuid:
         type: string
         description: A RFC4122-compliant ID for the file.
-        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
       version:
         type: string
         format: DSS_VERSION
@@ -2219,7 +2219,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
       versions:
         type: array
         items:
@@ -2235,7 +2235,7 @@ definitions:
       uuid:
         description: A RFC4122-compliant ID for the file.
         type: string
-        pattern: "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
       version:
         description: Timestamp of file creation in DSS_VERSION format.
         type: string
@@ -2265,7 +2265,7 @@ definitions:
       uuid:
         type: string
         description: Uniquely identifies this subscription.
-        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
       replica:
         description: >
           The DSS replica to subscribe. When a new bundle is indexed in a particular replica, only subscriptions for
@@ -2429,7 +2429,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
       version:
         type: string
         format: DSS_VERSION
@@ -2463,7 +2463,7 @@ definitions:
       uuid:
         type: string
         description: A UUID identifying the collection.
-        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
       version:
         description: The version of the UUID identifying the collection.
         type: string
@@ -2503,7 +2503,7 @@ definitions:
       uuid:
         type: string
         description: Unique ID of the file, bundle, collection, or file containing a metadata fragment.
-        pattern: "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+        pattern: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
       version:
         type: string
         format: DSS_VERSION

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -348,7 +348,7 @@ paths:
           description: A RFC4122-compliant ID for the file.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -483,7 +483,7 @@ paths:
           description: A RFC4122-compliant ID for the file.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: version
           in: query
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
@@ -542,7 +542,7 @@ paths:
               task_id:
                 description: ID for the task responsible for managing the copy.
                 type: string
-                pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+                pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
             required:
               - version
         400:
@@ -855,7 +855,7 @@ paths:
               uuid:
                 description: A RFC4122-compliant ID for the subscription.
                 type: string
-                pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+                pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
             required:
               - uuid
         500:
@@ -903,7 +903,7 @@ paths:
           description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -959,7 +959,7 @@ paths:
           description: A RFC4122-compliant ID for the subscription.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: replica
           in: query
           description: Replica to delete from.
@@ -1117,7 +1117,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: version
           in: query
           description: Timestamp of collection creation in DSS_VERSION format.
@@ -1138,7 +1138,7 @@ paths:
               uuid:
                 description: A RFC4122-compliant ID for the collection.
                 type: string
-                pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+                pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
             required:
               - uuid
         500:
@@ -1181,7 +1181,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: replica
           in: query
           description: Replica to fetch from.
@@ -1236,7 +1236,7 @@ paths:
           description: A RFC4122-compliant ID of the collection to update.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: replica
           in: query
           description: Replica to update the collection on. Updates are propagated to other replicas.
@@ -1398,7 +1398,7 @@ paths:
           description: A RFC4122-compliant ID for the collection.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: replica
           in: query
           description: Replica to delete from.
@@ -1441,7 +1441,7 @@ paths:
           description: Bundle unique ID.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: version
           in: query
           description: Timestamp of bundle creation in DSS_VERSION format.
@@ -1610,7 +1610,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: version
           in: query
           description: Timestamp of bundle creation in DSS_VERSION format.
@@ -1759,7 +1759,7 @@ paths:
           description: A RFC4122-compliant ID of the bundle to update.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: replica
           in: query
           description: Replica to update the bundle on. Updates are propagated to other replicas.
@@ -1904,7 +1904,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: replica
           in: query
           description: Replica to write to.
@@ -2008,7 +2008,7 @@ paths:
           description: A RFC4122-compliant ID for the bundle.
           required: true
           type: string
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
         - name: version
           in: query
           description: Timestamp of file creation in DSS_VERSION format.  If this is not provided, the latest version is returned.
@@ -2041,7 +2041,7 @@ paths:
             properties:
               checkout_job_id:
                 description: A RFC4122-compliant ID for the checkout job request.
-                pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+                pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
                 type: string
             required:
               - checkout_job_id
@@ -2075,7 +2075,7 @@ paths:
         - name: checkout_job_id
           in: path
           description: A RFC4122-compliant ID for the checkout job request.
-          pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+          pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
           required: true
           type: string
       responses:
@@ -2145,7 +2145,7 @@ definitions:
       uuid:
         type: string
         description: File unique ID
-        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
       name:
         type: string
         description: Filename (unique within a bundle)
@@ -2177,7 +2177,7 @@ definitions:
       uuid:
         type: string
         description: A RFC4122-compliant ID for the file.
-        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
       version:
         type: string
         format: DSS_VERSION
@@ -2219,7 +2219,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
       versions:
         type: array
         items:
@@ -2235,7 +2235,7 @@ definitions:
       uuid:
         description: A RFC4122-compliant ID for the file.
         type: string
-        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
       version:
         description: Timestamp of file creation in DSS_VERSION format.
         type: string
@@ -2265,7 +2265,7 @@ definitions:
       uuid:
         type: string
         description: Uniquely identifies this subscription.
-        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
       replica:
         description: >
           The DSS replica to subscribe. When a new bundle is indexed in a particular replica, only subscriptions for
@@ -2429,7 +2429,7 @@ definitions:
       uuid:
         type: string
         description: Bundle unique ID
-        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
       version:
         type: string
         format: DSS_VERSION
@@ -2463,7 +2463,7 @@ definitions:
       uuid:
         type: string
         description: A UUID identifying the collection.
-        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
       version:
         description: The version of the UUID identifying the collection.
         type: string
@@ -2503,7 +2503,7 @@ definitions:
       uuid:
         type: string
         description: Unique ID of the file, bundle, collection, or file containing a metadata fragment.
-        pattern: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+        pattern: "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
       version:
         type: string
         format: DSS_VERSION

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -28,10 +28,6 @@ DSS_BUNDLE_TOMBSTONE_REGEX = re.compile(
 DSS_OBJECT_NAME_REGEX = re.compile(
     f"^({BUNDLE_PREFIX}|{FILE_PREFIX}|{COLLECTION_PREFIX})/({UUID_PATTERN})(?:\.({VERSION_PATTERN}))?(\.{TOMBSTONE_SUFFIX})?$")  # noqa
 
-# API endpoint patterns
-BUNDLE_CHECKOUT_PATTERN = f'/v1/bundles/{UUID_PATTERN}/checkout'
-BUNDLE_CHECKOUT_URI_REGEX = re.compile(BUNDLE_CHECKOUT_PATTERN)
-
 
 class ObjectIdentifierError(ValueError):
     pass

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -10,7 +10,7 @@ COLLECTION_PREFIX = "collections"
 # versioned tombstones are indexed after all bundles during a reindex operation.
 TOMBSTONE_SUFFIX = "dead"
 
-UUID_PATTERN = "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+UUID_PATTERN = "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
 UUID_REGEX = re.compile(UUID_PATTERN)
 
 VERSION_PATTERN = "\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}[.]\d{6}Z"

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -2,7 +2,6 @@ import re
 from collections import namedtuple
 from typing import Type
 
-BLOB_PREFIX = "blobs"
 BUNDLE_PREFIX = "bundles"
 FILE_PREFIX = "files"
 COLLECTION_PREFIX = "collections"
@@ -10,7 +9,7 @@ COLLECTION_PREFIX = "collections"
 # versioned tombstones are indexed after all bundles during a reindex operation.
 TOMBSTONE_SUFFIX = "dead"
 
-UUID_PATTERN = "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 UUID_REGEX = re.compile(UUID_PATTERN)
 
 VERSION_PATTERN = "\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}[.]\d{6}Z"
@@ -28,6 +27,10 @@ DSS_BUNDLE_TOMBSTONE_REGEX = re.compile(
 # matches all bundle objects
 DSS_OBJECT_NAME_REGEX = re.compile(
     f"^({BUNDLE_PREFIX}|{FILE_PREFIX}|{COLLECTION_PREFIX})/({UUID_PATTERN})(?:\.({VERSION_PATTERN}))?(\.{TOMBSTONE_SUFFIX})?$")  # noqa
+
+# API endpoint patterns
+BUNDLE_CHECKOUT_PATTERN = f'/v1/bundles/{UUID_PATTERN}/checkout'
+BUNDLE_CHECKOUT_URI_REGEX = re.compile(BUNDLE_CHECKOUT_PATTERN)
 
 
 class ObjectIdentifierError(ValueError):

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -10,7 +10,8 @@ COLLECTION_PREFIX = "collections"
 # versioned tombstones are indexed after all bundles during a reindex operation.
 TOMBSTONE_SUFFIX = "dead"
 
-# does not allow caps (though our swagger params allow users to input this, s3 keys are changed to lowercase after ingested)
+# does not allow caps
+# (though our swagger params allow users to input this, s3 keys are changed to lowercase after ingestion)
 UUID_PATTERN = "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
 UUID_REGEX = re.compile(UUID_PATTERN)
 

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -10,7 +10,7 @@ COLLECTION_PREFIX = "collections"
 # versioned tombstones are indexed after all bundles during a reindex operation.
 TOMBSTONE_SUFFIX = "dead"
 
-UUID_PATTERN = "[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}"
+UUID_PATTERN = "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
 UUID_REGEX = re.compile(UUID_PATTERN)
 
 VERSION_PATTERN = "\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}[.]\d{6}Z"

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -9,7 +9,7 @@ COLLECTION_PREFIX = "collections"
 # versioned tombstones are indexed after all bundles during a reindex operation.
 TOMBSTONE_SUFFIX = "dead"
 
-UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+UUID_PATTERN = "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
 UUID_REGEX = re.compile(UUID_PATTERN)
 
 VERSION_PATTERN = "\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}[.]\d{6}Z"

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -2,6 +2,7 @@ import re
 from collections import namedtuple
 from typing import Type
 
+BLOB_PREFIX = "blobs"
 BUNDLE_PREFIX = "bundles"
 FILE_PREFIX = "files"
 COLLECTION_PREFIX = "collections"

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -10,7 +10,8 @@ COLLECTION_PREFIX = "collections"
 # versioned tombstones are indexed after all bundles during a reindex operation.
 TOMBSTONE_SUFFIX = "dead"
 
-UUID_PATTERN = "[A-Za-z0-9]{8}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{12}"
+# does not allow caps (though our swagger params allow users to input this, s3 keys are changed to lowercase after ingested)
+UUID_PATTERN = "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
 UUID_REGEX = re.compile(UUID_PATTERN)
 
 VERSION_PATTERN = "\d{4}-\d{2}-\d{2}T\d{2}\d{2}\d{2}[.]\d{6}Z"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,7 +67,7 @@ class TestApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin, DSSStorageMixin
         self.assertEquals(res.json['version_info']['version'], os.environ['DSS_VERSION'])
 
     def test_read_only(self):
-        uuid = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        uuid = "11111111-1111-1111-1111-111111111111"
         body = dict(
             files=[],
             creator_uid=12345,

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -16,7 +16,7 @@ from tests.infra import testmode
 @testmode.standalone
 class TestRegexIdentifiers(unittest.TestCase):
     def test_REGEX_MATCHING(self):
-        chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        chars = '0123456789abcdefghijklmnopqrstuvwxyz'
         for i, c in enumerate(chars):
             uuid = f'{c*8}-{c*4}-{c*4}-{c*4}-{c*12}'
             if i <= 15:

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -17,7 +17,7 @@ from tests.infra import testmode
 @testmode.standalone
 class TestRegexIdentifiers(unittest.TestCase):
     def test_REGEX_MATCHING(self):
-        chars = string.ascii_letters + string.digits
+        chars = string.lowercase + string.digits
         for i, c in enumerate(chars):
             uuid = f'{c*8}-{c*4}-{c*4}-{c*4}-{c*12}'
             self.assertTrue(UUID_REGEX.match(uuid), uuid)

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -17,7 +17,7 @@ from tests.infra import testmode
 @testmode.standalone
 class TestRegexIdentifiers(unittest.TestCase):
     def test_REGEX_MATCHING(self):
-        chars = string.lowercase + string.digits
+        chars = string.ascii_lowercase + string.digits
         for i, c in enumerate(chars):
             uuid = f'{c*8}-{c*4}-{c*4}-{c*4}-{c*12}'
             self.assertTrue(UUID_REGEX.match(uuid), uuid)

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -16,13 +16,10 @@ from tests.infra import testmode
 @testmode.standalone
 class TestRegexIdentifiers(unittest.TestCase):
     def test_REGEX_MATCHING(self):
-        chars = '0123456789abcdefghijklmnopqrstuvwxyz'
+        chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
         for i, c in enumerate(chars):
             uuid = f'{c*8}-{c*4}-{c*4}-{c*4}-{c*12}'
-            if i <= 15:
-                self.assertTrue(UUID_REGEX.match(uuid), uuid)
-            else:
-                self.assertIsNone(UUID_REGEX.match(uuid), uuid)
+            self.assertTrue(UUID_REGEX.match(uuid), uuid)
 
         for i in range(100):
             uuid = str(uuid4())

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import sys
+import unittest
+from uuid import uuid4
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from dss.storage.identifiers import UUID_REGEX
+from tests.infra import testmode
+
+
+@testmode.standalone
+class TestRegexIdentifiers(unittest.TestCase):
+    def test_REGEX_MATCHING(self):
+        chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        for i, c in enumerate(chars):
+            uuid = f'{c*8}-{c*4}-{c*4}-{c*4}-{c*12}'
+            if i <= 15:
+                self.assertTrue(UUID_REGEX.match(uuid), uuid)
+            else:
+                self.assertIsNone(UUID_REGEX.match(uuid), uuid)
+
+        for i in range(100):
+            uuid = str(uuid4())
+            self.assertTrue(UUID_REGEX.match(uuid), uuid)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import string
 import unittest
 from uuid import uuid4
 
@@ -16,7 +17,7 @@ from tests.infra import testmode
 @testmode.standalone
 class TestRegexIdentifiers(unittest.TestCase):
     def test_REGEX_MATCHING(self):
-        chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        chars = string.ascii_letters + string.digits
         for i, c in enumerate(chars):
             uuid = f'{c*8}-{c*4}-{c*4}-{c*4}-{c*12}'
             self.assertTrue(UUID_REGEX.match(uuid), uuid)


### PR DESCRIPTION
Noticed this when testing.  Some of the uuids in the swagger differ from each other as well.  This ensures we only use version 4 RFC4122-compliant IDs.

We seem to have variations between `A-Za-z0-9` and `a-z0-9` in our swagger doc, and the regex in `storage/identifiers.py` only allows `A-Fa-f0-9`.

The actual standard (for version 4) is `a-f0-9`, which is none of these.  I'm wondering which regex makes sense, because I think they should all be the same regex.

I opted for `A-Za-z0-9` based on @kislyuk 's response.