### PR TITLE
Add SSM parameter store functionality to dss-ops

### DIFF
--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -37,7 +37,7 @@ def get_ssm_variable_prefix() -> str:
 def fix_ssm_variable_prefix(param_name: str) -> str:
     """Add the variable store and stage prefix to the front of an SSM param name"""
     prefix = get_ssm_variable_prefix()
-    if not param_name.startswith(prefix):
+    if not (param_name.startswith(prefix) or param_name.startswith("/"+prefix)):
         param_name = f"{prefix}/{param_name}"
     return param_name
 
@@ -152,7 +152,7 @@ def ssm_set(argv: typing.List[str], args: argparse.Namespace):
         print(f'Name: {name}')
         print(f'Value: {val}')
     else:
-        set_ssm_var(name, val)
+        set_ssm_parameter(name, val)
 
 
 @ssm_params.action(
@@ -175,4 +175,4 @@ def ssm_unset(argv: typing.List[str], args: argparse.Namespace):
     if args.dry_run:
         print(f'Dry-run deleting variable "{name}" from SSM store')
     else:
-        unset_ssm_var(name)
+        unset_ssm_parameter(name)

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -1,12 +1,17 @@
 """
 Get and set parameters in the "environment" variable in the SSM parameter store.
-These parameters are used in a way that is similar to environment variables.
+
+Parameters in the SSM store are utilized similar to environment variables. Any parameter set with
+this script will be stored in the SSM parameter store, in the "environment" variable, which is
+stored as a serialized JSON object with key-value pairs.
 """
 import os
 import sys
 import select
 import json
 import argparse
+import logging
+import typing
 
 from botocore.exceptions import ClientError
 

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -65,10 +65,7 @@ def set_ssm_parameter(env_var: str, value) -> None:
     :param value: the value of the environment variable being set
     """
     environment = get_ssm_environment()
-    try:
-        prev_value = environment[env_var]
-    except KeyError:
-        prev_value = None
+    prev_value = environment.get(env_var)
     environment[env_var] = value
     set_ssm_environment(environment)
     print(f"Success! Set variable in SSM parameter store environment:")

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -34,7 +34,7 @@ def get_ssm_variable_prefix() -> str:
 def fix_ssm_variable_prefix(param_name: str) -> str:
     """Add the variable store and stage prefix to the front of an SSM param name"""
     prefix = get_ssm_variable_prefix()
-    if not (param_name.startswith(prefix) or param_name.startswith("/"+prefix)):
+    if not (param_name.startswith(prefix) or param_name.startswith("/" + prefix)):
         param_name = f"{prefix}/{param_name}"
     return param_name
 
@@ -43,7 +43,7 @@ def get_ssm_environment() -> dict:
     """Get the value of the parameter named "environment" in the SSM param store"""
     prefix = get_ssm_variable_prefix()
     p = ssm_client.get_parameter(Name=f"/{prefix}/environment")
-    parms = p["Parameter"]["Value"] # this is a string, so convert to dict
+    parms = p["Parameter"]["Value"]  # this is a string, so convert to dict
     return json.loads(parms)
 
 
@@ -74,14 +74,14 @@ def set_ssm_parameter(env_var: str, value) -> None:
         prev_value = None
     environment[env_var] = value
     set_ssm_environment(environment)
-    print(f'Success! Set variable in SSM parameter store environment:')
-    print(f'Name: {env_var}')
-    print(f'Value: {value}')
+    print(f"Success! Set variable in SSM parameter store environment:")
+    print(f"Name: {env_var}")
+    print(f"Value: {value}")
     if prev_value:
-        print(f'Previous value: {prev_value}')
+        print(f"Previous value: {prev_value}")
 
 
-def unset_ssm_parameter(env_var: str) -> None: 
+def unset_ssm_parameter(env_var: str) -> None:
     """
     Unset a parameter in the SSM param store variable "environment".
 
@@ -92,11 +92,11 @@ def unset_ssm_parameter(env_var: str) -> None:
         prev_value = environment[env_var]
         del environment[env_var]
         set_ssm_environment(environment)
-        print(f'Success! Unset variable in SSM parameter store environment:')
-        print(f'Name: {env_var} ')
-        print(f'Previous value: {prev_value}')
+        print(f"Success! Unset variable in SSM parameter store environment:")
+        print(f"Name: {env_var} ")
+        print(f"Previous value: {prev_value}")
     except KeyError:
-        print(f'Nothing to unset for variable {env_var} in SSM parameter store environment')
+        print(f"Nothing to unset for variable {env_var} in SSM parameter store environment")
 
 
 ssm_params = dispatch.target("params", arguments={}, help=__doc__)
@@ -105,12 +105,8 @@ ssm_params = dispatch.target("params", arguments={}, help=__doc__)
 @ssm_params.action(
     "list",
     arguments={
-        "--json": dict(
-            default=False,
-            action="store_true",
-            help="format the output as JSON"
-        )
-    }
+        "--json": dict(default=False, action="store_true", help="format the output as JSON")
+    },
 )
 def ssm_list(argv: typing.List[str], args: argparse.Namespace):
     """Print out all variables stored in the SSM store"""
