### PR TITLE
Prevent non-team members from merging unreviewed code

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,7 @@
+version: 3
+
+groups:
+  software-review:
+    reviews:
+      required: 1
+      author_value: 1 # if author in group reduce number of approvals needed by this number


### PR DESCRIPTION
This adds a [PullApprove] definition to prevent non-team members from merging changes into protected branches without a review.

To use pull approve, the following actions are required:
  1. Define the `software-review` team in the data-store repo. Members should be the DSS team.
  1. Add GitHub branch protection rules for `master`, `integration`, `staging`, and `prod`.

closes #1946 