### PR TITLE
Add secrets management to dss-ops script

### DIFF
--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -1,0 +1,103 @@
+"""
+Get/set secret variable values from the AWS Secrets Manager
+"""
+import os
+import sys
+import click
+import boto3
+import select
+import typing
+import argparse
+import json
+import logging
+import subprocess
+
+from dss.operations import dispatch
+
+
+logger = logging.getLogger(__name__)
+
+
+events = dispatch.target("secrets",
+                         help=__doc__)
+
+
+@events.action("list-secrets")
+def list_secrets(argv: typing.List[str], args: argparse.Namespace):
+    """Print a list of all secrets"""
+    pass
+
+@events.action("get-secret",
+               arguments={
+                   "--secret-name": dict(
+                       required=True,
+                       nargs="*",
+                       help="name of secret to retrieve")})
+def get_secret(argv: typing.List[str], args: argparse.Namespace):
+    """Get the value of the secret variable specified by the --secret-name flag"""
+    SM = boto3.client('secretsmanager')
+    stage = os.environ['DSS_DEPLOYMENT_STAGE']
+    secrets_store = os.environ['DSS_SECRETS_STORE']
+    secret_id = f'{secrets_store}/{stage}/{args.secret_name}'
+
+    try:
+        # Start by trying to get the secret variable
+        secret_val = SM.get_secret_value(SecretId=secret_id)
+
+    except SM.exceptions.ResourceNotFoundException:
+        # The secret variable does not exist
+        print("Resource Not Found: {}".format(secret_id))
+
+    else:
+        # Get operation was successful, secret variable exists
+        print('Resource Found: {} = {}'.format(secret_id, secret_val))
+
+@events.action("set-secret",
+               arguments={
+                   "--secret-name": dict(required=True,
+                                         nargs="*",
+                                         help="name of secret to retrieve"),
+                   "--dry-run": dict(help="do a dry run of the actual operation")})
+def set_secret(argv: typing.List[str], args: argparse.Namespace):
+    """Set the value of the secret variable specified by the --secret-name flag"""
+    SM = boto3.client('secretsmanager')
+    stage = os.environ['DSS_DEPLOYMENT_STAGE']
+    secrets_store = os.environ['DSS_SECRETS_STORE']
+    secret_id = f'{secrets_store}/{stage}/{args.secret_name}'
+
+    # Use the `select` module to obtain the value that is passed
+    # to this script via stdin (i.e., piped to this script).
+    # Note: user provides secret variable *value* via stdin,
+    # user provides secret variable *name* via --secret-name flag.
+    if not select.select([sys.stdin, ], [], [], 0.0)[0]:
+        print(f"No data in stdin, exiting without setting {secret_id}")
+        sys.exit()
+    val = sys.stdin.read()
+
+    print("Setting", secret_id)
+
+    try:
+        # Start by trying to get the secret variable
+        _ = SM.get_secret_value(SecretId=secret_id)
+
+    except SM.exceptions.ResourceNotFoundException:
+        # The secret variable does not exist, so create it
+        if args.dry_run:
+            # Create it for fakes
+            print("Resource Not Found: Creating {}".format(secret_id))
+        else:
+            # Create it for real
+            _ = SM.create_secret(
+                Name=secret_id,
+                SecretString=val
+            )
+
+    else:
+        # Get operation was successful, secret variable exists
+        if args.dry_run:
+            print('Resource Found: Updating {}'.format(secret_id))
+        else:
+            _ = SM.update_secret(
+                SecretId=secret_id,
+                SecretString=val
+            )

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -10,7 +10,7 @@ import json
 import logging
 
 from dss.operations import dispatch
-from dss.util.aws import ARN as arn
+from dss.util.aws import ARN as arn  # type: ignore
 from dss.util.aws.clients import secretsmanager  # type: ignore
 
 logger = logging.getLogger(__name__)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -100,19 +100,20 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 def get_secret(argv: typing.List[str], args: argparse.Namespace):
     """
     Get the value of the secret variable (or list of variables) specified by
-    the --secret-name flag
+    the --secret-name flag; separate multiple secret names using a space.
     """
     # Note: this function should not print anything except the final JSON,
     # in case the user pipes the JSON output of this script to something else
 
     store_prefix = get_secretsmanager_prefix(args)
 
-    # Make sure a secret name was specified
-    if args.secret_name is None:
+    # Make sure something was specified for secret name(s)
+    if len(args.secret_name) == 0:
         raise RuntimeError(
             "Unable to set secret: no secret name was specified! Use the --secret-name flag."
         )
-    secret_names = args.secret_name.split(" ")
+    else:
+        secret_names = args.secret_name
 
     # Tack on the store prefix if it isn't there already
     for i in range(len(secret_names)):

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -42,7 +42,6 @@ def get_secretsmanager_prefixes(args):
 
     return arn_prefix, store_prefix
 