@@ -126,29 +122,25 @@ def ssm_list(argv: typing.List[str], args: argparse.Namespace):
 @ssm_params.action(
     "set",
     arguments={
-        "name": dict(
-            help="name of variable to set in SSM param store environment"
-        ),
+        "name": dict(help="name of variable to set in SSM param store environment"),
         "--dry-run": dict(
-            default=False,
-            action="store_true",
-            help="do a dry run of the actual operation",
-        )
-    }
+            default=False, action="store_true", help="do a dry run of the actual operation"
+        ),
+    },
 )
 def ssm_set(argv: typing.List[str], args: argparse.Namespace):
     """Set a variable in the SSM param store environment"""
     name = args.name
 
     # Use stdin (input piped to script)
-    if not select.select([sys.stdin,], [], [], 0.0)[0]:
+    if not select.select([sys.stdin], [], [], 0.0)[0]:
         raise RuntimeError("Error: stdin was empty! A variable value must be provided via stdin")
     val = sys.stdin.read()
 
     if args.dry_run:
-        print(f'Dry-run creating variable in SSM param store environment:')
-        print(f'Name: {name}')
-        print(f'Value: {val}')
+        print(f"Dry-run creating variable in SSM param store environment:")
+        print(f"Name: {name}")
+        print(f"Value: {val}")
     else:
         set_ssm_parameter(name, val)
 
@@ -156,15 +148,11 @@ def ssm_set(argv: typing.List[str], args: argparse.Namespace):
 @ssm_params.action(
     "unset",
     arguments={
-        "name": dict(
-            help="name of variable to unset in SSM param store environment"
-        ),
+        "name": dict(help="name of variable to unset in SSM param store environment"),
         "--dry-run": dict(
-            default=False,
-            action="store_true",
-            help="do a dry run of the actual operation",
-        )
-    }
+            default=False, action="store_true", help="do a dry run of the actual operation"
+        ),
+    },
 )
 def ssm_unset(argv: typing.List[str], args: argparse.Namespace):
     name = args.name

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -1,9 +1,6 @@
 """
-Get and set parameters in the "environment" variable in the SSM parameter store.
-
-Parameters in the SSM store are utilized similar to environment variables. Any parameter set with
-this script will be stored in the SSM parameter store, in the "environment" variable, which is
-stored as a serialized JSON object with key-value pairs.
+Get and set parameters in the SSM parameter store "environment". Parameters are stored as key-value
+pairs in a map named "environment" (stored in the SSM param store).
 """
 import os
 import sys
@@ -141,7 +138,7 @@ def ssm_set(argv: typing.List[str], args: argparse.Namespace):
     name = args.name
 
     # Use stdin (input piped to script)
-    if not select.select([sys.stdin], [], [])[0]:
+    if not select.select([sys.stdin,], [], [], 0.0)[0]:
         raise RuntimeError("Error: stdin was empty! A variable value must be provided via stdin")
     val = sys.stdin.read()
 

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -60,10 +60,17 @@ def set_ssm_environment(env: dict) -> None:
 ssm_params = dispatch.target("params", arguments={}, help=__doc__)
 
 
