### PR TITLE
Skip retry-after headers on timeout responses.

### DIFF
--- a/chalice/app.py
+++ b/chalice/app.py
@@ -85,8 +85,7 @@ def timeout_response() -> chalice.Response:
         'traces': trace_dump
     }
 
-    headers = {"Content-Type": "application/problem+json",
-               'Retry-After': '10'}
+    headers = {"Content-Type": "application/problem+json"}  # add retry-after headers to timeouts
 
     return chalice.Response(status_code=problem['status'],
                             headers=headers,

--- a/tests/test_exptime.py
+++ b/tests/test_exptime.py
@@ -52,8 +52,6 @@ class TestExptime(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                 "DSS_FAKE_504_PROBABILITY": "1.0",
             }
         )
-        with self.subTest('Retry-After headers are included in a GET /v1/bundles/{uuid} 504 response.'):
-            self.assertEqual(int(r.response.headers['Retry-After']), 10)
 
 
 if __name__ == '__main__':

--- a/tests/test_exptime.py
+++ b/tests/test_exptime.py
@@ -41,7 +41,7 @@ class TestExptime(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
     @unittest.skipIf(DeploymentStage.IS_PROD(), "Skipping synthetic 504 test for PROD.")
     def test_synthetic_504(self):
         file_uuid = str(uuid.uuid4())
-        r = self.assertGetResponse(
+        self.assertGetResponse(
             f"/v1/files/{file_uuid}?replica=aws",
             requests.codes.gateway_timeout,
             expected_error=ExpectedErrorFields(

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -103,11 +103,11 @@ class TestRetryAfterHeaders(unittest.TestCase, DSSAssertMixin):
             r = mock_503_service_unavailable()
             self.assertEqual(int(r.headers['Retry-After']), 10)
 
-    def test_504_504_gateway_timeout(self):
+    def test_504_gateway_timeout(self):
         """Test that the dss_handler includes retry-after headers."""
         with app.test_request_context('/test'):
             r = mock_504_gateway_timeout()
-            self.assertEqual(int(r.headers['Retry-After']), 10)
+            self.assertEqual(r.headers.get('Retry-After'), None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
smoketest is failing: https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/data-store/-/jobs/38836

The error seems to be: https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/lambda/dss-dev;stream=2019/07/30/[$LATEST]645e77b78aa94df0ae631c7d4c371b2c;start=2019-07-29T04:16:09Z:
```
[ERROR] 2019-07-30T03:07:54.667Z 6a59c2b8-ae69-4a15-9e22-5619e9a3e781 Internal Error for <function get_chalice_app.<locals>.dispatch at 0x7f046f801bf8>
Traceback (most recent call last):
File "/var/task/app.py", line 138, in wrapper
chalice_response = future.result(timeout=time_remaining_s)
File "/var/lang/lib/python3.6/concurrent/futures/_base.py", line 434, in result
raise TimeoutError()
concurrent.futures._base.TimeoutError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/var/task/chalice/app.py", line 842, in _get_view_function_response
response = view_function(**function_args)
File "/var/task/app.py", line 141, in wrapper
return timeout_response(method=method, uri=None)
File "/var/task/app.py", line 100, in timeout_response
method, uri = request.method, request.path
File "/opt/python/lib/python3.6/site-packages/werkzeug/local.py", line 348, in __getattr__
return getattr(self._get_current_object(), name)
File "/opt/python/lib/python3.6/site-packages/werkzeug/local.py", line 307, in _get_current_object
return self.__local()
File "/opt/python/lib/python3.6/site-packages/flask/globals.py", line 37, in _lookup_req_object
raise RuntimeError(_request_ctx_err_msg)
RuntimeError: Working outside of request context.

This typically means that you attempted to use functionality that needed
an active HTTP request. Consult the documentation on testing for
information about how to avoid this problem.
```
Commenting out `tests/test_headers.py` will cause smoketest to pass locally.  This PR reverts just the case for timeout responses in the meantime.