-
 def long_short_resource_names(secret_name, arn_prefix, store_prefix):
     """
     Given a (user-provided) name of a secret variable,

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -39,7 +39,7 @@ events = dispatch.target("secrets", arguments={}, help=__doc__)
             default=False,
             action="store_true",
             help="format the output as JSON if this flag is present",
-        ),
+        )
     },
 )
 def list_secrets(argv: typing.List[str], args: argparse.Namespace):
@@ -184,7 +184,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
     # Create or update
     try:
         # Start by trying to get the secret variable
-        _ = secretsmanager.get_secret_value(SecretId=secret_name)
+        secretsmanager.get_secret_value(SecretId=secret_name)
 
     except ClientError:
         # A secret variable with that name does not exist, so create it
@@ -199,7 +199,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
             print(
                 f"Secret variable {secret_name} not found in secrets manager, creating it"
             )
-            _ = secretsmanager.create_secret(Name=secret_name, SecretString=secret_val)
+            secretsmanager.create_secret(Name=secret_name, SecretString=secret_val)
 
     else:
         # Get operation was successful, secret variable exists
@@ -213,9 +213,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
             print(
                 f"Secret variable {secret_name} found in secrets manager, updating it"
             )
-            _ = secretsmanager.update_secret(
-                SecretId=secret_name, SecretString=secret_val
-            )
+            secretsmanager.update_secret(SecretId=secret_name, SecretString=secret_val)
 
 
 @events.action(
@@ -265,7 +263,7 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
 
     try:
         # Start by trying to get the secret variable
-        _ = secretsmanager.get_secret_value(SecretId=secret_name)
+        secretsmanager.get_secret_value(SecretId=secret_name)
 
     except ClientError:
         # No secret var found
@@ -289,4 +287,4 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
             print(
                 f"Secret variable {secret_name} found in secrets manager, deleting it"
             )
-            _ = secretsmanager.delete_secret(SecretId=secret_name)
+            secretsmanager.delete_secret(SecretId=secret_name)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -10,132 +10,316 @@ import typing
 import argparse
 import json
 import logging
-import subprocess
+from pprint import pprint
 
 from dss.operations import dispatch
+from dss.util.aws import ARN as arn
+from dss.util.aws.clients import secretsmanager # note: ssm = param store, not secrets manager
 
 
 logger = logging.getLogger(__name__)
 
 
+def get_long_name(secret_name, arn_prefix, store_prefix):
+    """
+    Given a (user-provided) name of a secret variable, 
+    determine whether the ARN prefix and store/stage 
+    prefix must be added to that variable to get its
+    long name.
+
+    Users can specify variable names in any of the 
+    following forms, and this function will return
+    the full ARN resource name:
+
+    - es_source_ip-q2baD1 (no store/stage prefix present)
+    - dcp/dss/dev/es_source_ip-q2baD1 (no ARN prefix present)
+    - arn:aws:secretsmanager:us-east-1:861229788715:secret:dcp/dss/dev/es_source_ip-q2baD1 (target output; store/stage prefix and ARN prefix present)
+    """
+    # Figure out what kind of prefix the user provided
+    # with the provided list of list
+    user_provided_arn = secret_name.startswith(arn_prefix)
+    user_provided_store = secret_name.startswith(store_prefix)
+
+    # Add any prefix that is needed, get the full ARN
+    if user_provided_arn:
+        full_secret_name = secret_name
+    elif user_provided_store:
+        full_secret_name = arn_prefix + secret_name
+    else:
+        full_secret_name = arn_prefix + store_prefix + secret_name
+
+    return full_secret_name
+
+
+def get_short_name(secret_name, arn_prefix, store_prefix):
+    """
+    Given a (user-provided) name of a secret variable, 
+    determine whether the ARN prefix and store/stage 
+    prefix must be removed from that variable to get
+    its short name.
+
+    Users can specify variable names in any of the 
+    following forms, and this function will return
+    the store/stage prefixed resource name only:
+
+    - es_source_ip-q2baD1 (no store/stage prefix present)
+    - dcp/dss/dev/es_source_ip-q2baD1 (target output)
+    - arn:aws:secretsmanager:us-east-1:861229788715:secret:dcp/dss/dev/es_source_ip-q2baD1 (ARN prefix present)
+    """
+    # Figure out what kind of prefix the user provided
+    # with the provided list of list
+    user_provided_arn = secret_name.startswith(arn_prefix)
+    user_provided_store = secret_name.startswith(store_prefix)
+
+    # Remove any prefix that is needed, get the store/stage prefixed name
+    if user_provided_arn:
+        short_secret_name = secret_name[len(arn_prefix):]
+    elif user_provided_store:
+        short_secret_name = secret_name
+    else:
+        short_secret_name = store_prefix + secret_name
+
+    return short_secret_name
+
+
 events = dispatch.target("secrets",
+                         arguments={},
                          help=__doc__)
 
-
-def get_secret_names(sm_client):
-    """
-    This retrieves a list of names of all secret variables 
-    in the secret manager
-    """
-    # Also see boto docs:
-    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html#SSM.Client.describe_parameters
-    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html#SSM.Paginator.DescribeParameters
-    secret_names = []
-
-    # Create a paginator from the describe_parameters endpoint
-    # and use it to get the name of each parameter
-    paginator = sm.get_paginator('describe_parameters')
-    for response in paginator.paginate():
-        while response['NextToken'] != '':
-            for param in response['Parameters']:
-                secret_names.append(param['Name'])
-
-    return secret_names
-
-@events.action("name-secrets")
-def name_secrets(argv: typing.List[str], args: argparse.Namespace):
-    """Print the names of all secret variables"""
-    sm = boto3.client('ssm')
-
-    # Print the name of each secret
-    names = get_secret_names(sm)
-    for secret_name in secret_names:
-        print("{}".format(secret_name))
-
-@events.action("list-secrets")
-def list_secrets(argv: typing.List[str], args: argparse.Namespace):
-    """Print a list of all secrets"""
-    sm = boto3.client('ssm')
-
-    # Get the name of each secret
-    secret_names = get_secret_names(sm)
-
-    # Use the name of each secret to retrieve/print its value
-    for secret_name in secret_names:
-        response = sm.get_parameter(Name=secret_name)
-        print("{} = {}".format(response['Parameter']['Name'], response['Parameter']['Value']))
-
-@events.action("get-secret",
+@events.action("list",
                arguments={
+                   "--stage": dict(
+                       required=False,
+                       help="the stage for which secrets should be listed"),
+                   "--long": dict(
+                       default=False,
+                       action="store_true",
+                       help="use long identifiers (incl. ARN, region, project ID) for resources"),
+                   "--json": dict(
+                       default=False,
+                       action="store_true",
+                       help="format the output as JSON if this flag is present")})
+def list_secrets(argv: typing.List[str], args: argparse.Namespace):
+    """
+    Print a list of names of every secret variable in the secrets manager
+    for the given store and stage
+    """
+    store_name = os.environ['DSS_SECRETS_STORE']
+    if args.stage is None:
+        stage_name = os.environ['DSS_DEPLOYMENT_STAGE']
+
+    paginator = secretsmanager.get_paginator('list_secrets')
+
+    prefix = f'{store_name}/{stage_name}/'
+    secret_names = []
+    for response in paginator.paginate():
+        for secret in response['SecretList']:
+
+            long_name = secret['ARN']
+            short_name = long_name.split(":")[-1]
+            if short_name.startswith(prefix):
+                # If the prefix matches the store and stage specified, 
+                # store this secret's name for later
+                if args.long:
+                    secret_names.append(long_name)
+                else:
+                    secret_names.append(short_name)
+
+    secret_names.sort()
+
+    if args.json:
+        print(json.dumps(secret_names))
+    else:
+        for secret_name in secret_names:
+            print(secret_name)
+
+
+@events.action("get",
+               arguments={
+                   "--stage": dict(
+                       required=False,
+                       help="the stage for which secrets should be listed"),
                    "--secret-name": dict(
                        required=True,
                        nargs="*",
-                       help="name of secret to retrieve")})
+                       help="name of secret or secrets to retrieve (list values can be separated by a space)"),
+                   "--json": dict(
+                       default=False,
+                       action="store_true",
+                       help="format the output as JSON if this flag is present")})
 def get_secret(argv: typing.List[str], args: argparse.Namespace):
-    """Get the value of the secret variable specified by the --secret-name flag"""
-    sm = boto3.client('secretsmanager')
-    stage = os.environ['DSS_DEPLOYMENT_STAGE']
-    secrets_store = os.environ['DSS_SECRETS_STORE']
-    secret_id = f'{secrets_store}/{stage}/{args.secret_name}'
+    """
+    Get the value of the secret variable (or list of variables) specified by
+    the --secret-name flag
+    """
+    # Note: this function should not print anything except the final JSON,
+    # in case the user pipes the JSON output of this script to something else
+    store_name = os.environ['DSS_SECRETS_STORE']
+    if args.stage is None:
+        stage_name = os.environ['DSS_DEPLOYMENT_STAGE']
 
-    try:
-        # Start by trying to get the secret variable
-        secret_val = sm.get_secret_value(SecretId=secret_id)
+    if args.secret_name is None or len(args.secret_name)==0:
+        logger.error("Unable to get secret: no secret was specified! Use the --secret-name flag.")
+        sys.exit()
 
-    except sm.exceptions.ResourceNotFoundException:
-        # The secret variable does not exist
-        print("Resource Not Found: {}".format(secret_id))
+    # Necessary because AWS requires full resource identifiers to fetch secrets
+    region_name = arn.get_region()
+    account_id = arn.get_account_id()
+    arn_prefix = f'arn:aws:secretsmanager:{region_name}:{account_id}:secret:'
+    store_prefix = f'{store_name}/{stage_name}/'
 
-    else:
-        # Get operation was successful, secret variable exists
-        print('Resource Found: {} = {}'.format(secret_id, secret_val))
+    for secret_name in args.secret_name:
+        full_secret_name = get_long_name(secret_name, arn_prefix, store_prefix)
+        short_secret_name = get_short_name(full_secret_name, arn_prefix, store_prefix)
 
-@events.action("set-secret",
+        try:
+            response = secretsmanager.get_secret_value(SecretId=full_secret_name)
+            secret_val = response['SecretString']
+        except secretsmanager.exceptions.ResourceNotFoundException:
+            # A secret variable with that name does not exist
+            logger.warning("Resource not found: {}".format(full_secret_name))
+        else:
+            if args.json:
+                print(json.dumps({full_secret_name: secret_val}))
+            else:
+                # Get operation was successful, secret variable exists
+                print("{}={}".format(short_secret_name, secret_val))
+
+
+@events.action("set",
                arguments={
-                   "--secret-name": dict(required=True,
-                                         nargs="*",
-                                         help="name of secret to retrieve"),
-                   "--dry-run": dict(help="do a dry run of the actual operation")})
+                   "--stage": dict(
+                       required=False,
+                       help="the stage for which secrets should be set"),
+                   "--secret-name": dict(
+                       required=True,
+                       help="name of secret to set (limit 1 at a time)"),
+                   "--dry-run": dict(
+                       default=False,
+                       action="store_true",
+                       help="do a dry run of the actual operation")})
 def set_secret(argv: typing.List[str], args: argparse.Namespace):
     """Set the value of the secret variable specified by the --secret-name flag"""
-    sm = boto3.client('secretsmanager')
-    stage = os.environ['DSS_DEPLOYMENT_STAGE']
-    secrets_store = os.environ['DSS_SECRETS_STORE']
-    secret_id = f'{secrets_store}/{stage}/{args.secret_name}'
+    store_name = os.environ['DSS_SECRETS_STORE']
+    if args.stage is None:
+        stage_name = os.environ['DSS_DEPLOYMENT_STAGE']
+
+    # Make sure a secret name was specified
+    if args.secret_name is None or len(args.secret_name)==0:
+        logger.error("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
+        sys.exit()
+    secret_name = args.secret_name
 
     # Use the `select` module to obtain the value that is passed
     # to this script via stdin (i.e., piped to this script).
     # Note: user provides secret variable *value* via stdin,
     # user provides secret variable *name* via --secret-name flag.
     if not select.select([sys.stdin, ], [], [], 0.0)[0]:
-        print(f"No data in stdin, exiting without setting {secret_id}")
+        err_msg = f"No data in stdin, cannot set secret {secret_name} without a value from stdin!"
+        logger.error()
         sys.exit()
-    val = sys.stdin.read()
+    secret_val = sys.stdin.read()
 
-    print("Setting", secret_id)
+    # Necessary because AWS requires full resource identifiers to fetch secrets
+    region_name = arn.get_region()
+    account_id = arn.get_account_id()
+    arn_prefix = f'arn:aws:secretsmanager:{region_name}:{account_id}:secret:'
+    store_prefix = f'{store_name}/{stage_name}/'
+
+    full_secret_name = get_long_name(secret_name, arn_prefix, store_prefix)
+    short_secret_name = get_short_name(full_secret_name, arn_prefix, store_prefix)
 
     try:
         # Start by trying to get the secret variable
-        _ = sm.get_secret_value(SecretId=secret_id)
+        _ = secretsmanager.get_secret_value(SecretId=full_secret_name)
 
-    except sm.exceptions.ResourceNotFoundException:
-        # The secret variable does not exist, so create it
+    except secretsmanager.exceptions.ResourceNotFoundException:
+        # A secret variable with that name does not exist, so create it
         if args.dry_run:
             # Create it for fakes
-            print("Resource Not Found: Creating {}".format(secret_id))
+            print("Secret variable {} not found in secrets manager, dry-run creating it".format(short_secret_name))
         else:
             # Create it for real
-            _ = sm.create_secret(
-                Name=secret_id,
-                SecretString=val
+            print("Secret variable {} not found in secrets manager, creating it".format(short_secret_name))
+            _ = secretsmanager.create_secret(
+                    Name=short_secret_name,
+                    SecretString=secret_val
             )
+    else:
+        # Get operation was successful, secret variable exists
+        if args.dry_run:
+            # Update it for fakes
+            print("Secret variable {} found in secrets manager, dry-run updating it".format(short_secret_name))
+        else:
+            # Update it for real
+            print("Secret variable {} found in secrets manager, updating it".format(short_secret_name))
+            _ = secretsmanager.update_secret(
+                    SecretId=short_secret_name,
+                    SecretString=secret_val
+            )
+
+
+@events.action("delete",
+               arguments={
+                   "--stage": dict(
+                       required=False,
+                       help="the stage for which secrets should be deleted"),
+                   "--secret-name": dict(
+                       required=True,
+                       help="name of secret to delete (limit 1 at a time)"),
+                   "--dry-run": dict(
+                       default=False,
+                       action="store_true",
+                       help="do a dry run of the actual operation")})
+def del_secret(argv: typing.List[str], args: argparse.Namespace):
+    """
+    Delete the value of the secret variable specified by the 
+    --secret-name flag from the secrets manager
+    """
+    store_name = os.environ['DSS_SECRETS_STORE']
+    if args.stage is None:
+        stage_name = os.environ['DSS_DEPLOYMENT_STAGE']
+
+    # Make sure a secret name was specified
+    if args.secret_name is None or len(args.secret_name)==0:
+        logger.error("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
+        sys.exit()
+    secret_name = args.secret_name
+
+    # Necessary because AWS requires full resource identifiers to delete secrets
+    region_name = arn.get_region()
+    account_id = arn.get_account_id()
+    arn_prefix = f'arn:aws:secretsmanager:{region_name}:{account_id}:secret:'
+    store_prefix = f'{store_name}/{stage_name}/'
+
+    full_secret_name = get_long_name(secret_name, arn_prefix, store_prefix)
+    short_secret_name = get_short_name(full_secret_name, arn_prefix, store_prefix)
+
+    # Make sure the user really wants to do this
+    response = input("Are you really sure you want to delete secret {}? (Type 'y' or 'yes' to confirm): ".format(secret_name))
+    if response.lower() not in ['y','yes']:
+        logger.error("You safely aborted the delete secret operation!")
+        sys.exit()
+
+    try:
+        # Start by trying to get the secret variable
+        _ = secretsmanager.get_secret_value(SecretId=full_secret_name)
+
+    except secretsmanager.exceptions.ResourceNotFoundException:
+        # No secret var found
+        logger.warning("Secret variable {} not found in secrets manager!".format(short_secret_name))
+
+    except secretsmanager.exceptions.InvalidRequestException:
+        # Already deleted secret var
+        logger.warning("Secret variable {} already marked for deletion in secrets manager!".format(short_secret_name))
 
     else:
         # Get operation was successful, secret variable exists
         if args.dry_run:
-            print('Resource Found: Updating {}'.format(secret_id))
+            # Delete it for fakes
+            print("Secret variable {} found in secrets manager, dry-run deleting it".format(short_secret_name))
         else:
-            _ = sm.update_secret(
-                SecretId=secret_id,
-                SecretString=val
-            )
+            # Delete it for real
+            print("Secret variable {} found in secrets manager, deleting it".format(short_secret_name))
+            _ = secretsmanager.delete_secret(SecretId=full_secret_name)
+

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -13,7 +13,7 @@ import logging
 
 from dss.operations import dispatch
 from dss.util.aws import ARN as arn
-from dss.util.aws.clients import secretsmanager
+from dss.util.aws.clients import secretsmanager # type: ignore
 
 
 logger = logging.getLogger(__name__)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -74,10 +74,10 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 @events.action(
     "get",
     arguments={
-        "--secret-name": dict(
+        "--secret-names": dict(
             required=True,
             nargs="*",
-            help="name of secret or secrets to retrieve (list values can be separated by a space)",
+            help="names of secrets to retrieve (separate multiple values with spaces)",
         ),
         "--json": dict(
             default=False,
@@ -89,7 +89,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 def get_secret(argv: typing.List[str], args: argparse.Namespace):
     """
     Get the value of the secret variable (or list of variables) specified by
