### PR TITLE
Add tests for dss-ops secrets functionality

### DIFF
--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -22,7 +22,10 @@ def get_secretsmanager_prefix(args):
     the SecretsManager.
     """
     store_name = os.environ["DSS_SECRETS_STORE"]
-    if args.stage is None:
+
+    if hasattr(args,'stage') and args.stage is not None:
+        stage_name = args.stage
+    else:
         stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
 
     store_prefix = f"{store_name}/{stage_name}/"
@@ -36,7 +39,7 @@ events = dispatch.target("secrets", arguments={}, help=__doc__)
     "list",
     arguments={
         "--stage": dict(
-            required=False, help="the stage for which secrets should be listed"
+            required=True, help="the stage for which secrets should be listed"
         ),
         "--json": dict(
             default=False,
@@ -67,7 +70,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 
     secret_names.sort()
 
-    if args.json:
+    if hasattr(args,'json') and args.json is True:
         print(json.dumps(secret_names))
     else:
         for secret_name in secret_names:
@@ -78,7 +81,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
     "get",
     arguments={
         "--stage": dict(
-            required=False, help="the stage for which secrets should be listed"
+            required=True, help="the stage for which secrets should be listed"
         ),
         "--secret-name": dict(
             required=True,
@@ -103,17 +106,23 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
     store_prefix = get_secretsmanager_prefix(args)
 
     # Make sure a secret name was specified
-    if args.secret_name is None or len(args.secret_name) == 0:
+    if args.secret_name is None:
         raise RuntimeError(
             "Unable to set secret: no secret name was specified! Use the --secret-name flag."
         )
-    secret_names = args.secret_name
+    secret_names = args.secret_name.split(" ")
 
     # Tack on the store prefix if it isn't there already
     for i in range(len(secret_names)):
         secret_name = secret_names[i]
         if not secret_name.startswith(store_prefix):
             secret_names[i] = store_prefix + secret_name
+
+    # Determine if we should format output as JSON
+    use_json = False
+    if hasattr(args,'json'):
+        if args.json:
+            use_json = True
 
     for secret_name in secret_names:
         # Attempt to obtain secret
@@ -125,7 +134,7 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
             logger.warning(f"Resource not found: {secret_name}")
         else:
             # Get operation was successful, secret variable exists
-            if args.json:
+            if use_json:
                 print(json.dumps({secret_name: secret_val}))
             else:
                 print(f"{secret_name}={secret_val}")
@@ -135,10 +144,15 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
     "set",
     arguments={
         "--stage": dict(
-            required=False, help="the stage for which secrets should be set"
+            required=True, help="the stage for which secrets should be set"
         ),
         "--secret-name": dict(
             required=True, help="name of secret to set (limit 1 at a time)"
+        ),
+        "--secret-value": dict(
+            required=False,
+            default=None,
+            help="value of secret to set (optional, if not present then stdin will be used)",
         ),
         "--dry-run": dict(
             default=False,
@@ -162,20 +176,36 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
     if not secret_name.startswith(store_prefix):
         secret_name = store_prefix + secret_name
 
-    # Use stdin (input piped to this script) as secret value.
-    # stdin provides secret value, flag --secret-name provides secret name.
-    if not select.select([sys.stdin], [], [], 0.0)[0]:
-        err_msg = f"No data in stdin, cannot set secret {secret_name} without a value from stdin!"
-        raise RuntimeError(err_msg)
-    secret_val = sys.stdin.read()
+    # Decide what to use for input
+    if hasattr(args,'secret_value'):
+        if args.secret_value is not None:
+            secret_val = args.secret_value
+        else:
+            msg = f"Error setting secret value for {secret_name}, invalid --secret-value flag"
+            raise RuntimeError(msg)
+    else:
+        # Use stdin (input piped to this script) as secret value.
+        # stdin provides secret value, flag --secret-name provides secret name.
+        if not select.select([sys.stdin], [], [])[0]:
+            err_msg = f"No data in stdin, cannot set secret {secret_name} without a value from stdin or without --secret-value flag!"
+            raise RuntimeError(err_msg)
+        secret_val = sys.stdin.read()
 
+    # Determine if we are doing a dry run
+    dry_run = False
+    if hasattr(args,'dry_run'):
+        if args.dry_run:
+            dry_run = True
+
+    # Create or update
     try:
         # Start by trying to get the secret variable
         _ = secretsmanager.get_secret_value(SecretId=secret_name)
 
     except secretsmanager.exceptions.ResourceNotFoundException:
         # A secret variable with that name does not exist, so create it
-        if args.dry_run:
+
+        if dry_run:
             # Create it for fakes
             print(
                 f"Secret variable {secret_name} not found in secrets manager, dry-run creating it"
@@ -186,9 +216,10 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
                 f"Secret variable {secret_name} not found in secrets manager, creating it"
             )
             _ = secretsmanager.create_secret(Name=secret_name, SecretString=secret_val)
+
     else:
         # Get operation was successful, secret variable exists
-        if args.dry_run:
+        if dry_run:
             # Update it for fakes
             print(
                 f"Secret variable {secret_name} found in secrets manager, dry-run updating it"
@@ -207,7 +238,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
     "delete",
     arguments={
         "--stage": dict(
-            required=False, help="the stage for which secrets should be deleted"
+            required=True, help="the stage for which secrets should be deleted"
         ),
         "--secret-name": dict(
             required=True, help="name of secret to delete (limit 1 at a time)"
@@ -238,11 +269,23 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
         )
     secret_name = args.secret_name
 
+    # Determine if we are doing a dry run
+    dry_run = False
+    if hasattr(args,'dry_run'):
+        if args.dry_run:
+            dry_run = True
+
+    # Determine if we are doing a forced action
+    force = False
+    if hasattr(args,'force'):
+        if args.force:
+            force = True
+
     # Tack on the store prefix if it isn't there already
     if not secret_name.startswith(store_prefix):
         secret_name = store_prefix + secret_name
 
-    if args.force is False:
+    if force is False:
         # Make sure the user really wants to do this
         confirm = f"""
         Are you really sure you want to delete secret {secret_name}? (Type 'y' or 'yes' to confirm):
