### PR TITLE
Notify V2 Payload Context

### DIFF
--- a/daemons/dss-notify-v2/Readme.md
+++ b/daemons/dss-notify-v2/Readme.md
@@ -30,7 +30,7 @@ Bundle creation notifications have the format
 
 ```
 {
-  'dss-api': {dss_api_url}
+  'dss_api': {dss_api_url}
   'bundle_url': {dss_api}"/v1/bundles/{uuid}?version={version}
   'transaction_id': {uuid},
   'subscription_id': {uuid},

--- a/daemons/dss-notify-v2/Readme.md
+++ b/daemons/dss-notify-v2/Readme.md
@@ -30,9 +30,12 @@ Bundle creation notifications have the format
 
 ```
 {
+  'dss-api': dss_api
+  'bundle_url': {dss_api}"/bundles/{uuid}?version={version}
   'transaction_id': {uuid},
   'subscription_id': {uuid},
   'event_type': "CREATE"|"TOMBSTONE"|"DELETE",
+  'event_timestamp': "timestamp"
   'match': {
     'bundle_uuid': {uuid},
     'bundle_version': {version},
@@ -50,6 +53,9 @@ Bundle creation notifications have the format
 The `jmespath_query` and `attachment` fields are subscription dependent and may not be present. Attachment
 usage and format description can be found in the /subscription endpoint of the [DSS OpenAPI specifications](../../dss-api.yml).
 
+The `event_timestamp` field is a timestamp for when the event was created, the formatting is in the `DSS_VERSION` format.
+
+The `dss_api` field is the URL for 
 ## Subscriptions
 
 Event subscriptions are managed via the `/subscriptions` API endpoint, described in detail by the

--- a/daemons/dss-notify-v2/Readme.md
+++ b/daemons/dss-notify-v2/Readme.md
@@ -30,7 +30,7 @@ Bundle creation notifications have the format
 
 ```
 {
-  'dss-api': dss_api
+  'dss-api': {dss_api_url}
   'bundle_url': {dss_api}"/v1/bundles/{uuid}?version={version}
   'transaction_id': {uuid},
   'subscription_id': {uuid},
@@ -53,9 +53,8 @@ Bundle creation notifications have the format
 The `jmespath_query` and `attachment` fields are subscription dependent and may not be present. Attachment
 usage and format description can be found in the /subscription endpoint of the [DSS OpenAPI specifications](../../dss-api.yml).
 
-The `event_timestamp` field is a timestamp for when the event was created, the formatting is in the `DSS_VERSION` format.
+The `event_timestamp` field is the event creation date in the `DSS_VERSION` format.
 
-The `dss_api` field is the URL for 
 ## Subscriptions
 
 Event subscriptions are managed via the `/subscriptions` API endpoint, described in detail by the

--- a/daemons/dss-notify-v2/Readme.md
+++ b/daemons/dss-notify-v2/Readme.md
@@ -31,7 +31,7 @@ Bundle creation notifications have the format
 ```
 {
   'dss-api': dss_api
-  'bundle_url': {dss_api}"/bundles/{uuid}?version={version}
+  'bundle_url': {dss_api}"/v1/bundles/{uuid}?version={version}
   'transaction_id': {uuid},
   'subscription_id': {uuid},
   'event_type': "CREATE"|"TOMBSTONE"|"DELETE",

--- a/dss/events/handlers/notify_v2.py
+++ b/dss/events/handlers/notify_v2.py
@@ -96,7 +96,7 @@ def notify(subscription: dict, metadata_document: dict, key: str) -> bool:
         bundle_version = bundle_version[:-len(sfx)]
     api_domain_name = f'https://{os.environ.get("API_DOMAIN_NAME")}'
     payload = {
-        'bundle_url': api_domain_name+f'/bundles/{bundle_uuid}?version={bundle_version}',
+        'bundle_url': api_domain_name+f'/v1/bundles/{bundle_uuid}?version={bundle_version}',
         'dss_api': api_domain_name,
         'subscription_id': subscription[SubscriptionData.UUID],
         'event_timestamp': datetime_to_version_format(datetime.datetime.utcnow()),

--- a/dss/events/handlers/notify_v2.py
+++ b/dss/events/handlers/notify_v2.py
@@ -10,7 +10,6 @@ import datetime
 from uuid import uuid4
 from collections import defaultdict
 
-from flask import request
 from functools import lru_cache
 from concurrent.futures import ThreadPoolExecutor
 import jmespath
@@ -96,7 +95,7 @@ def notify(subscription: dict, metadata_document: dict, key: str) -> bool:
         bundle_version = bundle_version[:-len(sfx)]
     api_domain_name = f'https://{os.environ.get("API_DOMAIN_NAME")}'
     payload = {
-        'bundle_url': api_domain_name+f'/v1/bundles/{bundle_uuid}?version={bundle_version}',
+        'bundle_url': api_domain_name + f'/v1/bundles/{bundle_uuid}?version={bundle_version}',
         'dss_api': api_domain_name,
         'subscription_id': subscription[SubscriptionData.UUID],
         'event_timestamp': datetime_to_version_format(datetime.datetime.utcnow()),

--- a/dss/events/handlers/notify_v2.py
+++ b/dss/events/handlers/notify_v2.py
@@ -6,16 +6,18 @@ import urllib3
 import threading
 from requests_http_signature import HTTPSignatureAuth
 import logging
+import datetime
 from uuid import uuid4
 from collections import defaultdict
 
+from flask import request
 from functools import lru_cache
 from concurrent.futures import ThreadPoolExecutor
 import jmespath
 from jmespath.exceptions import JMESPathError
 from dcplib.aws.sqs import SQSMessenger, get_queue_url
 
-from dss import Config, Replica
+from dss import Config, Replica, datetime_to_version_format
 from dss.subscriptions_v2 import SubscriptionData
 from dss.storage.identifiers import UUID_PATTERN, VERSION_PATTERN, TOMBSTONE_SUFFIX, DSS_BUNDLE_KEY_REGEX
 
@@ -27,6 +29,7 @@ _attachment_size_limit = 128 * 1024
 _versioned_tombstone_key_regex = re.compile(f"^(bundles)/({UUID_PATTERN}).({VERSION_PATTERN}).{TOMBSTONE_SUFFIX}$")
 _unversioned_tombstone_key_regex = re.compile(f"^(bundles)/({UUID_PATTERN}).{TOMBSTONE_SUFFIX}$")
 _bundle_key_regex = DSS_BUNDLE_KEY_REGEX
+
 
 def should_notify(replica: Replica, subscription: dict, metadata_document: dict, key: str) -> bool:
     """
@@ -51,6 +54,7 @@ def should_notify(replica: Replica, subscription: dict, metadata_document: dict,
                 key
             ))
             return False
+
 
 def notify_or_queue(replica: Replica, subscription: dict, metadata_document: dict, key: str):
     """
@@ -80,6 +84,7 @@ def notify_or_queue(replica: Replica, subscription: dict, metadata_document: dic
             if not notify(subscription, metadata_document, bundle_key):
                 sqsm.send(_format_sqs_message(replica, subscription, "TOMBSTONE", bundle_key), delay_seconds=15 * 60)
 
+
 def notify(subscription: dict, metadata_document: dict, key: str) -> bool:
     """
     Attempt notification delivery. Return True for success, False for failure
@@ -89,15 +94,18 @@ def notify(subscription: dict, metadata_document: dict, key: str) -> bool:
     sfx = f".{TOMBSTONE_SUFFIX}"
     if bundle_version.endswith(sfx):
         bundle_version = bundle_version[:-len(sfx)]
-
+    api_domain_name = f'https://{os.environ.get("API_DOMAIN_NAME")}'
     payload = {
-        'transaction_id': str(uuid4()),
+        'bundle_url': api_domain_name+f'/bundles/{bundle_uuid}?version={bundle_version}',
+        'dss_api': api_domain_name,
         'subscription_id': subscription[SubscriptionData.UUID],
+        'event_timestamp': datetime_to_version_format(datetime.datetime.utcnow()),
         'event_type': metadata_document['event_type'],
         'match': {
             'bundle_uuid': bundle_uuid,
             'bundle_version': bundle_version,
-        }
+        },
+        'transaction_id': str(uuid4())
     }
 
     jmespath_query = subscription.get(SubscriptionData.JMESPATH_QUERY)

--- a/tests/test_notify_v2.py
+++ b/tests/test_notify_v2.py
@@ -482,7 +482,6 @@ class TestNotifyV2(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             'event_type': "CREATE",
         }
 
-
         with self.subTest("success"):
             sub = deepcopy(subscription)
             self.assertTrue(notify_v2.notify(sub, metadata_doc, bundle_key))

--- a/tests/test_notify_v2.py
+++ b/tests/test_notify_v2.py
@@ -463,7 +463,7 @@ class TestNotifyV2(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self._test_notify({'event_type': "DELETE"})
 
     def _test_notify(self, metadata_document):
-        api_name = f"https://os.getenv('API_DOMAIN_NAME')"
+        api_name = f"https://{os.getenv('API_DOMAIN_NAME')}"
         bundle_uuid, bundle_version = self._shared_bundle_once(Replica.aws)
         bundle_key = f"bundles/{bundle_uuid}.{bundle_version}"
         subscription = {

--- a/tests/test_notify_v2.py
+++ b/tests/test_notify_v2.py
@@ -463,6 +463,7 @@ class TestNotifyV2(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self._test_notify({'event_type': "DELETE"})
 
     def _test_notify(self, metadata_document):
+        api_name = f"https://os.getenv('API_DOMAIN_NAME')"
         bundle_uuid, bundle_version = self._shared_bundle_once(Replica.aws)
         bundle_key = f"bundles/{bundle_uuid}.{bundle_version}"
         subscription = {
@@ -480,6 +481,7 @@ class TestNotifyV2(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         metadata_doc = {
             'event_type': "CREATE",
         }
+
 
         with self.subTest("success"):
             sub = deepcopy(subscription)
@@ -531,6 +533,9 @@ class TestNotifyV2(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             self.assertEqual(recieved_notification['attachments']['my_attachment_1'], metadata_doc['foo'])
             self.assertEqual(recieved_notification['attachments']['my_attachment_2'], metadata_doc['bar'])
             self.assertEqual(recieved_notification['attachments']['my_attachment_3'], None)
+            self.assertEquals(api_name, recieved_notification['dss_api'])
+            self.assertIn('bundle_url', recieved_notification)
+            self.assertIn('event_timestamp', recieved_notification)
 
         with self.subTest("Test notification with no attachments"):
             sub = deepcopy(subscription)
@@ -539,6 +544,9 @@ class TestNotifyV2(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
             }
             self.assertTrue(notify_v2.notify(sub, metadata_doc, bundle_key))
             self.assertEqual(recieved_notification.get('attachments'), None)
+            self.assertEquals(api_name, recieved_notification['dss_api'])
+            self.assertIn('bundle_url', recieved_notification)
+            self.assertIn('event_timestamp', recieved_notification)
 
     def _put_subscription(self, doc, replica=Replica.aws, codes=requests.codes.created):
         url = str(UrlBuilder()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -21,7 +21,7 @@ import dss
 from tests.infra import testmode
 from dss.operations import DSSOperationsCommandDispatch
 from dss.operations.util import map_bucket_results
-from dss.operations import storage, sync
+from dss.operations import storage, sync, checkout
 from dss.logging import configure_test_logging
 from dss.config import BucketConfig, Config, Replica, override_bucket_config
 from dss.storage.hcablobstore import FileMetadata, compose_blob_key
@@ -266,6 +266,7 @@ class TestOperations(unittest.TestCase):
         gs_blob = gs_bucket.blob(key, chunk_size=1 * 1024 * 1024)
         with io.BytesIO(data) as fh:
             gs_blob.upload_from_file(fh, content_type="application/octet-stream")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -21,7 +21,7 @@ import dss
 from tests.infra import testmode
 from dss.operations import DSSOperationsCommandDispatch
 from dss.operations.util import map_bucket_results
-from dss.operations import storage, sync, checkout
+from dss.operations import storage, sync
 from dss.logging import configure_test_logging
 from dss.config import BucketConfig, Config, Replica, override_bucket_config
 from dss.storage.hcablobstore import FileMetadata, compose_blob_key
@@ -266,7 +266,6 @@ class TestOperations(unittest.TestCase):
         gs_blob = gs_bucket.blob(key, chunk_size=1 * 1024 * 1024)
         with io.BytesIO(data) as fh:
             gs_blob.upload_from_file(fh, content_type="application/octet-stream")
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Provides more context to a jmespath notification, adds:
``` 
"dss_api": api url
"bundle_url" : url to bundle matched.
"event_timestamp": timestamp for when event was created
```
Resolves: #2184 
