### PR TITLE
Add operation to output bundle metadata document

### DIFF
--- a/dss/operations/events.py
+++ b/dss/operations/events.py
@@ -9,15 +9,13 @@ from dss.config import Replica
 from dss.operations import dispatch
 from dss.events.handlers.notify_v2 import build_bundle_metadata_document
 
-events = dispatch.target("events",
-    help=__doc__
-)
+events = dispatch.target("events", help=__doc__)
 
 @events.action("bundle-metadata-document",
                arguments={"--replica": dict(choices=[r.name for r in Replica], required=True),
                           "--keys": dict(default=None,
-                                    nargs="*",
-                                    help="bundle keys to generate documents.")})
+                                         nargs="*",
+                                         help="bundle keys to generate documents.")})
 def bundle_metadata_document(argv: typing.List[str], args: argparse.Namespace):
     for key in args.keys:
         md = build_bundle_metadata_document(Replica[args.replica], key)

--- a/dss/operations/events.py
+++ b/dss/operations/events.py
@@ -1,0 +1,24 @@
+"""
+JMESPath Eventing/subscription admin tooling
+"""
+import typing
+import argparse
+import json
+
+from dss.config import Replica
+from dss.operations import dispatch
+from dss.events.handlers.notify_v2 import build_bundle_metadata_document
+
+events = dispatch.target("events",
+    help=__doc__
+)
+
+@events.action("bundle-metadata-document",
+               arguments={"--replica": dict(choices=[r.name for r in Replica], required=True),
+                          "--keys": dict(default=None,
+                                    nargs="*",
+                                    help="bundle keys to generate documents.")})
+def bundle_metadata_document(argv: typing.List[str], args: argparse.Namespace):
+    for key in args.keys:
+        md = build_bundle_metadata_document(Replica[args.replica], key)
+        print(json.dumps(md))

--- a/dss/operations/events.py
+++ b/dss/operations/events.py
@@ -1,15 +1,23 @@
 """
-JMESPath Eventing/subscription admin tooling
+JMESPath eventing and subscription admin tooling
 """
 import typing
 import argparse
 import json
+import logging
+
+from cloud_blobstore import BlobNotFoundError
 
 from dss.config import Replica
 from dss.operations import dispatch
 from dss.events.handlers.notify_v2 import build_bundle_metadata_document
 
+
+logger = logging.getLogger(__name__)
+
+
 events = dispatch.target("events", help=__doc__)
+
 
 @events.action("bundle-metadata-document",
                arguments={"--replica": dict(choices=[r.name for r in Replica], required=True),
@@ -18,5 +26,11 @@ events = dispatch.target("events", help=__doc__)
                                          help="bundle keys to generate documents.")})
 def bundle_metadata_document(argv: typing.List[str], args: argparse.Namespace):
     for key in args.keys:
-        md = build_bundle_metadata_document(Replica[args.replica], key)
-        print(json.dumps(md))
+        if not key.startswith("bundles/"):
+            logger.warning(f"Unable to produce bundle metadata document for '{key}'")
+            continue
+        try:
+            md = build_bundle_metadata_document(Replica[args.replica], key)
+            print(json.dumps(md))
+        except BlobNotFoundError:
+            logger.error(f"Bundle not found for '{key}'")

--- a/scripts/dss-ops.py
+++ b/scripts/dss-ops.py
@@ -13,6 +13,7 @@ import dss
 import dss.operations.storage
 import dss.operations.sync
 import dss.operations.elasticsearch
+import dss.operations.events
 from dss.operations import dispatch
 
 logging.basicConfig(stream=sys.stdout)


### PR DESCRIPTION
This is useful for quickly downloading the metadata of a bundle, which is the document validated against JMESPath subscriptions filters.