+dryrun_flag_options = dict(
+    default=False, action="store_true", help="do a dry run of the actual operation"
+)
+
+
 @ssm_params.action(
     "list",
     arguments={
-        "--json": dict(default=False, action="store_true", help="format the output as JSON")
+        "--json": dict(
+            default=False, action="store_true", help="format the output as JSON if this flag is present"
+        )
     },
 )
 def ssm_list(argv: typing.List[str], args: argparse.Namespace):
@@ -81,9 +88,7 @@ def ssm_list(argv: typing.List[str], args: argparse.Namespace):
     "set",
     arguments={
         "name": dict(help="name of variable to set in SSM store under $DSS_DEPLOYMENT_STAGE/environment"),
-        "--dry-run": dict(
-            default=False, action="store_true", help="do a dry run of the actual operation"
-        ),
+        "--dry-run": dryrun_flag_options
     },
 )
 def ssm_set(argv: typing.List[str], args: argparse.Namespace):
@@ -114,9 +119,7 @@ def ssm_set(argv: typing.List[str], args: argparse.Namespace):
     "unset",
     arguments={
         "name": dict(help="name of variable to unset in SSM param store environment"),
-        "--dry-run": dict(
-            default=False, action="store_true", help="do a dry run of the actual operation"
-        ),
+        "--dry-run": dryrun_flag_options
     },
 )
 def ssm_unset(argv: typing.List[str], args: argparse.Namespace):

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -13,11 +13,8 @@ import typing
 from botocore.exceptions import ClientError
 
 from dss.operations import dispatch
-from dss.util.aws.clients import secretsmanager  # type: ignore
 import dss.operations.util as util
-
 from dss.util.aws.clients import ssm as ssm_client  # type: ignore
-from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore
 
 
 logger = logging.getLogger(__name__)

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -1,5 +1,6 @@
 """
-Get and set parameters in the SSM parameter store
+Get and set parameters in the "environment" variable in the SSM parameter store.
+These parameters are used in a way that is similar to environment variables.
 """
 import os
 import sys
@@ -20,9 +21,8 @@ from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore
 logger = logging.getLogger(__name__)
 
 
-
 def get_ssm_variable_prefix() -> str:
-    """Use info from environment to assemble necessary prefix for SSM parameter store variables"""
+    """Use info from local environment to assemble necessary prefix for SSM param store variables"""
     store_name = os.environ["DSS_PARAMETER_STORE"]
     stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
     store_prefix = f"{store_name}/{stage_name}"
@@ -30,10 +30,67 @@ def get_ssm_variable_prefix() -> str:
 
 
 def fix_ssm_variable_prefix(param_name: str) -> str:
-    """Adds the variable store and stage prefix to the front of an ssm parameter name"""
+    """Add the variable store and stage prefix to the front of an SSM param name"""
     prefix = get_ssm_variable_prefix()
     if not param_name.startswith(prefix):
         param_name = f"{prefix}/{param_name}"
     return param_name
 
 
