### PR TITLE
Assert we don't checkout to the main bucket (avoiding a sync error).

### DIFF
--- a/dss/storage/checkout/file.py
+++ b/dss/storage/checkout/file.py
@@ -18,6 +18,7 @@ def start_file_checkout(replica: Replica, blob_key, dst_bucket: typing.Optional[
     :return: The execution ID of the request.
     """
     dst_bucket = dst_bucket or replica.checkout_bucket
+    # change the assert below once the bug causing this to occur is found
     assert dst_bucket != replica.bucket, f'Cannot checkout a file from {dst_bucket} to itself!'
     source_bucket = replica.bucket
     return parallel_copy(replica, source_bucket, blob_key, dst_bucket, get_dst_key(blob_key))

--- a/dss/storage/checkout/file.py
+++ b/dss/storage/checkout/file.py
@@ -17,8 +17,8 @@ def start_file_checkout(replica: Replica, blob_key, dst_bucket: typing.Optional[
                        for the replica.
     :return: The execution ID of the request.
     """
-    if dst_bucket is None:
-        dst_bucket = replica.checkout_bucket
+    dst_bucket = dst_bucket or replica.checkout_bucket
+    assert dst_bucket != replica.bucket, f'Cannot checkout a file from {dst_bucket} to itself!'
     source_bucket = replica.bucket
     return parallel_copy(replica, source_bucket, blob_key, dst_bucket, get_dst_key(blob_key))
 


### PR DESCRIPTION
There have been some weird sync errors.
```
Unknown prefix for key 542497a4-cccc-4659-bb87-784273ed46bf/process_10.json: NotImplementedError
Traceback (most recent call last):
File "/var/task/domovoi/app.py", line 223, in __call__
result = handler(event, context)
File "/var/task/app.py", line 327, in check_deps
if dependencies_exist(source_replica, dest_replica, event["source_key"]):
File "/var/task/domovoilib/dss/events/handlers/sync.py", line 293, in dependencies_exist
raise NotImplementedError("Unknown prefix for key
{}
".format(key))
NotImplementedError: Unknown prefix for key 542497a4-cccc-4659-bb87-784273ed46bf/process_10.json
```

https://github.com/HumanCellAtlas/data-store/blob/master/dss/events/handlers/sync.py#L293

https://console.aws.amazon.com/states/home?region=us-east-1#/statemachines/view/arn:aws:states:us-east-1:861229788715:stateMachine:dss-sync-sfn-dev
https://s3.console.aws.amazon.com/s3/buckets/org-humancellatlas-dss-dev/?region=us-east-1&tab=overview
There are a ton of checkout files in the `integration` and `dev` main buckets but not in `staging` or `prod`.  This assert will hopefully smoke out the offending behavior.

There are quite a few keys in the main bucket that match.  ^

I feel like there's a checkout happening that's directing to the main bucket by mistake.