### PR TITLE
Dedicated Trufflehog CI/CD stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ variables:
   GITHUB_API: "https://api.github.com"
 
 stages:
+  - trufflehog
   - test
   - deploy
   - integration_test
@@ -22,10 +23,6 @@ before_script:
   - virtualenv ~/venv
   - source ~/venv/bin/activate
   - pip install -r requirements-dev.txt
-  - pip install trufflehog
-  - wget -O regex.json https://raw.githubusercontent.com/HumanCellAtlas/dcplib/master/components/trufflehog_regex_patterns.json
-  - trufflehog --regex --rules regex.json --entropy=False https://github.com/HumanCellAtlas/data-store.git
-  - rm regex.json
   - source environment
   - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then
   -   source environment.$CI_COMMIT_REF_NAME
@@ -39,6 +36,12 @@ before_script:
   except:
     - tags
     - schedules
+
+trufflehog:
+  script:
+    - pip install trufflehog
+    - wget -O regex.json https://raw.githubusercontent.com/HumanCellAtlas/dcplib/master/components/trufflehog_regex_patterns.json
+    - trufflehog --regex --rules regex.json --entropy=False https://github.com/HumanCellAtlas/data-store.git
 
 unit_tests:
   extends: .tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ before_script:
     - schedules
 
 trufflehog:
+  stage: trufflehog
   script:
     - pip install trufflehog
     - wget -O regex.json https://raw.githubusercontent.com/HumanCellAtlas/dcplib/master/components/trufflehog_regex_patterns.json


### PR DESCRIPTION
Move Trufflehog check to its own stage, and run it first. This prevents Trufflehog installation from contaminating release dependency verification.

![image](https://user-images.githubusercontent.com/32105697/62902098-5df6e280-bd13-11e9-89a9-079f4c343792.png)