### PR TITLE
DSS Sync: skip sync on file parts

### DIFF
--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -21,6 +21,7 @@ from dss.logging import configure_lambda_logging
 from dss.events.handlers.sync import (compose_upload, initiate_multipart_upload, complete_multipart_upload, copy_part,
                                       exists, get_part_size, get_sync_work_state, parts_per_worker, dependencies_exist,
                                       do_oneshot_copy, sync_sfn_dep_wait_sleep_seconds, sync_sfn_num_threads)
+from dss.storage.identifiers import BLOB_KEY_REGEX
 
 configure_lambda_logging()
 logger = logging.getLogger(__name__)
@@ -108,6 +109,9 @@ def launch_from_operator_queue(event, context):
         bucket = source_replica.bucket
         if exists(dest_replica, key):
             logger.info("Key %s already exists in %s, skipping sync", key, dest_replica)
+            continue
+        if not BLOB_KEY_REGEX.match(key):
+            logger.info("Key %s does not match blob key format, skipping sync", key)
             continue
         try:
             size = Config.get_blobstore_handle(source_replica).get_size(bucket, key)

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -115,9 +115,6 @@ def launch_from_operator_queue(event, context):
         if exists(dest_replica, key):
             logger.info("Key %s already exists in %s, skipping sync", key, dest_replica)
             continue
-        if key.startswith(BLOB_PREFIX) and not BLOB_KEY_REGEX.match(key):
-            logger.info("Key %s does not match blob key format, skipping sync", key)
-            continue
         try:
             size = Config.get_blobstore_handle(source_replica).get_size(bucket, key)
         except BlobNotFoundError:

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -77,6 +77,9 @@ def launch_from_forwarded_event(event, context):
             source_replica = Replica.gcp
             source_key = message["name"]
             bucket = source_replica.bucket
+            if source_key.startswith(BLOB_PREFIX) and not BLOB_KEY_REGEX.match(source_key):
+                logger.info("Key %s does not match blob key format, skipping sync", source_key)
+                continue
             for dest_replica in Config.get_replication_destinations(source_replica):
                 if exists(dest_replica, source_key):
                     logger.info("Key %s already exists in %s, skipping sync", source_key, dest_replica)

--- a/daemons/dss-sync-sfn/app.py
+++ b/daemons/dss-sync-sfn/app.py
@@ -21,7 +21,7 @@ from dss.logging import configure_lambda_logging
 from dss.events.handlers.sync import (compose_upload, initiate_multipart_upload, complete_multipart_upload, copy_part,
                                       exists, get_part_size, get_sync_work_state, parts_per_worker, dependencies_exist,
                                       do_oneshot_copy, sync_sfn_dep_wait_sleep_seconds, sync_sfn_num_threads)
-from dss.storage.identifiers import BLOB_KEY_REGEX
+from dss.storage.identifiers import BLOB_KEY_REGEX, BLOB_PREFIX
 
 configure_lambda_logging()
 logger = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ def launch_from_operator_queue(event, context):
         if exists(dest_replica, key):
             logger.info("Key %s already exists in %s, skipping sync", key, dest_replica)
             continue
-        if not BLOB_KEY_REGEX.match(key):
+        if key.startswith(BLOB_PREFIX) and not BLOB_KEY_REGEX.match(key):
             logger.info("Key %s does not match blob key format, skipping sync", key)
             continue
         try:

--- a/dss/api/files.py
+++ b/dss/api/files.py
@@ -19,6 +19,7 @@ from dss.storage.checkout import CheckoutTokenKeys
 from dss.storage.checkout.file import get_dst_key, start_file_checkout
 from dss.storage.files import write_file_metadata
 from dss.storage.hcablobstore import FileMetadata, HCABlobStore, compose_blob_key
+from dss.storage.identifiers import blob_checksum_format as checksum_format
 from dss.stepfunctions import gscopyclient, s3copyclient
 from dss.util import tracing, UrlBuilder, security
 from dss.util.async_state import AsyncStateItem, AsyncStateError
