### PR TITLE
Simplify release scripting

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,41 +133,41 @@ scale_and_performance:
 release_integration:
   extends: .release
   variables:
-    RELEASE_COMMAND: scripts/release.sh master integration --no-deploy --skip-account-verification
+    RELEASE_COMMAND: scripts/release.sh master integration
   only:
     - master
 
 force_release_integration:
   extends: .release
   variables:
-    RELEASE_COMMAND: scripts/release.sh master integration --force --no-deploy --skip-account-verification
+    RELEASE_COMMAND: scripts/release.sh master integration --force
   only:
     - master
 
 release_staging:
   extends: .release
   variables:
-    RELEASE_COMMAND: scripts/release.sh integration staging --no-deploy --skip-account-verification
+    RELEASE_COMMAND: scripts/release.sh integration staging
   only:
     - integration
 
 force_release_staging:
   extends: .release
   variables:
-    RELEASE_COMMAND: scripts/release.sh integration staging --force --no-deploy --skip-account-verification
+    RELEASE_COMMAND: scripts/release.sh integration staging --force
   only:
     - integration
 
 release_prod:
   extends: .release
   variables:
-    RELEASE_COMMAND: scripts/release.sh staging prod --no-deploy --skip-account-verification
+    RELEASE_COMMAND: scripts/release.sh staging prod
   only:
     - staging
 
 force_release_prod:
   extends: .release
   variables:
-    RELEASE_COMMAND: scripts/release.sh staging prod --force --no-deploy --skip-account-verification
+    RELEASE_COMMAND: scripts/release.sh staging prod --force
   only:
     - staging

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -87,18 +87,18 @@ export PROMOTE_FROM_BRANCH=$1 PROMOTE_DEST_BRANCH=$2
 if [[ ${CI:-} == true ]]; then
     echo "CI environment detected, skipping status checks."
 else
-	STATUS=$(${DSS_HOME}/scripts/status.py HumanCellAtlas data-store $PROMOTE_FROM_BRANCH)
-	if [[ "$STATUS" != success ]]; then
-	    if [[ $FORCE == "--force" ]]; then
-	        echo "Status was $STATUS on branch $PROMOTE_FROM_BRANCH."
-	        echo "Status checks failed on branch $PROMOTE_FROM_BRANCH. Forcing promotion and deployment anyway."
-	    else
-	        echo "Status was $STATUS on branch $PROMOTE_FROM_BRANCH."
-	        echo "Status checks failed on branch $PROMOTE_FROM_BRANCH."
-	        echo "Run with --force to promote $PROMOTE_FROM_BRANCH to $PROMOTE_DEST_BRANCH and deploy anyway."
-	        exit 1
-	    fi
-	fi
+    STATUS=$(${DSS_HOME}/scripts/status.py HumanCellAtlas data-store $PROMOTE_FROM_BRANCH)
+    if [[ "$STATUS" != success ]]; then
+        if [[ $FORCE == "--force" ]]; then
+            echo "Status was $STATUS on branch $PROMOTE_FROM_BRANCH."
+            echo "Status checks failed on branch $PROMOTE_FROM_BRANCH. Forcing promotion and deployment anyway."
+        else
+            echo "Status was $STATUS on branch $PROMOTE_FROM_BRANCH."
+            echo "Status checks failed on branch $PROMOTE_FROM_BRANCH."
+            echo "Run with --force to promote $PROMOTE_FROM_BRANCH to $PROMOTE_DEST_BRANCH and deploy anyway."
+            exit 1
+        fi
+    fi
 fi
 
 RELEASE_TAG=$(date -u +"%Y-%m-%d-%H-%M-%S")-${PROMOTE_DEST_BRANCH}.release
@@ -127,7 +127,7 @@ git push --force origin $PROMOTE_DEST_BRANCH
 git push --tags
 
 if [[ ${CI:-} == true ]]; then