+def get_ssm_environment() -> dict:
+    """Get the value of the parameter named "environment" in the SSM param store"""
+    prefix = get_ssm_variable_prefix()
+    p = ssm_client.get_parameter(Name=f"/{prefix}/environment")
+    parms = p["Parameter"]["Value"] # this is a string, so convert to dict
+    return json.loads(parms)
+
+
+def set_ssm_environment(env: dict) -> None:
+    """
+    Set the SSM param store param "environment" to the values in env (dict).
+
+    :param env: dict containing environment variables to set in SSM param store
+    :returns: nothing
+    """
+    prefix = get_ssm_variable_prefix()
+    ssm_client.put_parameter(
+        Name=f"/{prefix}/environment", Value=json.dumps(env), Type="String", Overwrite=True
+    )
+
+
+def set_ssm_parameter(environment: dict, set_env_fn, env_var: str, value) -> None:
+    """
+    Set a parameter in the SSM param store variable "environment".
+
+    :param environment: a dictionary containing environment variables
+    :param set_env_fn: a function handle that will set the SSM parameter variable "environment"
+    :param env_var: the name of the environment variable being set
+    :param value: the value of the environment variable being set
+    """
+    try:
+        prev_value = environment[env_var]
+    except:
+        prev_value = None
+    environment[env_var] = value
+    set_env_fn(environment)
+    print(f'Set variable {env_var} in SSM param store environment')
+    if prev_value:
+        print(f'Previous value: {prev_value}')
+
+
+def unset_ssm_parameter(environment: dict, set_env_fn, env_var: str) -> None: 
+    """
+    Unset a parameter in the SSM param store variable "environment".
+
+    :param environment: a dictionary containing environment variables
+    :param set_env_fn: a function handle that will set the SSM parameter variable "environment"
+    :param env_var: the name of the environment variable being set
+    """
+    try:
+        prev_value = environment[env_var]
+        del environment[env_var]
+        env_set_fn(environment)
+        print(f'Unset variable {env_var} in SSM param store environment')
+        print(f'Previous value: {prev_value}')
+    except KeyError:
+        print(f'Nothing to unset for variable "{env_var}" in SSM param store environment')

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -74,7 +74,9 @@ def set_ssm_parameter(env_var: str, value) -> None:
         prev_value = None
     environment[env_var] = value
     set_ssm_environment(environment)
-    print(f'Set variable {env_var} in SSM param store environment')
+    print(f'Success! Set variable in SSM parameter store environment:')
+    print(f'Name: {env_var}')
+    print(f'Value: {value}')
     if prev_value:
         print(f'Previous value: {prev_value}')
 
@@ -90,10 +92,11 @@ def unset_ssm_parameter(env_var: str) -> None:
         prev_value = environment[env_var]
         del environment[env_var]
         set_ssm_environment(environment)
-        print(f'Unset variable {env_var} in SSM param store environment')
+        print(f'Success! Unset variable in SSM parameter store environment:')
+        print(f'Name: {env_var} ')
         print(f'Previous value: {prev_value}')
     except KeyError:
-        print(f'Nothing to unset for variable {env_var} in SSM param store environment')
+        print(f'Nothing to unset for variable {env_var} in SSM parameter store environment')
 
 
 ssm_params = dispatch.target("params", arguments={}, help=__doc__)

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -1,0 +1,39 @@
+"""
+Get and set parameters in the SSM parameter store
+"""
+import os
+import sys
+import select
+import json
+import argparse
+
+from botocore.exceptions import ClientError
+
+from dss.operations import dispatch
+from dss.util.aws.clients import secretsmanager  # type: ignore
+import dss.operations.util as util
+
+from dss.util.aws.clients import ssm as ssm_client  # type: ignore
+from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+
+
+def get_ssm_variable_prefix() -> str:
+    """Use info from environment to assemble necessary prefix for SSM parameter store variables"""
+    store_name = os.environ["DSS_PARAMETER_STORE"]
+    stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
+    store_prefix = f"{store_name}/{stage_name}"
+    return store_prefix
+
+
+def fix_ssm_variable_prefix(param_name: str) -> str:
+    """Adds the variable store and stage prefix to the front of an ssm parameter name"""
+    prefix = get_ssm_variable_prefix()
+    if not param_name.startswith(prefix):
+        param_name = f"{prefix}/{param_name}"
+    return param_name
+
+

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -63,42 +63,40 @@ def set_ssm_environment(env: dict) -> None:
     )
 
 
-def set_ssm_parameter(environment: dict, set_env_fn, env_var: str, value) -> None:
+def set_ssm_parameter(env_var: str, value) -> None:
     """
     Set a parameter in the SSM param store variable "environment".
 
-    :param environment: a dictionary containing environment variables
-    :param set_env_fn: a function handle that will set the SSM parameter variable "environment"
     :param env_var: the name of the environment variable being set
     :param value: the value of the environment variable being set
     """