@@ -34,17 +35,6 @@ retry request after the specified interval."""
 RETRY_AFTER_INTERVAL = 10
 
 logger = logging.getLogger(__name__)
-checksum_format = {
-    # These are regular expressions that are used to verify the forms of
-    # checksums provided to a `PUT /file/{uuid}` API call. You can see the
-    # same ones in the Swagger spec (see definitions.file_version).
-    'hca-dss-crc32c': r'^[a-z0-9]{8}$',
-    'hca-dss-s3_etag': r'^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2'
-                       r'}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|9'
-                       r'9[0-8][0-9]|999[0-9]|10000))?$',
-    'hca-dss-sha1': r'^[a-z0-9]{40}$',
-    'hca-dss-sha256': r'^[a-z0-9]{64}$'
-}
 
 
 @dss_handler

--- a/dss/storage/identifiers.py
+++ b/dss/storage/identifiers.py
@@ -10,6 +10,25 @@ COLLECTION_PREFIX = "collections"
 # versioned tombstones are indexed after all bundles during a reindex operation.
 TOMBSTONE_SUFFIX = "dead"
 
+blob_checksum_format = {
+    # These are regular expressions that are used to verify the forms of
+    # checksums provided to a `PUT /file/{uuid}` API call. You can see the
+    # same ones in the Swagger spec (see definitions.file_version).
+    'hca-dss-crc32c': r'^[a-z0-9]{8}$',
+    'hca-dss-s3_etag': r'^[a-z0-9]{32}(-([2-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2'
+                       r'}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|9'
+                       r'9[0-8][0-9]|999[0-9]|10000))?$',
+    'hca-dss-sha1': r'^[a-z0-9]{40}$',
+    'hca-dss-sha256': r'^[a-z0-9]{64}$'
+}
+
+blob_checksum_format_pure = {key: value.strip('$^') for key, value in blob_checksum_format.items()}
+BLOB_KEY_REGEX = re.compile(f'^(blobs)/'
+                            f'({blob_checksum_format_pure["hca-dss-sha256"]}).'
+                            f'({blob_checksum_format_pure["hca-dss-sha1"]}).'
+                            f'({blob_checksum_format_pure["hca-dss-s3_etag"]}).'
+                            f'({blob_checksum_format_pure["hca-dss-crc32c"]})$')
+
 # does not allow caps
 # (though our swagger params allow users to input this, s3 keys are changed to lowercase after ingestion)
 UUID_PATTERN = "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -278,7 +278,7 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
         gcp_parts = f"blobs/{self.generate_random_blob_key()}.partA"
         temp_etag_modification = f"blobs/{self.generate_random_blob_key()}"
         temp_etag_modification = temp_etag_modification.rsplit('.')
-        temp_etag_modification[2] = temp_etag_modification[2] + f'-{random.choice(string.digits)}'
+        temp_etag_modification[2] = temp_etag_modification[2] + f'-{random.choice([x for x in range(2,10000)])}'
         aws_parts = '.'.join(temp_etag_modification)
 
         expected_results = {"good_blob_key": (good_blob_key, 7),  # good blobs have 7 parts, (e_tag takes 3)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 import base64
+import binascii
 import datetime
 import io
 import logging
@@ -260,6 +261,13 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
                 with self.subTest(part_size=part_size, object_size=event['source_obj_metadata']['size']):
                     self.assertEqual(sync.get_sync_work_state(event)['total_parts'], expected_total_parts)
 
+    def get_random_blob(self):
+        random_uuid = str(uuid.uuid4())
+
+        crc = binascii.crc32(str.encode(random_uuid))
+        random_blob =
+        return random_blob
+
     def test_blob_key_format(self):
         good_blob_key = 'blobs/015b0751073d17e358989649bc49f7e2bcf544073a98bf24d762fbe5c6468cb3.' \
                         'd3c4a8f1aadcf6036c9c7ca5e80189fce3f12629.70910bba1cc60b415f34254f7e0d9673.93d22640'
@@ -281,6 +289,7 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
             self.assertEquals(num_groups, v[1])
 
     def test_skip_part_sync(self):
+
         json_message = json.dumps({"bucket": "org-humancellatlas-dss-dev",
                                    "componentCount": 30,
                                    "contentType": "application/octet-stream",
@@ -316,6 +325,9 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
                  }
         results = daemon_app.launch_from_forwarded_event(event, None)
         self.assertFalse(results)
+        results = daemon_app.launch_from_s3_event(event, None)
+        self.assertFalse(results)
+
 # TODO: (akislyuk) integration test of SQS fault injection, SFN fault injection
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -299,8 +299,8 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
                                    "metageneration": "1",
                                    "name": random_part_blob,
                                    "resourceState": "exists",
-                                   "selfLink": f"https://www.googleapis.com/storage/v1/b/org-humancellatlas-dss-staging/"
-                                               f"o/{random_part_blob}",
+                                   "selfLink": f"https://www.googleapis.com/storage/v1/b/"
+                                   f"org-humancellatlas-dss-staging/o/{random_part_blob}",
                                    "size": "19658416372",
                                    "storageClass": "MULTI_REGIONAL",
                                    "timeCreated": "2019-09-17T05:20:01.122Z",
@@ -321,11 +321,14 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
         random_part_blob = f"blobs/{self.generate_random_blob_key()}.partc"
 
         class MagicBucket(object):
-            name = "magic_bucket"
+            name = self.s3_bucket_name
+
             def __init__(bucket_self, *args):
                 pass
+
             class Object(object):
                 key = random_part_blob
+
                 def __init__(self, *args):
                     pass
 
@@ -337,7 +340,7 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
         }]}
 
         # Note that MagicBucket must provide anything the callee asks of Bucket
-        thisBucket = mock_resource.s3.Bucket = mock.MagicMock(return_value=MagicBucket())
+        thisBucket = mock_resource.s3.Bucket = mock.MagicMock(return_value=MagicBucket())  # noqa
         results = daemon_app.launch_from_s3_event(event, None)
         self.assertFalse(results)
 # TODO: (akislyuk) integration test of SQS fault injection, SFN fault injection

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -26,7 +26,6 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import importlib
-daemon_app = importlib.import_module('daemons.dss-sync-sfn.app')
 import dss
 from dss.api import bundles as bundles_api
 from dss.api import files as files_api
@@ -35,13 +34,14 @@ from dss.events.handlers import sync
 from dss.logging import configure_test_logging
 from dss.util import UrlBuilder
 from dss.util.streaming import get_pool_manager, S3SigningChunker
-from dss.storage.identifiers import FILE_PREFIX, BUNDLE_PREFIX, COLLECTION_PREFIX, FileFQID, BundleFQID, CollectionFQID, \
-    BLOB_KEY_REGEX
+from dss.storage.identifiers import FILE_PREFIX, BUNDLE_PREFIX, COLLECTION_PREFIX, FileFQID, BundleFQID,\
+    CollectionFQID, BLOB_KEY_REGEX
 from dss.storage.hcablobstore import BundleFileMetadata, BundleMetadata, FileMetadata, compose_blob_key
 from tests import get_auth_header
 from tests.infra.server import ThreadedLocalServer
 from tests import eventually, get_version, get_collection_fqid
 from tests.infra import testmode
+daemon_app = importlib.import_module('daemons.dss-sync-sfn.app')
 
 def setUpModule():
     configure_test_logging()
@@ -312,10 +312,10 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
                  "21a11df0cf55b1e197cf27d4185221dd9d909797.cbc62efcbe1a02c5b2f2fc38dce59287-933.5d0be7cf"
                  ".partc",
                  "body": json.dumps({"Message": json_message})
-                  }]
-                }
+                 }]
+                 }
         results = daemon_app.launch_from_forwarded_event(event, None)
-        print(results)
+        self.assertFalse(results)
 # TODO: (akislyuk) integration test of SQS fault injection, SFN fault injection
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -276,11 +276,16 @@ class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
         bad_blob_key = f"blobs/{self.generate_random_blob_key()[:-1]}"
         missing_prefix = f"{self.generate_random_blob_key()}"
         gcp_parts = f"blobs/{self.generate_random_blob_key()}.partA"
+        temp_etag_modification = f"blobs/{self.generate_random_blob_key()}"
+        temp_etag_modification = temp_etag_modification.rsplit('.')
+        temp_etag_modification[2] = temp_etag_modification[2] + f'-{random.choice(string.digits)}'
+        aws_parts = '.'.join(temp_etag_modification)
 
         expected_results = {"good_blob_key": (good_blob_key, 7),  # good blobs have 7 parts, (e_tag takes 3)
                             "bad_blob_key": (bad_blob_key, None),
                             "missing_prefix": (missing_prefix, None),
-                            "gcp_parts": (gcp_parts, None)}
+                            "gcp_parts": (gcp_parts, None),
+                            "aws_parts": (aws_parts, 7)}
 
         for k, v in expected_results.items():
             match = BLOB_KEY_REGEX.match(v[0])


### PR DESCRIPTION
skips sync if blob key does not match `blob/{sha256}-{sha1}-{s3_etag}-{crc32c}`