### PR TITLE
Replace and remove populate_lambda_ssm_parameters scripts with dss-ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,18 +147,27 @@ The DSS uses the [Amazon S3 backend](https://www.terraform.io/docs/backends/type
 1.  Run the command
 
     ```
-    ./scripts/populate_lambda_ssm_parameters.py
+    ./scripts/dss-ops.py params lambda-update
     ```
 
-	This populates the environment variables defining your stage into an AWS Simple Systems Manager parameter store.
-    These variables will be read from the parameter store and in-lined into the Lambda deployment packages during
-	deployment. This command should be executed whenever the environment variables are updated. The environments
-	of currently deployed Lambdas may optionally by updated in place with the flag `--update-deployed-lambdas`.
+    This populates the environment variables defining your stage into an AWS
+    Simple Systems Manager parameter store.  These variables are stored in a
+    single "environment" variable and will be read from the parameter store and
+    in-lined into the Lambda deployment packages during deployment. This
+    command should be executed whenever the environment variables are updated.
+    The environments of currently deployed Lambdas may optionally by updated in
+    place with the flag `--update-deployed`:
+
+    ```
+    ./scripts/dss-ops.py params lambda-update --update-deployed
+    ```
 
 1.  Choose a region that has support for Cloud Functions and set `GCP_DEFAULT_REGION` to that region. See
     [the GCP locations list](https://cloud.google.com/about/locations/) for a list of supported regions.
 
-1.  Run `gcloud config set project PROJECT_ID` **where PROJECT_ID is the ID, not the name (i.e: hca-store-21555, NOT just hca-store) of the GCP project you selected earlier**.
+1.  Run `gcloud config set project PROJECT_ID` **where `PROJECT_ID` is the ID,
+    not the name (i.e., `hca-store-21555`, NOT just `hca-store`) of the GCP
+    project you selected earlier**.
 
 1.  Enable required APIs:
 

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# This script sets the version variable DSS_VERSION into the SSM parameter contianing
-# the environment variables used when deploying lambdas, and into all deployed lambdas
+# This script sets the version variable DSS_VERSION into the SSM parameter
+# containing the environment variables used when deploying lambdas, and into
+# all deployed lambdas
 
 set -euo pipefail
 
@@ -18,4 +19,6 @@ else
     version=$(git describe --tags --always)
 fi
 
-scripts/populate_lambda_ssm_parameters.py --set DSS_VERSION=${version}
+# Update lambda environment in SSM param store, and update deployed lambdas
+scripts/dss-ops.py params ssm-set --name DSS_VERSION --value ${version}
+scripts/dss-ops.py params lambda-set --name DSS_VERSION --value ${version}


### PR DESCRIPTION
Closes #2389 (issue - replace and remove populate_lambda_ssm_parameters script)

This pull request is a follow-on to PR #2324 (adding parameter store and lambda environment functionality to DSS operations tooling). PR #2324 adds new functionality to dss-ops, this pull request removes the old `populate_lambda_ssm_parameters.py` functionality and references to it in readmes, documentation, and scripts.

This pull request needs to be tested on allspark, since it affects several infrastructure scripts.