+    environment = get_ssm_environment()
     try:
         prev_value = environment[env_var]
-    except:
+    except KeyError:
         prev_value = None
     environment[env_var] = value
-    set_env_fn(environment)
+    set_ssm_environment(environment)
     print(f'Set variable {env_var} in SSM param store environment')
     if prev_value:
         print(f'Previous value: {prev_value}')
 
 
-def unset_ssm_parameter(environment: dict, set_env_fn, env_var: str) -> None: 
+def unset_ssm_parameter(env_var: str) -> None: 
     """
     Unset a parameter in the SSM param store variable "environment".
 
-    :param environment: a dictionary containing environment variables
-    :param set_env_fn: a function handle that will set the SSM parameter variable "environment"
     :param env_var: the name of the environment variable being set
     """
+    environment = get_ssm_environment()
     try:
         prev_value = environment[env_var]
         del environment[env_var]
-        env_set_fn(environment)
+        set_ssm_environment(environment)
         print(f'Unset variable {env_var} in SSM param store environment')
         print(f'Previous value: {prev_value}')
     except KeyError:
-        print(f'Nothing to unset for variable "{env_var}" in SSM param store environment')
+        print(f'Nothing to unset for variable {env_var} in SSM param store environment')
 
 
 ssm_params = dispatch.target("params", arguments={}, help=__doc__)

--- a/scripts/dss-ops.py
+++ b/scripts/dss-ops.py
@@ -13,6 +13,7 @@ import dss
 import dss.operations.checkout
 import dss.operations.storage
 import dss.operations.sync
+import dss.operations.ssm_params
 import dss.operations.elasticsearch
 import dss.operations.events
 import dss.operations.secrets

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -166,7 +166,7 @@ class SwapStdin(object):
     def __init__(self, *, input=None):
         if input is None:
             raise RuntimeError("Error: SwapStdin object was not provided with an 'input' keyword arg")
-        elif isinstance(input, ""):
+        elif isinstance(input, type("")):
             input = bytes(input, 'utf-8')
         self.input = input
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -163,12 +163,12 @@ class CaptureStdout(list):
 
 class SwapStdin(object):
     """Utility object using a context manager to swap out stdin with user-provided data."""
-    def __init__(self, *, input=None):
-        if input is None:
-            raise RuntimeError("Error: SwapStdin object was not provided with an 'input' keyword arg")
-        elif isinstance(input, type("")):
-            input = bytes(input, 'utf-8')
-        self.input = input
+    def __init__(self, swap_with):
+        if swap_with is None:
+            raise RuntimeError("Error: SwapStdin constructor must be provided with a value to substitute for stdin!")
+        elif isinstance(swap_with, type("")):
+            swap_with = bytes(swap_with, 'utf-8')
+        self.swap_with = swap_with
 
     def __enter__(self, *args, **kwargs):
         """
@@ -177,14 +177,12 @@ class SwapStdin(object):
         the pipe, so we create a pipe and fill it with mock data, then swap it out with stdin.
         """
         fdr, fdw = os.pipe()
-        os.write(fdw, self.input)
+        os.write(fdw, self.swap_with)
         os.close(fdw)
         f = os.fdopen(fdr)  # use the file descriptor directly
-
-        self._stdin = sys.stdin
         sys.stdin = f
 
         return self
 
     def __exit__(self, *args, **kwargs):
-        sys.stdin = self._stdin
+        sys.stdin = sys.__stdin__

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -166,7 +166,7 @@ class SwapStdin(object):
     def __init__(self, *, input=None):
         if input is None:
             raise RuntimeError("Error: SwapStdin object was not provided with an 'input' keyword arg")
-        elif type(input) == type(""):
+        elif isinstance(input, ""):
             input = bytes(input, 'utf-8')
         self.input = input
 
@@ -179,7 +179,7 @@ class SwapStdin(object):
         fdr, fdw = os.pipe()
         os.write(fdw, self.input)
         os.close(fdw)
