### PR TITLE
Allow Terra user read access to Google checkout bucket

### DIFF
--- a/environment
+++ b/environment
@@ -139,7 +139,7 @@ DSS_GCP_SERVICE_ACCOUNT_NAME="travis-test"
 
 # This list manages the GCP Users and serviceAccounts able to access direct URLs on the GS checkout bucket.
 # Other GCP entities must use presigned urls, or checkout to an external GS bucket they have access to. 
-DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS="serviceAccount:619310558212-compute@developer.gserviceaccount.com,serviceAccount:caas-account@broad-dsde-mint-dev.iam.gserviceaccount.com,serviceAccount:caas-prod-account-for-dev@broad-dsde-mint-dev.iam.gserviceaccount.com"
+DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS="serviceAccount:619310558212-compute@developer.gserviceaccount.com,serviceAccount:caas-account@broad-dsde-mint-dev.iam.gserviceaccount.com,serviceAccount:caas-prod-account-for-dev@broad-dsde-mint-dev.iam.gserviceaccount.com,GROUP_All_Users@firecloud.org"
 
 AWS_SDK_LOAD_CONFIG=1 # Needed for Terraform to correctly use AWS assumed roles
 


### PR DESCRIPTION
Added `GROUP_All_Users@firecloud.org` to the `DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS` environment variable so users of the Broad's Terra/FireCloud workspace can run workflows accessing HCA data.

For more information, please see: #2210

 Fixes #2210