### PR TITLE
[DO NOT MERGE] Demonstrate that retrieval of secrets using short names is broken

### DIFF
--- a/dss/operations/foobar.py
+++ b/dss/operations/foobar.py
@@ -31,12 +31,13 @@ def plink(argv: typing.List[str], args: argparse.Namespace):
     stage_name = os.environ['DSS_DEPLOYMENT_STAGE']
 
     tiny_secret_name = "es_source_ip-q2baD1"
-    short_secret_name = "dcp/dss/dev/es_source_ip-q2baD1"
+    short_secret_name_broken = "dcp/dss/dev/es_source_ip-q2baD1"
+    short_secret_name = "dcp/dss/dev/es_source_ip"
     full_secret_name = "arn:aws:secretsmanager:us-east-1:861229788715:secret:dcp/dss/dev/es_source_ip-q2baD1"
 
     try:
         print("------------------")
-        print("Full secret name:")
+        print(f"Full secret name {full_secret_name}:")
         print(full_secret_name)
         response1 = secretsmanager.get_secret_value(SecretId=full_secret_name)
         pprint(response1)
@@ -45,7 +46,7 @@ def plink(argv: typing.List[str], args: argparse.Namespace):
 
     try:
         print("------------------")
-        print("Short secret name:")
+        print(f"Short secret name {short_secret_name}:")
         print(short_secret_name)
         response2 = secretsmanager.get_secret_value(SecretId=short_secret_name)
         pprint(response2)

--- a/dss/operations/foobar.py
+++ b/dss/operations/foobar.py
@@ -1,0 +1,54 @@
+"""
+Get/set secret variable values from the AWS Secrets Manager
+"""
+import os
+import sys
+import click
+import boto3
+import select
+import typing
+import argparse
+import json
+import logging
+from pprint import pprint
+
+from dss.operations import dispatch
+from dss.util.aws import ARN as arn
+from dss.util.aws.clients import secretsmanager # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+
+events = dispatch.target("foobar",
+                         arguments={},
+                         help=__doc__)
+@events.action("plink",
+        arguments={})
+def plink(argv: typing.List[str], args: argparse.Namespace):
+    """Plink something"""
+    store_name = os.environ['DSS_SECRETS_STORE']
+    stage_name = os.environ['DSS_DEPLOYMENT_STAGE']
+
+    tiny_secret_name = "es_source_ip-q2baD1"
+    short_secret_name = "dcp/dss/dev/es_source_ip-q2baD1"
+    full_secret_name = "arn:aws:secretsmanager:us-east-1:861229788715:secret:dcp/dss/dev/es_source_ip-q2baD1"
+
+    try:
+        print("------------------")
+        print("Full secret name:")
+        print(full_secret_name)
+        response1 = secretsmanager.get_secret_value(SecretId=full_secret_name)
+        pprint(response1)
+    except secretsmanager.exceptions.ResourceNotFoundException:
+        print(f"No resource with the name {full_secret_name} exists")
+
+    try:
+        print("------------------")
+        print("Short secret name:")
+        print(short_secret_name)
+        response2 = secretsmanager.get_secret_value(SecretId=short_secret_name)
+        pprint(response2)
+    except secretsmanager.exceptions.ResourceNotFoundException:
+        print(f"No resource with the name {short_secret_name} exists")
+

--- a/scripts/dss-ops.py
+++ b/scripts/dss-ops.py
@@ -14,6 +14,7 @@ import dss.operations.storage
 import dss.operations.sync
 import dss.operations.elasticsearch
 import dss.operations.events
+import dss.operations.foobar
 from dss.operations import dispatch
 
 logging.basicConfig(stream=sys.stdout)


### PR DESCRIPTION
In PR #2325 we had to jump through some hoops to assemble the full ARN number of the secrets, instead of using the (much simpler) secret store/stage prefix.

This pull request implements a simple `foobar` action in the dss operations script that proves the full ARN is required for each secret we retrieve from the secrets manager; simple/short names do not cut it.

Example of how to run this new action using the new branch, and example output:

```
$ git clone -b chmreid-short-arn-broken git@github.com:HumanCellAtlas/data-store

$ cd data-store

$ ./scripts/dss-ops.py foobar plink
------------------
Full secret name:
arn:aws:secretsmanager:us-east-1:861229788715:secret:dcp/dss/dev/es_source_ip-q2baD1
{'ARN': 'arn:aws:secretsmanager:us-east-1:861229788715:secret:dcp/dss/dev/es_source_ip-q2baD1',
 'CreatedDate': datetime.datetime(2019, 8, 1, 13, 41, 53, 237000, tzinfo=tzlocal()),
 'Name': 'dcp/dss/dev/es_source_ip',
 'ResponseMetadata': {'HTTPHeaders': {'connection': 'keep-alive',
                                      'content-length': '753',
                                      'content-type': 'application/x-amz-json-1.1',
                                      'date': 'Wed, 07 Aug 2019 21:47:19 GMT',
                                      'x-amzn-requestid': '3b78adf1-9b04-4407-81e7-6ce9111e9385'},
                      'HTTPStatusCode': 200,
                      'RequestId': '3b78adf1-9b04-4407-81e7-6ce9111e9385',
                      'RetryAttempts': 0},
 'SecretString': '<REDACTED>',
 'VersionId': '658c3b41-0806-48b9-b05d-ec7dc2dbf237',
 'VersionStages': ['AWSCURRENT']}
------------------
Short secret name:
dcp/dss/dev/es_source_ip-q2baD1
No resource with the name dcp/dss/dev/es_source_ip-q2baD1 exists
```


