### PR TITLE
[easy] Extend test_file_get_checkout's test_creation_date_updated time.

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -701,7 +701,7 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
             test_checkout()
 
         with self.subTest(f"{replica}: Initiates checkout and returns 302 immediately for GET on stale checkout file."):
-            @eventually(20, 1)
+            @eventually(30, 1)
             def test_creation_date_updated(key, prev_creation_date):
                 self.assertTrue(prev_creation_date < handle.get_creation_date(replica.checkout_bucket, key))
 


### PR DESCRIPTION
`test_file_get_checkout()` has been flaky lately.