-    echo "The --no-deploy flag is set. Skipping deployment."
+    echo "CI environment detected, skipping deployment."
 elif [[ -e "${DSS_HOME}/environment.${PROMOTE_DEST_BRANCH}" ]]; then
     source "${DSS_HOME}/environment.${PROMOTE_DEST_BRANCH}"
     make -C "$DSS_HOME" deploy

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,22 +6,12 @@ set -euo pipefail
 # and passes on positional arguments as $1, $2, etc.
 if [[ $# > 0 ]]; then
     FORCE=
-    NO_DEPLOY=
-    SKIP_ACCOUNT_VERIFICATION=
     POSITIONAL=()
     while [[ $# > 0 ]]; do
         key="$1"
         case $key in
             --force)
             FORCE="--force"
-            shift
-            ;;
-            --no-deploy)
-            NO_DEPLOY="--no-deploy"
-            shift
-            ;;
-            --skip-account-verification)
-            SKIP_ACCOUNT_VERIFICATION="--skip-account-verification"
             shift
             ;;
             *)
@@ -53,7 +43,9 @@ if [[ $# != 2 ]]; then
     exit 1
 fi
 
-if [[ $SKIP_ACCOUNT_VERIFICATION != "--skip-account-verification" ]]; then
+if [[ ${CI:-} == true ]]; then
+    echo "CI environment detected, skipping account verification."
+else
     echo "Please review and confirm your active AWS account configuration:"
     aws configure list
     aws sts get-caller-identity
@@ -92,17 +84,21 @@ fi
 
 export PROMOTE_FROM_BRANCH=$1 PROMOTE_DEST_BRANCH=$2
 
-STATUS=$(${DSS_HOME}/scripts/status.py HumanCellAtlas data-store $PROMOTE_FROM_BRANCH)
-if [[ "$STATUS" != success ]]; then
-    if [[ $FORCE == "--force" ]]; then
-        echo "Status was $STATUS on branch $PROMOTE_FROM_BRANCH."
-        echo "Status checks failed on branch $PROMOTE_FROM_BRANCH. Forcing promotion and deployment anyway."
-    else
-        echo "Status was $STATUS on branch $PROMOTE_FROM_BRANCH."
-        echo "Status checks failed on branch $PROMOTE_FROM_BRANCH."
-        echo "Run with --force to promote $PROMOTE_FROM_BRANCH to $PROMOTE_DEST_BRANCH and deploy anyway."
-        exit 1
-    fi
+if [[ ${CI:-} == true ]]; then
+    echo "CI environment detected, skipping status checks."
+else
+	STATUS=$(${DSS_HOME}/scripts/status.py HumanCellAtlas data-store $PROMOTE_FROM_BRANCH)
+	if [[ "$STATUS" != success ]]; then
+	    if [[ $FORCE == "--force" ]]; then
+	        echo "Status was $STATUS on branch $PROMOTE_FROM_BRANCH."
+	        echo "Status checks failed on branch $PROMOTE_FROM_BRANCH. Forcing promotion and deployment anyway."
+	    else
+	        echo "Status was $STATUS on branch $PROMOTE_FROM_BRANCH."
+	        echo "Status checks failed on branch $PROMOTE_FROM_BRANCH."
+	        echo "Run with --force to promote $PROMOTE_FROM_BRANCH to $PROMOTE_DEST_BRANCH and deploy anyway."
+	        exit 1
+	    fi
+	fi
 fi
 
 RELEASE_TAG=$(date -u +"%Y-%m-%d-%H-%M-%S")-${PROMOTE_DEST_BRANCH}.release
@@ -130,7 +126,7 @@ git tag $RELEASE_TAG
 git push --force origin $PROMOTE_DEST_BRANCH
 git push --tags
 
-if [[ $NO_DEPLOY == "--no-deploy" ]]; then
+if [[ ${CI:-} == true ]]; then
     echo "The --no-deploy flag is set. Skipping deployment."
 elif [[ -e "${DSS_HOME}/environment.${PROMOTE_DEST_BRANCH}" ]]; then
     source "${DSS_HOME}/environment.${PROMOTE_DEST_BRANCH}"


### PR DESCRIPTION
This simplifies the release scripting by skipping redundant status checks when a CI environment is detected.

Status checks were previously performed while the CI/CD pipeline was _currently running_. Since status is always `running` in this case, the check for `status==success` failed.