-        f = os.fdopen(fdr) # use the file descriptor directly
+        f = os.fdopen(fdr)  # use the file descriptor directly
 
         self._stdin = sys.stdin
         sys.stdin = f

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -444,15 +444,14 @@ class TestOperations(unittest.TestCase):
         ssm_new_env = _wrap_ssm_env(new_env)
 
         with self.subTest("Create a new SSM parameter"):
-            with mock.patch("dss.operations.ssm_params.ssm_client") as ssm:
-                with SwapStdin(input=testvar_value):
-                    # ssm_set in ssm_params.py first calls ssm.get_parameter to get the entire environment
-                    ssm.get_parameter = mock.MagicMock(return_value=ssm_old_env)
-                    # ssm_set then calls ssm.put_parameter to put the entire environment
-                    ssm.put_parameter = mock.MagicMock(return_value=None)
-                    ssm_params.ssm_set(
-                        [], argparse.Namespace(name=testvar_name, dry_run=False)
-                    )
+            with mock.patch("dss.operations.ssm_params.ssm_client") as ssm, SwapStdin(testvar_value):
+                # ssm_set in ssm_params.py first calls ssm.get_parameter to get the entire environment
+                ssm.get_parameter = mock.MagicMock(return_value=ssm_old_env)
+                # ssm_set then calls ssm.put_parameter to put the entire environment
+                ssm.put_parameter = mock.MagicMock(return_value=None)
+                ssm_params.ssm_set(
+                    [], argparse.Namespace(name=testvar_name, dry_run=False)
+                )
 
         with self.subTest("List SSM parameters"):
             with mock.patch("dss.operations.ssm_params.ssm_client") as ssm:
@@ -472,29 +471,20 @@ class TestOperations(unittest.TestCase):
                 self.assertIn(testvar_name, d)
 
         with self.subTest("Update existing SSM parameter"):
-            with mock.patch("dss.operations.ssm_params.ssm_client") as ssm:
-                with SwapStdin(input=testvar_value2):
-                    # Mock the same way we did for set new param above
-                    ssm.get_parameter = mock.MagicMock(return_value=ssm_new_env)
-                    ssm.put_parameter = mock.MagicMock(return_value=None)
-                    ssm_params.ssm_set(
-                        [], argparse.Namespace(name=testvar_name, dry_run=True)
-                    )
-                    ssm_params.ssm_set(
-                        [], argparse.Namespace(name=testvar_name, dry_run=False)
-                    )
+            with mock.patch("dss.operations.ssm_params.ssm_client") as ssm, SwapStdin(testvar_value2):
+                # Mock the same way we did for set new param above
+                ssm.get_parameter = mock.MagicMock(return_value=ssm_new_env)
+                ssm.put_parameter = mock.MagicMock(return_value=None)
+                ssm_params.ssm_set([], argparse.Namespace(name=testvar_name, dry_run=True))
+                ssm_params.ssm_set([], argparse.Namespace(name=testvar_name, dry_run=False))
 
         with self.subTest("Unset SSM parameter"):
             with mock.patch("dss.operations.ssm_params.ssm_client") as ssm:
                 # Mock the same way we did for set new secret above
                 ssm.get_parameter = mock.MagicMock(return_value=ssm_new_env)
                 ssm.put_parameter = mock.MagicMock(return_value=None)
-                ssm_params.ssm_unset(
-                    [], argparse.Namespace(name=testvar_name, dry_run=True)
-                )
-                ssm_params.ssm_unset(
-                    [], argparse.Namespace(name=testvar_name, dry_run=False)
-                )
+                ssm_params.ssm_unset([], argparse.Namespace(name=testvar_name, dry_run=True))
+                ssm_params.ssm_unset([], argparse.Namespace(name=testvar_name, dry_run=False))
 
 
 @testmode.integration


### PR DESCRIPTION
This PR adds functionality to the `dss-ops.py` script that allows operators to list, set, and unset parameters stored in the SSM store under the "environment" variables. It also adds tests for the new SSM parameter functionality.

This PR is part of #2299 and is a reworked version of (part of) a PR that was abandoned (#2324). This PR is much simpler and should be easier/faster to review.