### PR TITLE
[EZ] GET/ Subscription_v1 HMAC Key Change

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -2297,7 +2297,7 @@ definitions:
         pattern: 'https?://'
       hmac_key_id:
         description: >
-          id used to verify authenticity of subscription
+          The HMAC key-id used to verify authenticity of subscription
         type: string
       method:
         description: The HTTP request method to use when delivering a notification to the subscriber.

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -2295,9 +2295,9 @@ definitions:
           number of attempts is reached.
         type: string
         pattern: 'https?://'
-      hmac_secret_key:
+      hmac_key_id:
         description: >
-          Key used to verify authenticity of subscription
+          id used to verify authenticity of subscription
         type: string
       method:
         description: The HTTP request method to use when delivering a notification to the subscriber.

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -35,7 +35,7 @@ def get(uuid: str, replica: str):
     source = response['_source']
     source['uuid'] = uuid
     source['replica'] = replica
-    if 'hmac_key_id' in response.keys():
+    if 'hmac_key_id' in response:
         source['hmac_key_id'] = response['hmac_key_id']
 
     if source['owner'] != owner:
@@ -59,7 +59,7 @@ def find(replica: str):
         'uuid': hit.meta.id,
         'replica': replica,
         'owner': owner,
-        **{k: v for k, v in hit.to_dict().items() if not k.startswith('hmac_secret_key')}}
+        **{k: v for k, v in hit.to_dict().items() if k != 'hmac_secret_key'}}
         for hit in search.scan()]
 
     full_response = {'subscriptions': responses}

--- a/dss/api/subscriptions_v1.py
+++ b/dss/api/subscriptions_v1.py
@@ -35,8 +35,8 @@ def get(uuid: str, replica: str):
     source = response['_source']
     source['uuid'] = uuid
     source['replica'] = replica
-    if 'hmac_secret_key' in response.keys():
-        source['hmac_secret_key'] = response['hmac_secret_key']
+    if 'hmac_key_id' in response.keys():
+        source['hmac_key_id'] = response['hmac_key_id']
 
     if source['owner'] != owner:
         # common_error_handler defaults code to capitalized 'Forbidden' for Werkzeug exception. Keeping consistent.
@@ -59,7 +59,7 @@ def find(replica: str):
         'uuid': hit.meta.id,
         'replica': replica,
         'owner': owner,
-        **{k: v for k, v in hit.to_dict().items() if not k.startswith('hmac_key_id')}}
+        **{k: v for k, v in hit.to_dict().items() if not k.startswith('hmac_secret_key')}}
         for hit in search.scan()]
 
     full_response = {'subscriptions': responses}

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -160,7 +160,7 @@ class TestSubscriptionsBase(ElasticsearchTestCase, TestAuthMixin, DSSAssertMixin
         json_response = resp_obj.json
         self.assertEqual(self.sample_percolate_query, json_response['es_query'])
         self.assertEqual(self.endpoint, Endpoint.from_subscription(json_response))
-        self.assertEquals(self.hmac_secret_key, json_response['hmac_secret_key'])
+        self.assertEquals(self.hmac_key_id, json_response['hmac_key_id'])
 
         # File not found request
         url = str(UrlBuilder()
@@ -186,7 +186,7 @@ class TestSubscriptionsBase(ElasticsearchTestCase, TestAuthMixin, DSSAssertMixin
             headers=get_auth_header())
         json_response = resp_obj.json
         self.assertEqual(self.sample_percolate_query, json_response['subscriptions'][0]['es_query'])
-        self.assertEqual(self.hmac_secret_key, json_response['subscriptions'][0]['hmac_secret_key'])
+        self.assertEqual(self.hmac_key_id, json_response['subscriptions'][0]['hmac_key_id'])
         self.assertEqual(self.endpoint, Endpoint.from_subscription(json_response['subscriptions'][0]))
         self.assertEqual(num_additions, len(json_response['subscriptions']))
 


### PR DESCRIPTION
replaces `hmac_secret_key` with `hmac_key_id` for get/find subscription operations.