-    the --secret-name flag; separate multiple secret names using a space.
+    the --secret-names flag; separate multiple secret names using a space.
     """
     # Note: this function should not print anything except the final JSON,
     # in case the user pipes the JSON output of this script to something else
@@ -97,12 +97,12 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
     store_prefix = get_secretsmanager_prefix(args)
 
     # Make sure something was specified for secret name(s)
-    if len(args.secret_name) == 0:
+    if len(args.secret_names) == 0:
         raise RuntimeError(
-            "Unable to set secret: no secret name was specified! Use the --secret-name flag."
+            "Unable to set secret: no secret name was specified! Use the --secret-names flag."
         )
     else:
-        secret_names = args.secret_name
+        secret_names = args.secret_names
 
     # Tack on the store prefix if it isn't there already
     for i in range(len(secret_names)):

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -24,12 +24,7 @@ def get_secretsmanager_prefix(args):
     the SecretsManager.
     """
     store_name = os.environ["DSS_SECRETS_STORE"]
-
-    if hasattr(args, "stage") and args.stage is not None:
-        stage_name = args.stage
-    else:
-        stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
-
+    stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
     store_prefix = f"{store_name}/{stage_name}/"
     return store_prefix
 
@@ -40,9 +35,6 @@ events = dispatch.target("secrets", arguments={}, help=__doc__)
 @events.action(
     "list",
     arguments={
-        "--stage": dict(
-            required=False, help="the stage for which secrets should be listed"
-        ),
         "--json": dict(
             default=False,
             action="store_true",
@@ -82,9 +74,6 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 @events.action(
     "get",
     arguments={
-        "--stage": dict(
-            required=False, help="the stage for which secrets should be listed"
-        ),
         "--secret-name": dict(
             required=True,
             nargs="*",
@@ -146,9 +135,6 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
 @events.action(
     "set",
     arguments={
-        "--stage": dict(
-            required=False, help="the stage for which secrets should be set"
-        ),
         "--secret-name": dict(
             required=True, help="name of secret to set (limit 1 at a time)"
         ),
@@ -241,9 +227,6 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
 @events.action(
     "delete",
     arguments={
-        "--stage": dict(
-            required=False, help="the stage for which secrets should be deleted"
-        ),
         "--secret-name": dict(
             required=True, help="name of secret to delete (limit 1 at a time)"
         ),

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -156,8 +156,7 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
 
     # Make sure a secret name was specified
     if args.secret_name is None or len(args.secret_name) == 0:
-        logger.error("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
-        sys.exit()
+        raise RuntimeError("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
     secret_names = args.secret_name
 
     for secret_name in secret_names:
@@ -208,16 +207,14 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
 
     # Make sure a secret name was specified
     if args.secret_name is None or len(args.secret_name) == 0:
-        logger.error("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
-        sys.exit()
+        raise RuntimeError("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
     secret_name = args.secret_name
 
     # Use stdin (input piped to this script) as secret value.
     # stdin provides secret value, flag --secret-name provides secret name.
     if not select.select([sys.stdin, ], [], [], 0.0)[0]:
         err_msg = f"No data in stdin, cannot set secret {secret_name} without a value from stdin!"
-        logger.error(err_msg)
-        sys.exit()
+        raise RuntimeError(err_msg)
     secret_val = sys.stdin.read()
 
     # Get resouce IDs
@@ -273,8 +270,7 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
 
     # Make sure a secret name was specified
     if args.secret_name is None or len(args.secret_name) == 0:
-        logger.error("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
-        sys.exit()
+        raise RuntimeError("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
     secret_name = args.secret_name
 
     # Get resouce IDs
@@ -286,8 +282,7 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
     """
     response = input(confirm)
     if response.lower() not in ['y', 'yes']:
-        logger.error("You safely aborted the delete secret operation!")
-        sys.exit()
+        raise RuntimeError("You safely aborted the delete secret operation!")
 
     try:
         # Start by trying to get the secret variable

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 def get_secretsmanager_prefix(args):
     """
-    Use information from the environment to assemble 
+    Use information from the environment to assemble
     the necessary prefix for accessing variables in
     the SecretsManager.
     """

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -35,16 +35,16 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
                        help="name of secret to retrieve")})
 def get_secret(argv: typing.List[str], args: argparse.Namespace):
     """Get the value of the secret variable specified by the --secret-name flag"""
-    SM = boto3.client('secretsmanager')
+    sm = boto3.client('secretsmanager')
     stage = os.environ['DSS_DEPLOYMENT_STAGE']
     secrets_store = os.environ['DSS_SECRETS_STORE']
     secret_id = f'{secrets_store}/{stage}/{args.secret_name}'
 
     try:
         # Start by trying to get the secret variable
-        secret_val = SM.get_secret_value(SecretId=secret_id)
+        secret_val = sm.get_secret_value(SecretId=secret_id)
 
-    except SM.exceptions.ResourceNotFoundException:
+    except sm.exceptions.ResourceNotFoundException:
         # The secret variable does not exist
         print("Resource Not Found: {}".format(secret_id))
 
@@ -60,7 +60,7 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
                    "--dry-run": dict(help="do a dry run of the actual operation")})
 def set_secret(argv: typing.List[str], args: argparse.Namespace):
     """Set the value of the secret variable specified by the --secret-name flag"""
-    SM = boto3.client('secretsmanager')
+    sm = boto3.client('secretsmanager')
     stage = os.environ['DSS_DEPLOYMENT_STAGE']
     secrets_store = os.environ['DSS_SECRETS_STORE']
     secret_id = f'{secrets_store}/{stage}/{args.secret_name}'
@@ -78,16 +78,16 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
 
     try:
         # Start by trying to get the secret variable
-        _ = SM.get_secret_value(SecretId=secret_id)
+        _ = sm.get_secret_value(SecretId=secret_id)
 
-    except SM.exceptions.ResourceNotFoundException:
+    except sm.exceptions.ResourceNotFoundException:
         # The secret variable does not exist, so create it
         if args.dry_run:
             # Create it for fakes
             print("Resource Not Found: Creating {}".format(secret_id))
         else:
             # Create it for real
-            _ = SM.create_secret(
+            _ = sm.create_secret(
                 Name=secret_id,
                 SecretString=val
             )
@@ -97,7 +97,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
         if args.dry_run:
             print('Resource Found: Updating {}'.format(secret_id))
         else:
-            _ = SM.update_secret(
+            _ = sm.update_secret(
                 SecretId=secret_id,
                 SecretString=val
             )

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -48,7 +48,7 @@ events = dispatch.target("secrets", arguments={}, help=__doc__)
 def list_secrets(argv: typing.List[str], args: argparse.Namespace):
     """
     Print a list of names of every secret variable in the secrets manager
-    for the given store and stage
+    for the given store and stage.
     """
     store_prefix = get_secretsmanager_prefix(args)
 

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -3,8 +3,6 @@ Get/set secret variable values from the AWS Secrets Manager
 """
 import os
 import sys
-import click
-import boto3
 import select
 import typing
 import argparse
@@ -13,7 +11,7 @@ import logging
 
 from dss.operations import dispatch
 from dss.util.aws import ARN as arn
-from dss.util.aws.clients import secretsmanager # type: ignore
+from dss.util.aws.clients import secretsmanager  # type: ignore
 
 
 logger = logging.getLogger(__name__)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -10,7 +10,6 @@ import json
 import logging
 
 from dss.operations import dispatch
-from dss.util.aws import ARN as arn  # type: ignore
 from dss.util.aws.clients import secretsmanager  # type: ignore
 
 logger = logging.getLogger(__name__)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -37,7 +37,6 @@ def get_long_name(secret_name, arn_prefix, store_prefix):
       and ARN prefix present)
     """
     # Figure out what kind of prefix the user provided
-    # with the provided list of list
     user_provided_arn = secret_name.startswith(arn_prefix)
     user_provided_store = secret_name.startswith(store_prefix)
 
@@ -72,7 +71,8 @@ def get_short_name(secret_name, arn_prefix, store_prefix):
     user_provided_arn = secret_name.startswith(arn_prefix)
     user_provided_store = secret_name.startswith(store_prefix)
 
-    # Remove any prefix that is needed, get the store/stage prefixed name
+    # Remove any prefix that is present,
+    # then add the store/stage prefixed name
     if user_provided_arn:
         short_secret_name = secret_name[len(arn_prefix):]
     elif user_provided_store:
@@ -111,7 +111,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 
     paginator = secretsmanager.get_paginator('list_secrets')
 
-    prefix = f'{store_name}/{stage_name}/'
+    prefix = f"{store_name}/{stage_name}/"
     secret_names = []
     for response in paginator.paginate():
         for secret in response['SecretList']:
@@ -170,8 +170,8 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
     # Necessary because AWS requires full resource identifiers to fetch secrets
     region_name = arn.get_region()
     account_id = arn.get_account_id()
-    arn_prefix = f'arn:aws:secretsmanager:{region_name}:{account_id}:secret:'
-    store_prefix = f'{store_name}/{stage_name}/'
+    arn_prefix = f"arn:aws:secretsmanager:{region_name}:{account_id}:secret:"
+    store_prefix = f"{store_name}/{stage_name}/"
 
     for secret_name in args.secret_name:
         full_secret_name = get_long_name(secret_name, arn_prefix, store_prefix)
@@ -237,8 +237,8 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
     # Necessary because AWS requires full resource identifiers to fetch secrets
     region_name = arn.get_region()
     account_id = arn.get_account_id()
-    arn_prefix = f'arn:aws:secretsmanager:{region_name}:{account_id}:secret:'
-    store_prefix = f'{store_name}/{stage_name}/'
+    arn_prefix = f"arn:aws:secretsmanager:{region_name}:{account_id}:secret:"
+    store_prefix = f"{store_name}/{stage_name}/"
 
     full_secret_name = get_long_name(secret_name, arn_prefix, store_prefix)
     short_secret_name = get_short_name(full_secret_name, arn_prefix, store_prefix)
@@ -251,10 +251,10 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
         # A secret variable with that name does not exist, so create it
         if args.dry_run:
             # Create it for fakes
-            print("Secret variable {} not found in secrets manager, dry-run creating it".format(short_secret_name))
+            print(f"Secret variable {short_secret_name} not found in secrets manager, dry-run creating it")
         else:
             # Create it for real
-            print("Secret variable {} not found in secrets manager, creating it".format(short_secret_name))
+            print(f"Secret variable {short_secret_name} not found in secrets manager, creating it")
             _ = secretsmanager.create_secret(
                 Name=short_secret_name, SecretString=secret_val
             )
@@ -262,10 +262,10 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
         # Get operation was successful, secret variable exists
         if args.dry_run:
             # Update it for fakes
-            print("Secret variable {} found in secrets manager, dry-run updating it".format(short_secret_name))
+            print(f"Secret variable {short_secret_name} found in secrets manager, dry-run updating it")
         else:
             # Update it for real
-            print("Secret variable {} found in secrets manager, updating it".format(short_secret_name))
+            print(f"Secret variable {short_secret_name} found in secrets manager, updating it")
             _ = secretsmanager.update_secret(
                 SecretId=short_secret_name, SecretString=secret_val
             )
@@ -301,8 +301,8 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
     # Necessary because AWS requires full resource identifiers to delete secrets
     region_name = arn.get_region()
     account_id = arn.get_account_id()
-    arn_prefix = f'arn:aws:secretsmanager:{region_name}:{account_id}:secret:'
-    store_prefix = f'{store_name}/{stage_name}/'
+    arn_prefix = f"arn:aws:secretsmanager:{region_name}:{account_id}:secret:"
+    store_prefix = f"{store_name}/{stage_name}/"
 
     full_secret_name = get_long_name(secret_name, arn_prefix, store_prefix)
     short_secret_name = get_short_name(full_secret_name, arn_prefix, store_prefix)
@@ -322,18 +322,18 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
 
     except secretsmanager.exceptions.ResourceNotFoundException:
         # No secret var found
-        logger.warning("Secret variable {} not found in secrets manager!".format(short_secret_name))
+        logger.warning(f"Secret variable {short_secret_name} not found in secrets manager!")
 
     except secretsmanager.exceptions.InvalidRequestException:
         # Already deleted secret var
-        logger.warning("Secret variable {} already marked for deletion in secrets manager!".format(short_secret_name))
+        logger.warning(f"Secret variable {short_secret_name} already marked for deletion in secrets manager!")
 
     else:
         # Get operation was successful, secret variable exists
         if args.dry_run:
             # Delete it for fakes
-            print("Secret variable {} found in secrets manager, dry-run deleting it".format(short_secret_name))
+            print("Secret variable {short_secret_name} found in secrets manager, dry-run deleting it")
         else:
             # Delete it for real
-            print("Secret variable {} found in secrets manager, deleting it".format(short_secret_name))
+            print("Secret variable {short_secret_name} found in secrets manager, deleting it")
             _ = secretsmanager.delete_secret(SecretId=full_secret_name)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -17,63 +17,18 @@ from dss.util.aws.clients import secretsmanager  # type: ignore
 logger = logging.getLogger(__name__)
 
 
-def get_secretsmanager_names(args):
+def get_secretsmanager_prefix(args):
     """
-    Get the keyword arguments used to access the secrets manager and
-    assemble secrets prefixes
+    Use information from the environment to assemble 
+    the necessary prefix for accessing variables in
+    the SecretsManager.
     """
     store_name = os.environ['DSS_SECRETS_STORE']
     if args.stage is None:
         stage_name = os.environ['DSS_DEPLOYMENT_STAGE']
 
-    return store_name, stage_name
-
-def get_secretsmanager_prefixes(args):
-    """
-    Use information from the environment to assemble ARN and Secrets Manager
-    prefixes for secret variables (necessary because AWS requires full resource
-    identifiers to fetch secrets)
-    """
-    store_name, stage_name = get_secretsmanager_names(args)
-    region_name = arn.get_region()
-    account_id = arn.get_account_id()
-    arn_prefix = f"arn:aws:secretsmanager:{region_name}:{account_id}:secret:"
     store_prefix = f"{store_name}/{stage_name}/"
-
-    return arn_prefix, store_prefix
-
-def long_short_resource_names(secret_name, arn_prefix, store_prefix):
-    """
-    Given a (user-provided) name of a secret variable,
-    determine whether the ARN prefix and store/stage
-    prefix are present, then determine and return the
-    long and short versions of the resource name.
-
-    Example short resouce name:
-    - dcp/dss/dev/es_source_ip-q2baD1 (store/stage prefix, no ARN prefix)
-
-    Example long resource name:
-    - arn:aws:secretsmanager:us-east-1:861229788715:secret:(continued)
-      dcp/dss/dev/es_source_ip-q2baD1 (both store/stage prefix and ARN prefix)
-    """
-
-    # Figure out what kind of prefix the user provided
-    user_provided_arn = secret_name.startswith(arn_prefix)
-    user_provided_store = secret_name.startswith(store_prefix)
-
-    if user_provided_arn:
-        short_secret_name = secret_name[len(arn_prefix):]
-        long_secret_name = secret_name
-
-    elif user_provided_store:
-        short_secret_name = secret_name
-        long_secret_name = arn_prefix + secret_name
-
-    else:
-        short_secret_name = store_prefix + secret_name
-        long_secret_name = arn_prefix + store_prefix + secret_name
-
-    return short_secret_name, long_secret_name
+    return store_prefix
 
 
 events = dispatch.target("secrets",
@@ -85,10 +40,6 @@ events = dispatch.target("secrets",
                    "--stage": dict(
                        required=False,
                        help="the stage for which secrets should be listed"),
-                   "--long": dict(
-                       default=False,
-                       action="store_true",
-                       help="use long (full ARN) identifiers when printing secret variables"),
                    "--json": dict(
                        default=False,
                        action="store_true",
@@ -98,8 +49,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
     Print a list of names of every secret variable in the secrets manager
     for the given store and stage
     """
-    store_name, stage_name = get_secretsmanager_names(args)
-    arn_prefix, store_prefix = get_secretsmanager_prefixes(args)
+    store_prefix = get_secretsmanager_prefix(args)
 
     paginator = secretsmanager.get_paginator('list_secrets')
 
@@ -108,15 +58,11 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
         for secret in response['SecretList']:
 
             # Get resource IDs
-            secret_name = secret['ARN']
-            short_secret_name, long_secret_name = long_short_resource_names(secret_name, arn_prefix, store_prefix)
+            secret_name = secret['Name']
 
             # Only save secrets for this store and stage
-            if short_secret_name.startswith(store_prefix):
-                if args.long:
-                    secret_names.append(long_secret_name)
-                else:
-                    secret_names.append(short_secret_name)
+            if secret_name.startswith(store_prefix):
+                secret_names.append(secret_name)
 
     secret_names.sort()
 
@@ -136,10 +82,6 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
                        required=True,
                        nargs="*",
                        help="name of secret or secrets to retrieve (list values can be separated by a space)"),
-                   "--long": dict(
-                       default=False,
-                       action="store_true",
-                       help="use long (full ARN) identifiers when printing secret variable(s)"),
                    "--json": dict(
                        default=False,
                        action="store_true",
@@ -151,41 +93,34 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
     """
     # Note: this function should not print anything except the final JSON,
     # in case the user pipes the JSON output of this script to something else
-    store_name, stage_name = get_secretsmanager_names(args)
-    arn_prefix, store_prefix = get_secretsmanager_prefixes(args)
+
+    store_prefix = get_secretsmanager_prefix(args)
 
     # Make sure a secret name was specified
     if args.secret_name is None or len(args.secret_name) == 0:
         raise RuntimeError("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
     secret_names = args.secret_name
 
+    # Tack on the store prefix if it isn't there already
+    for i in range(len(secret_names)):
+        secret_name = secret_names[i]
+        if not secret_name.startswith(store_prefix):
+            secret_names[i] = store_prefix + secret_name
+
     for secret_name in secret_names:
-
-        # Get resource IDs
-        short_secret_name, long_secret_name = long_short_resource_names(secret_name, arn_prefix, store_prefix)
-
         # Attempt to obtain secret
         try:
-            response = secretsmanager.get_secret_value(SecretId=long_secret_name)
+            response = secretsmanager.get_secret_value(SecretId=secret_name)
             secret_val = response['SecretString']
         except secretsmanager.exceptions.ResourceNotFoundException:
             # A secret variable with that name does not exist
-            if args.long:
-                logger.warning(f"Resource not found: {long_secret_name}")
-            else:
-                logger.warning(f"Resource not found: {short_secret_name}")
+            logger.warning(f"Resource not found: {secret_name}")
         else:
             # Get operation was successful, secret variable exists
             if args.json:
-                if args.long:
-                    print(json.dumps({long_secret_name: secret_val}))
-                else:
-                    print(json.dumps({short_secret_name: secret_val}))
+                print(json.dumps({secret_name: secret_val}))
             else:
-                if args.long:
-                    print(f"{long_secret_name}={secret_val}")
-                else:
-                    print(f"{short_secret_name}={secret_val}")
+                print(f"{secret_name}={secret_val}")
 
 
 @events.action("set",
@@ -202,13 +137,16 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
                        help="do a dry run of the actual operation")})
 def set_secret(argv: typing.List[str], args: argparse.Namespace):
     """Set the value of the secret variable specified by the --secret-name flag"""
-    store_name, stage_name = get_secretsmanager_names(args)
-    arn_prefix, store_prefix = get_secretsmanager_prefixes(args)
+    store_prefix = get_secretsmanager_prefix(args)
 
     # Make sure a secret name was specified
     if args.secret_name is None or len(args.secret_name) == 0:
         raise RuntimeError("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
     secret_name = args.secret_name
+
+    # Tack on the store prefix if it isn't there already
+    if not secret_name.startswith(store_prefix):
+        secret_name = store_prefix + secret_name
 
     # Use stdin (input piped to this script) as secret value.
     # stdin provides secret value, flag --secret-name provides secret name.
@@ -217,34 +155,31 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
         raise RuntimeError(err_msg)
     secret_val = sys.stdin.read()
 
-    # Get resouce IDs
-    short_secret_name, long_secret_name = long_short_resource_names(secret_name, arn_prefix, store_prefix)
-
     try:
         # Start by trying to get the secret variable
-        _ = secretsmanager.get_secret_value(SecretId=long_secret_name)
+        _ = secretsmanager.get_secret_value(SecretId=secret_name)
 
     except secretsmanager.exceptions.ResourceNotFoundException:
         # A secret variable with that name does not exist, so create it
         if args.dry_run:
             # Create it for fakes
-            print(f"Secret variable {short_secret_name} not found in secrets manager, dry-run creating it")
+            print(f"Secret variable {secret_name} not found in secrets manager, dry-run creating it")
         else:
             # Create it for real
-            print(f"Secret variable {short_secret_name} not found in secrets manager, creating it")
+            print(f"Secret variable {secret_name} not found in secrets manager, creating it")
             _ = secretsmanager.create_secret(
-                Name=short_secret_name, SecretString=secret_val
+                Name=secret_name, SecretString=secret_val
             )
     else:
         # Get operation was successful, secret variable exists
         if args.dry_run:
             # Update it for fakes
-            print(f"Secret variable {short_secret_name} found in secrets manager, dry-run updating it")
+            print(f"Secret variable {secret_name} found in secrets manager, dry-run updating it")
         else:
             # Update it for real
-            print(f"Secret variable {short_secret_name} found in secrets manager, updating it")
+            print(f"Secret variable {secret_name} found in secrets manager, updating it")
             _ = secretsmanager.update_secret(
-                SecretId=short_secret_name, SecretString=secret_val
+                SecretId=secret_name, SecretString=secret_val
             )
 
 
@@ -256,6 +191,10 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
                    "--secret-name": dict(
                        required=True,
                        help="name of secret to delete (limit 1 at a time)"),
+                   "--force": dict(
+                       default=False,
+                       action="store_true",
+                       help="force the delete operation to happen non-interactively (no user prompt)"),
                    "--dry-run": dict(
                        default=False,
                        action="store_true",
@@ -265,43 +204,44 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
     Delete the value of the secret variable specified by the
     --secret-name flag from the secrets manager
     """
-    store_name, stage_name = get_secretsmanager_names(args)
-    arn_prefix, store_prefix = get_secretsmanager_prefixes(args)
+    store_prefix = get_secretsmanager_prefix(args)
 
     # Make sure a secret name was specified
     if args.secret_name is None or len(args.secret_name) == 0:
         raise RuntimeError("Unable to set secret: no secret name was specified! Use the --secret-name flag.")
     secret_name = args.secret_name
 
-    # Get resouce IDs
-    short_secret_name, long_secret_name = long_short_resource_names(secret_name, arn_prefix, store_prefix)
+    # Tack on the store prefix if it isn't there already
+    if not secret_name.startswith(store_prefix):
+        secret_name = store_prefix + secret_name
 
-    # Make sure the user really wants to do this
-    confirm = f"""
-    Are you really sure you want to delete secret {secret_name}? (Type 'y' or 'yes' to confirm):
-    """
-    response = input(confirm)
-    if response.lower() not in ['y', 'yes']:
-        raise RuntimeError("You safely aborted the delete secret operation!")
+    if args.force is False:
+        # Make sure the user really wants to do this
+        confirm = f"""
+        Are you really sure you want to delete secret {secret_name}? (Type 'y' or 'yes' to confirm):
+        """
+        response = input(confirm)
+        if response.lower() not in ['y', 'yes']:
+            raise RuntimeError("You safely aborted the delete secret operation!")
 
     try:
         # Start by trying to get the secret variable
-        _ = secretsmanager.get_secret_value(SecretId=long_secret_name)
+        _ = secretsmanager.get_secret_value(SecretId=secret_name)
 
     except secretsmanager.exceptions.ResourceNotFoundException:
         # No secret var found
-        logger.warning(f"Secret variable {short_secret_name} not found in secrets manager!")
+        logger.warning(f"Secret variable {secret_name} not found in secrets manager!")
 
     except secretsmanager.exceptions.InvalidRequestException:
         # Already deleted secret var
-        logger.warning(f"Secret variable {short_secret_name} already marked for deletion in secrets manager!")
+        logger.warning(f"Secret variable {secret_name} already marked for deletion in secrets manager!")
 
     else:
         # Get operation was successful, secret variable exists
         if args.dry_run:
             # Delete it for fakes
-            print(f"Secret variable {short_secret_name} found in secrets manager, dry-run deleting it")
+            print(f"Secret variable {secret_name} found in secrets manager, dry-run deleting it")
         else:
             # Delete it for real
-            print(f"Secret variable {short_secret_name} found in secrets manager, deleting it")
-            _ = secretsmanager.delete_secret(SecretId=long_secret_name)
+            print(f"Secret variable {secret_name} found in secrets manager, deleting it")
+            _ = secretsmanager.delete_secret(SecretId=secret_name)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -65,7 +65,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
     secret_names.sort()
 
     if args.json is True:
-        print(json.dumps(secret_names))
+        print(json.dumps(secret_names, indent=4))
     else:
         for secret_name in secret_names:
             print(secret_name)
@@ -126,7 +126,12 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
         else:
             # Get operation was successful, secret variable exists
             if use_json:
-                print(json.dumps({secret_name: secret_val}))
+                # Sometimes secret_val can be a dictionary
+                try:
+                    secret_val = json.loads(secret_val)
+                except json.decoder.JSONDecodeError:
+                    pass
+                print(json.dumps({secret_name: secret_val}, indent=4))
             else:
                 print(f"{secret_name}={secret_val}")
 

--- a/scripts/dss-ops.py
+++ b/scripts/dss-ops.py
@@ -14,6 +14,7 @@ import dss.operations.storage
 import dss.operations.sync
 import dss.operations.elasticsearch
 import dss.operations.events
+import dss.operations.secrets
 from dss.operations import dispatch
 
 logging.basicConfig(stream=sys.stdout)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,6 +8,8 @@ import jwt
 import functools
 import io
 import os
+import sys
+from io import StringIO
 
 from dss import Config
 from dss.api import bundles
@@ -120,3 +122,41 @@ def skip_on_travis(test_item):
         return unittest.skip("Test doesn't run on travis.")(test_item)
     else:
         return test_item
+
+class CaptureStdout(list):
+    """
+    Utility object using a context manager to capture stdout for a given block
+    of Python code. Subclass of list so that you can access stdout lines like a
+    list.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def __enter__(self, *args, **kwargs):
+        """
+        The function called when we open the context, this function swaps out
+        sys.stdout with a string buffer and saves the sys.stdout reference.
+        """
+        # Save existing stdout object so we can restore it when we're done
+        self._stdout = sys.stdout
+        # Swap out stdout
+        sys.stdout = self._stringio = StringIO()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        """
+        Close the context and clean up; the *args are needed in case there is
+        an exception (we don't deal with those here)
+        """
+        # This class extends the list class, so call self.extend to add a list
+        # to the end of self. This is to add all of the new lines from the
+        # StringIO object.
+        self.extend(self._stringio.getvalue().splitlines())
+
+        # Clean up (if this is missing, the garbage collector will eventually
+        # take care of this...)
+        del self._stringio
+
+        # Clean up by setting sys.stdout back to what it was before we opened
+        # up this context
+        sys.stdout = self._stdout

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -342,9 +342,18 @@ class TestOperations(unittest.TestCase):
                 # and verify variable name/value is in both.
                 #
                 # Start with non-JSON get call:
+                # Single variable:
                 with CaptureStdout() as output:
                     secrets.get_secret(
-                        [], argparse.Namespace(secret_name=testvar_name, stage=which_stage)
+                        [], argparse.Namespace(secret_name=[testvar_name])
+                    )
+                output = "".join(output)
+                self.assertIn(testvar_name, output)
+                self.assertIn(testvar_value, output)
+                # Multiple variables:
+                with CaptureStdout() as output:
+                    secrets.get_secret(
+                        [], argparse.Namespace(secret_name=[testvar_name,unusedvar_name])
                     )
                 output = "".join(output)
                 self.assertIn(testvar_name, output)
@@ -354,9 +363,7 @@ class TestOperations(unittest.TestCase):
                 with CaptureStdout() as output:
                     secrets.get_secret(
                         [],
-                        argparse.Namespace(
-                            secret_name=testvar_name, stage=which_stage, json=True
-                        ),
+                        argparse.Namespace(secret_name=[testvar_name], json=True),
                     )
                 output = "".join(output)
                 self.assertIn(testvar_name, output)
@@ -374,7 +381,6 @@ class TestOperations(unittest.TestCase):
                     argparse.Namespace(
                         secret_name=testvar_name,
                         secret_value=testvar_value2,
-                        stage=which_stage,
                     ),
                 )
 
@@ -386,9 +392,7 @@ class TestOperations(unittest.TestCase):
                 # Delete secret
                 secrets.del_secret(
                     [],
-                    argparse.Namespace(
-                        secret_name=testvar_name, stage=which_stage, force=True
-                    ),
+                    argparse.Namespace(secret_name=testvar_name, force=True),
                 )
 
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -305,7 +305,7 @@ class TestOperations(unittest.TestCase):
                     argparse.Namespace(
                         secret_name=testvar_name,
                         secret_value=testvar_value,
-                        stage=which_stage,
+                        dry_run=False
                     ),
                 )
 
@@ -331,7 +331,7 @@ class TestOperations(unittest.TestCase):
                 sm.get_paginator.return_value = MockPaginator()
                 # Test variable name should be in list of secret names
                 with CaptureStdout() as output:
-                    secrets.list_secrets([], argparse.Namespace(stage=which_stage))
+                    secrets.list_secrets([], argparse.Namespace(json=False))
                 self.assertIn(testvar_name, output)
 
         with self.subTest("Get secret value"):
@@ -345,7 +345,7 @@ class TestOperations(unittest.TestCase):
                 # Single variable:
                 with CaptureStdout() as output:
                     secrets.get_secret(
-                        [], argparse.Namespace(secret_names=[testvar_name])
+                        [], argparse.Namespace(secret_names=[testvar_name], json=False)
                     )
                 output = "".join(output)
                 self.assertIn(testvar_name, output)
@@ -353,17 +353,34 @@ class TestOperations(unittest.TestCase):
                 # Multiple variables:
                 with CaptureStdout() as output:
                     secrets.get_secret(
-                        [], argparse.Namespace(secret_names=[testvar_name,unusedvar_name])
+                        [],
+                        argparse.Namespace(
+                            secret_names=[testvar_name,unusedvar_name],
+                            json=False
+                        )
                     )
                 output = "".join(output)
                 self.assertIn(testvar_name, output)
                 self.assertIn(testvar_value, output)
                 #
                 # Now JSON get call:
+                # Single variable:
                 with CaptureStdout() as output:
                     secrets.get_secret(
                         [],
                         argparse.Namespace(secret_names=[testvar_name], json=True),
+                    )
+                output = "".join(output)
+                self.assertIn(testvar_name, output)
+                self.assertIn(testvar_value, output)
+                # Multiple variables:
+                with CaptureStdout() as output:
+                    secrets.get_secret(
+                        [],
+                        argparse.Namespace(
+                            secret_names=[testvar_name,unusedvar_name],
+                            json=True
+                        )
                     )
                 output = "".join(output)
                 self.assertIn(testvar_name, output)
@@ -381,6 +398,7 @@ class TestOperations(unittest.TestCase):
                     argparse.Namespace(
                         secret_name=testvar_name,
                         secret_value=testvar_value2,
+                        dry_run=False,
                     ),
                 )
 
@@ -392,7 +410,11 @@ class TestOperations(unittest.TestCase):
                 # Delete secret
                 secrets.del_secret(
                     [],
-                    argparse.Namespace(secret_name=testvar_name, force=True),
+                    argparse.Namespace(
+                        secret_name=testvar_name,
+                        force=True,
+                        dry_run=False,
+                    ),
                 )
 
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -345,7 +345,7 @@ class TestOperations(unittest.TestCase):
                 # Single variable:
                 with CaptureStdout() as output:
                     secrets.get_secret(
-                        [], argparse.Namespace(secret_name=[testvar_name])
+                        [], argparse.Namespace(secret_names=[testvar_name])
                     )
                 output = "".join(output)
                 self.assertIn(testvar_name, output)
@@ -353,7 +353,7 @@ class TestOperations(unittest.TestCase):
                 # Multiple variables:
                 with CaptureStdout() as output:
                     secrets.get_secret(
-                        [], argparse.Namespace(secret_name=[testvar_name,unusedvar_name])
+                        [], argparse.Namespace(secret_names=[testvar_name,unusedvar_name])
                     )
                 output = "".join(output)
                 self.assertIn(testvar_name, output)
@@ -363,7 +363,7 @@ class TestOperations(unittest.TestCase):
                 with CaptureStdout() as output:
                     secrets.get_secret(
                         [],
-                        argparse.Namespace(secret_name=[testvar_name], json=True),
+                        argparse.Namespace(secret_names=[testvar_name], json=True),
                     )
                 output = "".join(output)
                 self.assertIn(testvar_name, output)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -8,9 +8,12 @@ import uuid
 import json
 import argparse
 import unittest
+import string
+import random
 from collections import namedtuple
 from unittest import mock
 from boto3.s3.transfer import TransferConfig
+from botocore.exceptions import ClientError
 
 from cloud_blobstore import BlobNotFoundError
 
@@ -21,14 +24,18 @@ import dss
 from tests.infra import testmode
 from dss.operations import DSSOperationsCommandDispatch
 from dss.operations.util import map_bucket_results
-from dss.operations import storage, sync
+from dss.operations import storage, sync, secrets
 from dss.logging import configure_test_logging
 from dss.config import BucketConfig, Config, Replica, override_bucket_config
 from dss.storage.hcablobstore import FileMetadata, compose_blob_key
 from dss.util.aws import resources
+from tests import CaptureStdout
 
 def setUpModule():
     configure_test_logging()
+
+def random_alphanumeric_string(N=10):
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=N))
 
 @testmode.standalone
 class TestOperations(unittest.TestCase):
@@ -266,6 +273,124 @@ class TestOperations(unittest.TestCase):
         gs_blob = gs_bucket.blob(key, chunk_size=1 * 1024 * 1024)
         with io.BytesIO(data) as fh:
             gs_blob.upload_from_file(fh, content_type="application/octet-stream")
+
+    def test_secrets_crud(self):
+        # CRUD (create read update delete) test procedure:
+        # - create new secret
+        # - list secrets and verify new secret shows up
+        # - get secret value and verify it is correct
+        # - update secret value
+        # - get secret value and verify it is correct
+        # - delete secret
+        which_stage = "dev"
+        which_store = os.environ["DSS_SECRETS_STORE"]
+
+        secret_name = random_alphanumeric_string()
+        testvar_name = f"{which_store}/{which_stage}/{secret_name}"
+        testvar_value = "Hello world!"
+        testvar_value2 = "Goodbye world!"
+
+        unusedvar_name = f"{which_store}/{which_stage}/admin_user_emails"
+
+        with self.subTest("Create a new secret"):
+            # Monkeypatch the secrets manager
+            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+                # Creating a new variable will first call get, which will not find it
+                sm.get_secret_value = mock.MagicMock(return_value=None, side_effect=ClientError({}, None))
+                # Next we will use the create secret command
+                sm.create_secret = mock.MagicMock(return_value=None)
+                # Create initial secret value
+                secrets.set_secret(
+                    [],
+                    argparse.Namespace(
+                        secret_name=testvar_name,
+                        secret_value=testvar_value,
+                        stage=which_stage,
+                    ),
+                )
+
+        with self.subTest("List secrets"):
+            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+                # Listing secrets requires creating a paginator first,
+                # so mock what the paginator returns
+                class MockPaginator(object):
+                    def paginate(self):
+                        # Return a mock page from the mock paginator
+                        return [
+                            {
+                                "SecretList": [
+                                    {
+                                        "Name": testvar_name
+                                    },
+                                    {
+                                        "Name": unusedvar_name
+                                    }
+                                ]
+                            }
+                        ]
+                sm.get_paginator.return_value = MockPaginator()
+                # Test variable name should be in list of secret names
+                with CaptureStdout() as output:
+                    secrets.list_secrets([], argparse.Namespace(stage=which_stage))
+                self.assertIn(testvar_name, output)
+
+        with self.subTest("Get secret value"):
+            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+                # Requesting the variable will try to get secret value and succeed
+                sm.get_secret_value.return_value = {"SecretString": testvar_value}
+                # Now run get secret value in JSON mode and non-JSON mode
+                # and verify variable name/value is in both.
+                #
+                # Start with non-JSON get call:
+                with CaptureStdout() as output:
+                    secrets.get_secret(
+                        [], argparse.Namespace(secret_name=testvar_name, stage=which_stage)
+                    )
+                output = "".join(output)
+                self.assertIn(testvar_name, output)
+                self.assertIn(testvar_value, output)
+                #
+                # Now JSON get call:
+                with CaptureStdout() as output:
+                    secrets.get_secret(
+                        [],
+                        argparse.Namespace(
+                            secret_name=testvar_name, stage=which_stage, json=True
+                        ),
+                    )
+                output = "".join(output)
+                self.assertIn(testvar_name, output)
+                self.assertIn(testvar_value, output)
+
+        with self.subTest("Update existing secret"):
+            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+                # Updating the variable will try to get secret value and succeed
+                sm.get_secret_value = mock.MagicMock(return_value={"SecretString": testvar_value})
+                # Next we will call the update secret command
+                sm.update_secret = mock.MagicMock(return_value=None)
+                # Update secret
+                secrets.set_secret(
+                    [],
+                    argparse.Namespace(
+                        secret_name=testvar_name,
+                        secret_value=testvar_value2,
+                        stage=which_stage,
+                    ),
+                )
+
+        with self.subTest("Delete secret"):
+            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+                # Deleting the variable will try to get secret value and succeed
+                sm.get_secret_value = mock.MagicMock(return_value={"SecretString": testvar_value})
+                sm.delete_secret = mock.MagicMock(return_value=None)
+                # Delete secret
+                secrets.del_secret(
+                    [],
+                    argparse.Namespace(
+                        secret_name=testvar_name, stage=which_stage, force=True
+                    ),
+                )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -355,7 +355,7 @@ class TestOperations(unittest.TestCase):
                     secrets.get_secret(
                         [],
                         argparse.Namespace(
-                            secret_names=[testvar_name,unusedvar_name],
+                            secret_names=[testvar_name, unusedvar_name],
                             json=False
                         )
                     )
@@ -378,7 +378,7 @@ class TestOperations(unittest.TestCase):
                     secrets.get_secret(
                         [],
                         argparse.Namespace(
-                            secret_names=[testvar_name,unusedvar_name],
+                            secret_names=[testvar_name, unusedvar_name],
                             json=True
                         )
                     )


### PR DESCRIPTION
This pull request adds functionality to dss-ops that allows it to manage secrets. There are three verbs added:

* `dss-ops.py secrets list` to list secrets (names only)
* `dss-ops.py secrets get --secret-name <X>` to get a secret variable's value
* `dss-ops.py secrets set --secret-name <X>` to set a secret variable's value
* `dss-ops.py secrets delete --secret-name <X>` to delete a secret variable from the secrets manager

The `set` action can take input piped in from stdin.

This PR closes #2296 