### PR TITLE
Revert "1k item limit in PUT /collections (closes #2281)"

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1128,12 +1128,7 @@ paths:
           in: body
           required: true
           schema:
-            allOf:
-              - $ref: "#/definitions/Collection"
-              - type: object
-                properties:
-                  contents:
-                    maxItems: 1000
+            $ref: "#/definitions/Collection"
       responses:
         201:
           description: OK

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -446,15 +446,6 @@ class TestCollections(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                                params=dict(replica="aws"))
             self.assertEqual(res.status_code, requests.codes.not_found)
 
-    def test_put_excessive(self):
-        """Test trying to PUT a collection with more than 1k items"""
-        contents = [self.s3_col_ptr_item] * 1001  # the limit is 1000
-        res = self.app.put('/v1/collections',
-                           headers=get_auth_header(authorized=True),
-                           params=dict(version=self.version, replica='aws', uuid=uuid4()),
-                           json=dict(name="n", description="d", details={}, contents=contents))
-        self.assertEqual(res.status_code, requests.codes.bad_request)
-
     def _put(self, contents: typing.List,
              authorized: bool = True,
              uuid: typing.Optional[str] = None,


### PR DESCRIPTION
Reverts HumanCellAtlas/data-store#2317.
* Reverts changes to dss-api.yml due to changes being formatted in Swagger 3.0 spec, vs 2.0 (current)
* Reverts breakage in dcp-cli due to Client Method Factory not being able to parse mixed versions

Schema is OpenAPI v2, not v3.