@@ -267,7 +310,7 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
 
     else:
         # Get operation was successful, secret variable exists
-        if args.dry_run:
+        if dry_run:
             # Delete it for fakes
             print(
                 f"Secret variable {secret_name} found in secrets manager, dry-run deleting it"

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -9,6 +9,8 @@ import argparse
 import json
 import logging
 
+from botocore.exceptions import ClientError
+
 from dss.operations import dispatch
 from dss.util.aws.clients import secretsmanager  # type: ignore
 
@@ -129,7 +131,7 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
         try:
             response = secretsmanager.get_secret_value(SecretId=secret_name)
             secret_val = response["SecretString"]
-        except secretsmanager.exceptions.ResourceNotFoundException:
+        except ClientError:
             # A secret variable with that name does not exist
             logger.warning(f"Resource not found: {secret_name}")
         else:
@@ -203,7 +205,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
         # Start by trying to get the secret variable
         _ = secretsmanager.get_secret_value(SecretId=secret_name)
 
-    except secretsmanager.exceptions.ResourceNotFoundException:
+    except ClientError:
         # A secret variable with that name does not exist, so create it
 
         if dry_run:
@@ -299,7 +301,7 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
         # Start by trying to get the secret variable
         _ = secretsmanager.get_secret_value(SecretId=secret_name)
 
-    except secretsmanager.exceptions.ResourceNotFoundException:
+    except ClientError:
         # No secret var found
         logger.warning(f"Secret variable {secret_name} not found in secrets manager!")
 

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -187,7 +187,8 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
         # Use stdin (input piped to this script) as secret value.
         # stdin provides secret value, flag --secret-name provides secret name.
         if not select.select([sys.stdin], [], [])[0]:
-            err_msg = f"No data in stdin, cannot set secret {secret_name} without a value from stdin or without --secret-value flag!"
+            err_msg = f"No data in stdin, cannot set secret {secret_name} without "
+            err_msg += "a value from stdin or without --secret-value flag!"
             raise RuntimeError(err_msg)
         secret_val = sys.stdin.read()
 

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -23,7 +23,7 @@ def get_secretsmanager_prefix(args):
     """
     store_name = os.environ["DSS_SECRETS_STORE"]
 
-    if hasattr(args,'stage') and args.stage is not None:
+    if hasattr(args, "stage") and args.stage is not None:
         stage_name = args.stage
     else:
         stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
@@ -70,7 +70,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 
     secret_names.sort()
 
-    if hasattr(args,'json') and args.json is True:
+    if hasattr(args, "json") and args.json is True:
         print(json.dumps(secret_names))
     else:
         for secret_name in secret_names:
@@ -120,7 +120,7 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
 
     # Determine if we should format output as JSON
     use_json = False
-    if hasattr(args,'json'):
+    if hasattr(args, "json"):
         if args.json:
             use_json = True
 
@@ -177,7 +177,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
         secret_name = store_prefix + secret_name
 
     # Decide what to use for input
-    if hasattr(args,'secret_value'):
+    if hasattr(args, "secret_value"):
         if args.secret_value is not None:
             secret_val = args.secret_value
         else:
@@ -193,7 +193,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
 
     # Determine if we are doing a dry run
     dry_run = False
-    if hasattr(args,'dry_run'):
+    if hasattr(args, "dry_run"):
         if args.dry_run:
             dry_run = True
 
@@ -271,13 +271,13 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
 
     # Determine if we are doing a dry run
     dry_run = False
-    if hasattr(args,'dry_run'):
+    if hasattr(args, "dry_run"):
         if args.dry_run:
             dry_run = True
 
     # Determine if we are doing a forced action
     force = False
-    if hasattr(args,'force'):
+    if hasattr(args, "force"):
         if args.force:
             force = True
 

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -39,7 +39,7 @@ events = dispatch.target("secrets", arguments={}, help=__doc__)
     "list",
     arguments={
         "--stage": dict(
-            required=True, help="the stage for which secrets should be listed"
+            required=False, help="the stage for which secrets should be listed"
         ),
         "--json": dict(
             default=False,
@@ -81,7 +81,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
     "get",
     arguments={
         "--stage": dict(
-            required=True, help="the stage for which secrets should be listed"
+            required=False, help="the stage for which secrets should be listed"
         ),
         "--secret-name": dict(
             required=True,
@@ -144,7 +144,7 @@ def get_secret(argv: typing.List[str], args: argparse.Namespace):
     "set",
     arguments={
         "--stage": dict(
-            required=True, help="the stage for which secrets should be set"
+            required=False, help="the stage for which secrets should be set"
         ),
         "--secret-name": dict(
             required=True, help="name of secret to set (limit 1 at a time)"
@@ -239,7 +239,7 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
     "delete",
     arguments={
         "--stage": dict(
-            required=True, help="the stage for which secrets should be deleted"
+            required=False, help="the stage for which secrets should be deleted"
         ),
         "--secret-name": dict(
             required=True, help="name of secret to delete (limit 1 at a time)"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -125,24 +125,19 @@ def skip_on_travis(test_item):
 
 class CaptureStdout(list):
     """
-    Utility object using a context manager
-    to capture stdout for a given block
-    of Python code. Subclass of list so
-    that you can access stdout lines like
-    a list.
+    Utility object using a context manager to capture stdout for a given block
+    of Python code. Subclass of list so that you can access stdout lines like a
+    list.
     """
     def __init__(self, *args, **kwargs):
         super().__init__()
 
     def __enter__(self, *args, **kwargs):
         """
-        The function called when we open the context,
-        this function swaps out sys.stdout with a
-        string buffer and saves the sys.stdout
-        reference.
+        The function called when we open the context, this function swaps out
+        sys.stdout with a string buffer and saves the sys.stdout reference.
         """
-        # Save existing stdout object so we can
-        # restore it when we're done
+        # Save existing stdout object so we can restore it when we're done
         self._stdout = sys.stdout
         # Swap out stdout
         sys.stdout = self._stringio = StringIO()
@@ -150,28 +145,26 @@ class CaptureStdout(list):
 
     def __exit__(self, *args, **kwargs):
         """
-        Close the context and clean up; the *args are
-        needed in case there is an exception (we
-        don't deal with those here)
+        Close the context and clean up; the *args are needed in case there is
+        an exception (we don't deal with those here)
         """
-        # This class extends the list class, so call
-        # self.extend to add a list to the end of
-        # self. This is to add all of the new lines
-        # from the StringIO object.
+        # This class extends the list class, so call self.extend to add a list
+        # to the end of self. This is to add all of the new lines from the
+        # StringIO object.
         self.extend(self._stringio.getvalue().splitlines())
 
-        # Clean up (if this is missing, the garbage
-        # collector will eventually take care of this...)
+        # Clean up (if this is missing, the garbage collector will eventually
+        # take care of this...)
         del self._stringio
 
-        # Clean up by setting sys.stdout back to what it
-        # was before we opened up this context
+        # Clean up by setting sys.stdout back to what it was before we opened
+        # up this context
         sys.stdout = self._stdout
 
 class MockStdin(object):
     """
-    Utility object using a context manager
-    to replace stdin with a mock input string.
+    Utility object using a context manager to replace stdin with a mock input
+    string.
     """
     def __init__(self, *args, **kwargs):
         if len(args) == 0:
@@ -181,12 +174,10 @@ class MockStdin(object):
 
     def __enter__(self, *args, **kwargs):
         """
-        The function called when we open
-        the context, this function swaps out
+        The function called when we open the context, this function swaps out
         sys.stdin with a string self.msg.
         """
-        # Save existing stdin object so we can
-        # restore it when we're done
+        # Save existing stdin object so we can restore it when we're done
         self._stdin = sys.stdin
         # Swap out stdin
         sys.stdin = self.msg
@@ -196,5 +187,4 @@ class MockStdin(object):
         """
         Close the context and clean up.
         """
-        # Clean up
         sys.stdin = self._stdin

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -160,31 +160,3 @@ class CaptureStdout(list):
         # Clean up by setting sys.stdout back to what it was before we opened
         # up this context
         sys.stdout = self._stdout
-
-class MockStdin(object):
-    """
-    Utility object using a context manager to replace stdin with a mock input
-    string.
-    """
-    def __init__(self, *args, **kwargs):
-        if len(args) == 0:
-            self.msg = "Hello world"
-        else:
-            self.msg = args[0]
-
-    def __enter__(self, *args, **kwargs):
-        """
-        The function called when we open the context, this function swaps out
-        sys.stdin with a string self.msg.
-        """
-        # Save existing stdin object so we can restore it when we're done
-        self._stdin = sys.stdin
-        # Swap out stdin
-        sys.stdin = self.msg
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        """
-        Close the context and clean up.
-        """
-        sys.stdin = self._stdin

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,6 +8,8 @@ import jwt
 import functools
 import io
 import os
+import sys
+from io import StringIO
 
 from dss import Config
 from dss.api import bundles
@@ -120,3 +122,79 @@ def skip_on_travis(test_item):
         return unittest.skip("Test doesn't run on travis.")(test_item)
     else:
         return test_item
+
+class CaptureStdout(list):
+    """
+    Utility object using a context manager
+    to capture stdout for a given block
+    of Python code. Subclass of list so
+    that you can access stdout lines like
+    a list.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def __enter__(self, *args, **kwargs):
+        """
+        The function called when we open the context,
+        this function swaps out sys.stdout with a
+        string buffer and saves the sys.stdout
+        reference.
+        """
+        # Save existing stdout object so we can
+        # restore it when we're done
+        self._stdout = sys.stdout
+        # Swap out stdout
+        sys.stdout = self._stringio = StringIO()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        """
+        Close the context and clean up; the *args are
+        needed in case there is an exception (we
+        don't deal with those here)
+        """
+        # This class extends the list class, so call
+        # self.extend to add a list to the end of
+        # self. This is to add all of the new lines
+        # from the StringIO object.
+        self.extend(self._stringio.getvalue().splitlines())
+
+        # Clean up (if this is missing, the garbage
+        # collector will eventually take care of this...)
+        del self._stringio
+
+        # Clean up by setting sys.stdout back to what it
+        # was before we opened up this context
+        sys.stdout = self._stdout
+
+class MockStdin(object):
+    """
+    Utility object using a context manager
+    to replace stdin with a mock input string.
+    """
+    def __init__(self, *args, **kwargs):
+        if len(args) == 0:
+            self.msg = "Hello world"
+        else:
+            self.msg = args[0]
+
+    def __enter__(self, *args, **kwargs):
+        """
+        The function called when we open
+        the context, this function swaps out
+        sys.stdin with a string self.msg.
+        """
+        # Save existing stdin object so we can
+        # restore it when we're done
+        self._stdin = sys.stdin
+        # Swap out stdin
+        sys.stdin = self.msg
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        """
+        Close the context and clean up.
+        """
+        # Clean up
+        sys.stdin = self._stdin

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -325,6 +325,7 @@ class TestOperations(unittest.TestCase):
                 )
             # Output is a list of strings; convert to single string and read as
             # JSON/dict
+            self.assertNotEqual(output, "")
             d = json.loads("".join(output))
             self.assertIn(testvar_name, d.keys())
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -291,28 +291,25 @@ class TestOperations(unittest.TestCase):
 
         with self.subTest("Create a new secret"):
             # Create initial secret value
-            secrets.set_secret([], argparse.Namespace(
+            secrets.set_secret(
+                [],
+                argparse.Namespace(
                     secret_name=testvar_name,
                     secret_value=testvar_value,
-                    stage=which_stage
-                )
+                    stage=which_stage,
+                ),
             )
 
         with self.subTest("List secrets"):
             # Test variable name should be in list of secret names
             with CaptureStdout() as output:
-                secrets.list_secrets([], argparse.Namespace(
-                        stage=which_stage
-                    )
-                )
+                secrets.list_secrets([], argparse.Namespace(stage=which_stage))
             self.assertIn(testvar_name, output)
 
         with self.subTest("Get secret value"):
             with CaptureStdout() as output:
-                secrets.get_secret([], argparse.Namespace(
-                        secret_name=testvar_name,
-                        stage=which_stage
-                    )
+                secrets.get_secret(
+                    [], argparse.Namespace(secret_name=testvar_name, stage=which_stage)
                 )
             output = "".join(output)
             self.assertIn(testvar_name, output)
@@ -320,11 +317,11 @@ class TestOperations(unittest.TestCase):
 
         with self.subTest("Get secret value as JSON"):
             with CaptureStdout() as output:
-                secrets.get_secret([], argparse.Namespace(
-                        secret_name=testvar_name,
-                        stage=which_stage,
-                        json=True
-                    )
+                secrets.get_secret(
+                    [],
+                    argparse.Namespace(
+                        secret_name=testvar_name, stage=which_stage, json=True
+                    ),
                 )
             # Output is a list of strings; convert to single string and read as
             # JSON/dict
@@ -333,37 +330,34 @@ class TestOperations(unittest.TestCase):
 
         with self.subTest("Update existing secret"):
             # Set secret
-            secrets.set_secret([], argparse.Namespace(
+            secrets.set_secret(
+                [],
+                argparse.Namespace(
                     secret_name=testvar_name,
                     secret_value=testvar_value2,
-                    stage=which_stage
-                )
+                    stage=which_stage,
+                ),
             )
 
         with self.subTest("Get updated secret value"):
             with CaptureStdout() as output:
-                secrets.get_secret([], argparse.Namespace(
-                        secret_name=testvar_name,
-                        stage=which_stage
-                    )
+                secrets.get_secret(
+                    [], argparse.Namespace(secret_name=testvar_name, stage=which_stage)
                 )
             output = "".join(output)
             self.assertIn(testvar_name, output)
             self.assertIn(testvar_value2, output)
 
         with self.subTest("Delete secret"):
-            secrets.del_secret([], argparse.Namespace(
-                    secret_name=testvar_name,
-                    stage=which_stage,
-                    force=True
-                )
+            secrets.del_secret(
+                [],
+                argparse.Namespace(
+                    secret_name=testvar_name, stage=which_stage, force=True
+                ),
             )
             # Test variable name should not be in list of secret names
             with CaptureStdout() as output:
-                secrets.list_secrets([], argparse.Namespace(
-                        stage=which_stage
-                    )
-                )
+                secrets.list_secrets([], argparse.Namespace(stage=which_stage))
             self.assertNotIn(testvar_name, output)
 
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -285,7 +285,7 @@ class TestOperations(unittest.TestCase):
         with self.subTest("Create a new secret"):
             # Use mock stdin (this cmd expects secret value from stdin)
             with MockStdin(testvar_value) as output:
-                secrets.set_secrets([], args)
+                secrets.set_secret([], args)
 
         with self.subTest("List secrets"):
             # Test variable name should be in list of secret names
@@ -295,14 +295,14 @@ class TestOperations(unittest.TestCase):
 
         with self.subTest("Get secret value"):
             with CaptureStdout() as output:
-                secrets.get_secrets([], args)
+                secrets.get_secret([], args)
             self.assertIn(testvar_name, output)
             self.assertIn(testvar_value, output)
 
         with self.subTest("Get secret value as JSON"):
             json_args = argparse.Namespace(secret_name=testvar_name, json=True)
             with CaptureStdout() as output:
-                secrets.get_secrets([], json_args)
+                secrets.get_secret([], json_args)
             # Output is a list of strings; convert to single string and read as
             # JSON/dict
             d = json.loads("".join(output))
@@ -312,16 +312,16 @@ class TestOperations(unittest.TestCase):
             args = argparse.Namespace(secret_name=testvar_name)
             # Use mock stdin (this cmd expects secret value from stdin)
             with MockStdin(testvar_value2) as output:
-                secrets.set_secrets([], args)
+                secrets.set_secret([], args)
 
         with self.subTest("Get secret value"):
             with CaptureStdout() as output:
-                secrets.get_secrets([], args)
+                secrets.get_secret([], args)
             self.assertIn(testvar_name, output)
             self.assertIn(testvar_value2, output)
 
         with self.subTest("Delete secret"):
-            secrets.del_secrets([], args)
+            secrets.del_secret([], args)
             # Test variable name should not be in list of secret names
             with CaptureStdout() as output:
                 secrets.list_secrets([], argparse.Namespace())

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -282,14 +282,6 @@ class TestOperations(unittest.TestCase):
         # - update secret value
         # - get secret value and verify it is correct
         # - delete secret
-        # 
-        # Note on mocks and testing:
-        # - we need to mock the SecretsManager to avoid
-        #   the need to give permissions to Travis tester
-        # - to test the functionality in secrets, don't mock
-        #   the functions in secrets, mock the SecretsManager
-        #   object that it uses
-        # 
         which_stage = "dev"
         which_store = os.environ["DSS_SECRETS_STORE"]
 
@@ -299,13 +291,12 @@ class TestOperations(unittest.TestCase):
         testvar_value2 = "Goodbye world!"
 
         unusedvar_name = f"{which_store}/{which_stage}/admin_user_emails"
-        unusedvar_value = "user@example.com,abc@example.com,def@example.com"
 
         with self.subTest("Create a new secret"):
             # Monkeypatch the secrets manager
             with mock.patch("dss.operations.secrets.secretsmanager") as sm:
                 # Creating a new variable will first call get, which will not find it
-                sm.get_secret_value = mock.MagicMock(return_value=None, side_effect=ClientError({},None))
+                sm.get_secret_value = mock.MagicMock(return_value=None, side_effect=ClientError({}, None))
                 # Next we will use the create secret command
                 sm.create_secret = mock.MagicMock(return_value=None)
                 # Create initial secret value
@@ -326,16 +317,16 @@ class TestOperations(unittest.TestCase):
                     def paginate(self):
                         # Return a mock page from the mock paginator
                         return [
-                                {
-                                    "SecretList": [
-                                        {
-                                            "Name": testvar_name
-                                        },
-                                        {
-                                            "Name": unusedvar_name
-                                        }
-                                    ]
-                                }
+                            {
+                                "SecretList": [
+                                    {
+                                        "Name": testvar_name
+                                    },
+                                    {
+                                        "Name": unusedvar_name
+                                    }
+                                ]
+                            }
                         ]
                 sm.get_paginator.return_value = MockPaginator()
                 # Test variable name should be in list of secret names
@@ -349,7 +340,7 @@ class TestOperations(unittest.TestCase):
                 sm.get_secret_value.return_value = {"SecretString": testvar_value}
                 # Now run get secret value in JSON mode and non-JSON mode
                 # and verify variable name/value is in both.
-                # 
+                #
                 # Start with non-JSON get call:
                 with CaptureStdout() as output:
                     secrets.get_secret(


### PR DESCRIPTION
This commit has two parts:
- additions to `tests/__init__.py` that add context manager objects to capture stdout and to feed a string to stdin
- additions to `test_operations.py` that test specific functionality added to dss operations (secrets verb)

Note: this PR is to merge into the `dss-secrets` branch (#2325), not the `master` branch