### PR TITLE
Revert "Bump httpie from 1.0.2 to 1.0.3"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -43,7 +43,7 @@ google-cloud-core==1.0.3
 google-cloud-storage==1.18.0
 google-resumable-media==0.3.2
 googleapis-common-protos==1.6.0
-httpie==1.0.3
+httpie==1.0.2
 httplib2==0.13.1
 idna==2.8
 inflection==0.3.1


### PR DESCRIPTION
Reverts HumanCellAtlas/data-store#2397

Integration test error: https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/data-store/-/jobs/44213