### PR TITLE
Verify content type.

### DIFF
--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -315,8 +315,6 @@ def put(uuid: str, json_request_body: dict, version: str):
     try:
         write_file_metadata(handle, dst_bucket, uuid, version, file_metadata_json)
         status_code = requests.codes.created
-        assert file_metadata['content-type'] == blob_content_type, \
-            f"{file_metadata['content-type']} != {blob_content_type}"
     except BlobAlreadyExistsError:
         # fetch the file metadata, compare it to what we have.
         existing_file_metadata = json.loads(
@@ -324,8 +322,6 @@ def put(uuid: str, json_request_body: dict, version: str):
                 dst_bucket,
                 "files/{}.{}".format(uuid, version)
             ).decode("utf-8"))
-        assert existing_file_metadata['content-type'] == blob_content_type, \
-            f"{existing_file_metadata['content-type']} != {blob_content_type}"
         if existing_file_metadata != file_metadata:
             raise DSSException(
                 requests.codes.conflict,

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -311,7 +311,6 @@ def put(uuid: str, json_request_body: dict, version: str):
         # verify the copy was done correctly.
         assert hca_handle.verify_blob_checksum_from_staging_metadata(dst_bucket, dst_key, metadata)
 
-    blob_content_type = handle.get_content_type(dst_bucket, dst_key)
     try:
         write_file_metadata(handle, dst_bucket, uuid, version, file_metadata_json)
         status_code = requests.codes.created

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -315,6 +315,8 @@ def put(uuid: str, json_request_body: dict, version: str):
     try:
         write_file_metadata(handle, dst_bucket, uuid, version, file_metadata_json)
         status_code = requests.codes.created
+        assert file_metadata['content-type'] == blob_content_type, \
+            f"{file_metadata['content-type']} != {blob_content_type}"
     except BlobAlreadyExistsError:
         # fetch the file metadata, compare it to what we have.
         existing_file_metadata = json.loads(
@@ -330,11 +332,6 @@ def put(uuid: str, json_request_body: dict, version: str):
                 "file_already_exists",
                 f"file with UUID {uuid} and version {version} already exists")
         status_code = requests.codes.ok
-    else:
-        assert file_metadata['content-type'] == blob_content_type, \
-            f"{file_metadata['content-type']} != {blob_content_type}"
-
-
 
     if should_cache_file(content_type=content_type, size=size) and size <= ASYNC_COPY_THRESHOLD:
         start_file_checkout(replica=replica, blob_key=dst_key)

--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -205,6 +205,7 @@ class verify_referential_integrity(StorageOperationHandler):
         if not dependencies_exist(self.replica, self.replica, key):
             self.log_warning("EntityMissingDependencies", dict(key=key, replica=self.replica.name))
 
+
 # TODO: Move to cloud_blobstore
 def update_aws_content_type(s3_client, bucket, key, content_type):
     blob = resources.s3.Bucket(bucket).Object(key)
@@ -240,6 +241,7 @@ def update_aws_content_type(s3_client, bucket, key, content_type):
                                             Key=key,
                                             MultipartUpload=multipart_upload,
                                             UploadId=upload_id)
+
 
 # TODO: Move to cloud_blobstore
 def update_gcp_content_type(gs_client, bucket, key, content_type):

--- a/dss/stepfunctions/s3copyclient/implementation.py
+++ b/dss/stepfunctions/s3copyclient/implementation.py
@@ -66,6 +66,7 @@ def setup_copy_task(event, lambda_context):
         mpu = s3_blobstore.s3_client.create_multipart_upload(
             Bucket=destination_bucket,
             Key=destination_key,
+            Metadata=s3_blobstore.get_all_metadata(source_bucket, source_key),
             ContentType=blobinfo['ContentType'])
         event[_Key.UPLOAD_ID] = mpu['UploadId']
         event[Key.FINISHED] = False

--- a/dss/stepfunctions/s3copyclient/implementation.py
+++ b/dss/stepfunctions/s3copyclient/implementation.py
@@ -66,7 +66,6 @@ def setup_copy_task(event, lambda_context):
         mpu = s3_blobstore.s3_client.create_multipart_upload(
             Bucket=destination_bucket,
             Key=destination_key,
-            Metadata=s3_blobstore.get_user_metadata(source_bucket, source_key),
             ContentType=blobinfo['ContentType'])
         event[_Key.UPLOAD_ID] = mpu['UploadId']
         event[Key.FINISHED] = False

--- a/dss/stepfunctions/s3copyclient/implementation.py
+++ b/dss/stepfunctions/s3copyclient/implementation.py
@@ -63,7 +63,11 @@ def setup_copy_task(event, lambda_context):
     if part_count * part_size < source_size:
         part_count += 1
     if part_count > 1:
-        mpu = s3_blobstore.s3_client.create_multipart_upload(Bucket=destination_bucket, Key=destination_key)
+        mpu = s3_blobstore.s3_client.create_multipart_upload(
+            Bucket=destination_bucket,
+            Key=destination_key,
+            Metadata=s3_blobstore.get_user_metadata(source_bucket, source_key),
+            ContentType=blobinfo['ContentType'])
         event[_Key.UPLOAD_ID] = mpu['UploadId']
         event[Key.FINISHED] = False
     else:


### PR DESCRIPTION
Multipart file uploads weren't specifying the content-type and so this was creating mismatches.  Tested and working when the step function is manually deployed.