### PR TITLE
Add lambda parameter functionality to dss-ops

### DIFF
--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -98,7 +98,7 @@ def get_deployed_lambdas(quiet: bool = True):
             yield name
         except lambda_client.exceptions.ResourceNotFoundException:
             if not quiet:
-                logger.warning(f"{name} not deployed, or does not deploy a lambda function")
+                print(f"{name} not deployed, or does not deploy a lambda function")
 
 
 def get_deployed_lambda_environment(lambda_name: str, quiet: bool = True) -> dict:
@@ -108,7 +108,7 @@ def get_deployed_lambda_environment(lambda_name: str, quiet: bool = True) -> dic
         c = lambda_client.get_function_configuration(FunctionName=lambda_name)
     except lambda_client.exceptions.ResourceNotFoundException:
         if not quiet:
-            logger.warning(f"{lambda_name} is not a deployed lambda function")
+            print(f"{lambda_name} is not a deployed lambda function")
         return {}
     else:
         # above value is a dict, no need to convert
@@ -127,7 +127,7 @@ def get_local_lambda_environment(quiet: bool = True) -> dict:
     For each environment variable being set in deployed lambda functions, get the value of the
     environment variable from the local environment.
 
-    :param quiet: (boolean) if true, don't print warning messages
+    :param bool quiet: if true, don't print warning messages
     :returns: dict containing local environment's value of each variable exported to deployed lambda functions
     """
     env = dict()
@@ -136,7 +136,7 @@ def get_local_lambda_environment(quiet: bool = True) -> dict:
             env[name] = os.environ[name]
         except KeyError:
             if not quiet:
-                logger.warning(
+                print(
                     f"Warning: environment variable {name} is in the list of environment variables "
                     "to export to lambda functions, EXPORT_ENV_VARS_TO_LAMBDA, but variable is not "
                     "defined in the local environment, so there is no value to set."

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -1,0 +1,202 @@
+"""
+Get and set environment variables in deployed lambda functions using the SSM param store
+variable named "environment".
+"""
+import os
+import sys
+import select
+import json
+import argparse
+import logging
+import typing
+
+from dss.operations import dispatch
+from dss.operations.ssm_params import get_ssm_variable_prefix, fix_ssm_variable_prefix
+
+from dss.util.aws.clients import ssm as ssm_client  # type: ignore
+from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore
+from dss.util.aws.clients import es as es_client  # type: ignore
+import dss.util.aws.clients
+lambda_client = getattr(dss.util.aws.clients, "lambda")
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_elasticsearch_endpoint() -> str:
+    domain_name = os.environ["DSS_ES_DOMAIN"]
+    domain_info = es_client.describe_elasticsearch_domain(DomainName=domain_naame)
+    return domain_info["DomainStatus"]["Endpoint"]
+
+
+def get_admin_emails() -> str:
+
+    def get_secret_variable_prefix() -> str:
+        # TODO: this functionality should be moved to secrets.py
+        store_name = os.environ["DSS_SECRETS_STORE"]
+        stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
+        store_prefix = f"{store_name}/{stage_name}"
+        return store_prefix
+
+    def fix_secret_variable_prefix(secret_name: str) -> str:
+        # TODO: this functionality should be moved to secrets.py
+        prefix = get_secret_variable_prefix()
+        if not (secret_name.startswith(prefix) or secret_name.startswith("/" + prefix)):
+            secret_name = f"{prefix}/{secret_name}"
+        return secret_name
+
+    def fetch_secret_safely(secret_name: str) -> str:
+        # TODO:
+        try:
+            response = sm_client.get_secret_value(SecretId=secret_name)
+        except ClientError as e:
+            if 'Error' in e.response:
+                errtype = e.response['Error']['Code']
+                if errtype == 'ResourceNotFoundException':
+                    raise RuntimeError(f"Error: secret {secret_name} was not found!")
+                else:
+                    raise RuntimeError(
+                            f"Error: could not fetch {secret_name}, error type: {errtype}"
+                    )
+        else:
+            return response
+
+    gcp_var = "GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME"
+    gcp_secret_id = fix_secret_variable_prefix(gcp_var)
+    response = fetch_secret_safely(gcp_secret_id)['SecretString']
+    gcp_service_account_email = json.loads(response)['client_email']
+
+    admin_var = "ADMIN_USER_EMAILS_SECRETS_NAME"
+    admin_secret_id = fix_secret_variable_prefix(admin_var)
+    response = fetch_secret_safely(admin_secret_id)['SecretString']
+    email_list = [email.strip() for email in response.split(',') if email.strip()]
+
+    if gcp_service_account_email not in email_list:
+        email_list.append(gcp_service_account_email)
+    return ",".join(email_list)
+
+
+def get_deployed_lambdas(quiet=True):
+    """
+    Generator returning names of lambda functions
+
+    :param quiet: (boolean) if true, don't print warning messages
+    """
+    stage = os.environ["DSS_DEPLOYMENT_STAGE"]
+
+    dirs = []
+    path = os.path.join(os.environ["DSS_HOME"], "daemons")
+    for item in os.scandir(path):
+        if not item.name.startswith('.') and item.is_dir():
+            dirs.append(item.name)
+
+    functions = [f"{name}-{stage}" for name in dirs]
+    functions.append(f"dss-{stage}")
+    for name in functions:
+        try:
+            lambda_client.get_function(FunctionName=name)
+            yield name
+        except lambda_client.exceptions.ResourceNotFoundException:
+            if quiet:
+                pass
+            else:
+                logger.warning(f"{name} not deployed, or does not deploy a lambda function")
+
+
+def get_deployed_lambda_environment(lambda_name: str) -> dict:
+    """Get the environment variables in a deployed lambda function"""
+    c = lambda_client.get_function_configuration(FunctionName=lambda_name)
+    # above value is a dict, no need to convert
+    return c["Environment"]["Variables"]
+
+
+def set_deployed_lambda_environment(lambda_name: str, env: dict) -> None:
+    """Set the environment variables in a deployed lambda function"""
+    lambda_client.update_function_configuration(
+        FunctionName=lambda_name, Environment={"Variables": env}
+    )
+
+
+def get_local_lambda_environment(quiet=True) -> dict:
+    """
+    For each environment variable being set in deployed lambda functions, get the value of the
+    environment variable from the local environment.
+
+    :param quiet: (boolean) if true, don't print warning messages
+    :returns: dict containing local environment's value of each variable exported to deployed lambda functions
+    """
+    env = dict()
+    for name in os.environ["EXPORT_ENV_VARS_TO_LAMBDA"].split():
+        try:
+            env[name] = os.environ[name]
+        except KeyError:
+            if quiet:
+                pass
+            else:
+                logger.warning(
+                    f"Warning: environment variable {name} is in the list of environment variables "
+                    "to export to lambda functions, EXPORT_ENV_VARS_TO_LAMBDA, but variable is not "
+                    "defined in the local environment, so there is no value to set."
+                )
+    return env
+
+
+def set_lambda_var(env_var: str, value, lambda_name: str) -> None:
+    """Set a single variable in the environment of the specified lambda function"""
+    environment = get_deployed_lambda_environment(lambda_name)
+    if env_var in environment:
+        prev_value = environment[env_var]
+    environment[env_var] = value
+    set_deployed_lambda_environment(lambda_name, environment)
+    print(f"Success! Set variable in deployed lambda function {lambda_name}:")
+    print(f"Name: {env_var}")
+    print(f"Value: {value}")
+    if prev_value:
+        print(f"Previous value: {prev_value}")
+
+
+def unset_lambda_var(env_var: str, value, lambda_name: str) -> None:
+    """Unset a single variable in the environment of the specified lambda function"""
+    environment = get_deployed_lambda_environment(lambda_name)
+    try:
+        prev_value = environment[env_var]
+        del environment[env_var]
+        set_deployed_lambda_environment(lambda_name, environment)
+        print(f"Success! Unset variable in deployed lambda function {lambda_name}:")
+        print(f"Name: {env_var} ")
+        print(f"Previous value: {prev_value}")
+    except KeyError:
+        print(f"Nothing to unset for variable {env_var} in deployed lambda function {lambda_name}")
+
+
+def print_lambda_env(lambda_name, lambda_env):
+    """Print the environment variables set in a specified lambda function"""
+    print(f"\n{lambda_name}:")
+    for name, val in lambda_env.items():
+        print(f"{name}={val}")
+
+
+lambda_params = dispatch.target("lambda", arguments={}, help=__doc__)
+
+
+json_flag_options = dict(
+    default = False,
+    action="store_true",
+    help="format the output as JSON if this flag is present",
+)
+
+
+@lambda_params.action(
+    "list",
+    arguments={
+        "--json": json_flag_options,
+    }
+)
+def lambda_list(argv: typing.List[str], args: argparse.Namespace):
+    """Print a list of names of each deployed lambda function"""
+    lambda_names = get_deployed_lambdas()
+    if args.json:
+        print(json.dumps(lambda_names, indent=4, default=str))
+    else:
+        for lambda_name in lambda_names:
+            print(lambda_name)

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -201,7 +201,7 @@ json_flag_options = dict(
 )
 def lambda_list(argv: typing.List[str], args: argparse.Namespace):
     """Print a list of names of each deployed lambda function"""
-    lambda_names = get_deployed_lambdas()
+    lambda_names = list(get_deployed_lambdas())
     if args.json:
         print(json.dumps(lambda_names, indent=4, default=str))
     else:
@@ -230,7 +230,7 @@ def labmda_environment(argv: typing.List[str], args: argparse.Namespace):
     if args.lambda_name:
         lambda_names = [args.lambda_name]  # single lambda function
     else:
-        lambda_names = get_deployed_lambdas()  # all lambda functions
+        lambda_names = list(get_deployed_lambdas())  # all lambda functions
 
     # Iterate over lambda functions and get their environments
     d = {}

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -157,7 +157,6 @@ def unset_lambda_var(env_var: str, lambda_name: str, quiet: bool = False) -> Non
     """Unset a single variable in the environment of the specified lambda function"""
     environment = get_deployed_lambda_environment(lambda_name, quiet=False)
     try:
-        prev_value = environment[env_var]
         del environment[env_var]
         set_deployed_lambda_environment(lambda_name, environment)
         if not quiet:
@@ -178,14 +177,10 @@ lambda_params = dispatch.target("lambda", arguments={}, help=__doc__)
 
 
 json_flag_options = dict(
-    default = False, action="store_true", help="format the output as JSON if this flag is present"
+    default=False, action="store_true", help="format the output as JSON if this flag is present"
 )
-dryrun_flag_options = dict(
-    default = False, action="store_true", help="do a dry run of the actual operation"
-)
-quiet_flag_options = dict(
-    default = False, action="store_true", help="suppress output"
-)
+dryrun_flag_options = dict(default=False, action="store_true", help="do a dry run of the actual operation")
+quiet_flag_options = dict(default=False, action="store_true", help="suppress output")
 
 
 @lambda_params.action(
@@ -254,8 +249,10 @@ def lambda_set(argv: typing.List[str], args: argparse.Namespace):
 
     if args.dry_run:
         if not args.quiet:
-            print(f"Dry-run setting variable {name} in lambda environment in SSM store under "
-                   "$DSS_DEPLOYMENT_STAGE/environment")
+            print(
+                f"Dry-run setting variable {name} in lambda environment in SSM store under "
+                "$DSS_DEPLOYMENT_STAGE/environment"
+            )
             print(f"    Name: {name}")
             print(f"    Value: {val}")
             for lambda_name in get_deployed_lambdas():
@@ -318,7 +315,7 @@ def lambda_update(argv: typing.List[str], args: argparse.Namespace):
     """
     if args.force is False:
         # Make sure the user really wants to do this
-        comfirm  = f"""
+        confirm = f"""
         *** WARNING!!! ***
 
         Calling the lambda update function will overwrite the current
@@ -347,13 +344,17 @@ def lambda_update(argv: typing.List[str], args: argparse.Namespace):
 
     if args.dry_run:
         if not args.quiet:
-            print(f"Dry-run redeploying local environment to lambda function environment "
-                   "stored in SSM store under $DSS_DEPLOYMENT_STAGE/environment")
+            print(
+                f"Dry-run redeploying local environment to lambda function environment "
+                "stored in SSM store under $DSS_DEPLOYMENT_STAGE/environment"
+            )
     else:
         set_ssm_environment(local_env)
         if not args.quiet:
-            print(f"Finished redeploying local environment to lambda function environment "
-                    "stored in SSM store under $DSS_DEPLOY_STAGE/environment")
+            print(
+                f"Finished redeploying local environment to lambda function environment "
+                "stored in SSM store under $DSS_DEPLOY_STAGE/environment"
+            )
 
     # Optionally, update environment of each deployed lambda
     if args.update_deployed:

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -141,16 +141,11 @@ def get_local_lambda_environment(quiet: bool = True) -> dict:
 def set_lambda_var(env_var: str, value, lambda_name: str) -> None:
     """Set a single variable in the environment of the specified lambda function"""
     environment = get_deployed_lambda_environment(lambda_name, quiet=False)
-    prev_value = None
-    if env_var in environment:
-        prev_value = environment[env_var]
     environment[env_var] = value
     set_deployed_lambda_environment(lambda_name, environment)
     print(f"Success! Set variable in deployed lambda function {lambda_name}:")
     print(f"    Name: {env_var}")
     print(f"    Value: {value}")
-    if prev_value:
-        print(f"    Previous value: {prev_value}")
 
 
 def unset_lambda_var(env_var: str, value, lambda_name: str) -> None:

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -220,7 +220,8 @@ def lambda_environment(argv: typing.List[str], args: argparse.Namespace):
     d = {}
     for lambda_name in lambda_names:
         lambda_env = get_deployed_lambda_environment(lambda_name, quiet=args.json)
-        d[lambda_name] = lambda_env
+        if lambda_env != {}:
+            d[lambda_name] = lambda_env
 
     # Print environments
     if args.json:

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -141,6 +141,7 @@ def get_local_lambda_environment(quiet: bool = True) -> dict:
 def set_lambda_var(env_var: str, value, lambda_name: str) -> None:
     """Set a single variable in the environment of the specified lambda function"""
     environment = get_deployed_lambda_environment(lambda_name, quiet=False)
+    prev_value = None
     if env_var in environment:
         prev_value = environment[env_var]
     environment[env_var] = value
@@ -254,6 +255,8 @@ def lambda_set(argv: typing.List[str], args: argparse.Namespace):
         print(f"    Value: {val}")
         for lambda_name in get_deployed_lambdas():
             print(f"Dry-run creating variable {name} in lambda {lambda_name}")
+            print(f"    Name: {name}")
+            print(f"    Value: {val}")
 
     else:
         # Set the variable in the SSM store first, then in each deployed lambda

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -10,6 +10,8 @@ import argparse
 import logging
 import typing
 
+from botocore.exceptions import ClientError
+
 from dss.operations import dispatch
 from dss.operations.ssm_params import get_ssm_variable_prefix, fix_ssm_variable_prefix
 
@@ -25,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def get_elasticsearch_endpoint() -> str:
     domain_name = os.environ["DSS_ES_DOMAIN"]
-    domain_info = es_client.describe_elasticsearch_domain(DomainName=domain_naame)
+    domain_info = es_client.describe_elasticsearch_domain(DomainName=domain_name)
     return domain_info["DomainStatus"]["Endpoint"]
 
 
@@ -45,7 +47,7 @@ def get_admin_emails() -> str:
             secret_name = f"{prefix}/{secret_name}"
         return secret_name
 
-    def fetch_secret_safely(secret_name: str) -> str:
+    def fetch_secret_safely(secret_name: str) -> dict:
         # TODO:
         try:
             response = sm_client.get_secret_value(SecretId=secret_name)
@@ -54,10 +56,7 @@ def get_admin_emails() -> str:
                 errtype = e.response['Error']['Code']
                 if errtype == 'ResourceNotFoundException':
                     raise RuntimeError(f"Error: secret {secret_name} was not found!")
-                else:
-                    raise RuntimeError(
-                            f"Error: could not fetch {secret_name}, error type: {errtype}"
-                    )
+            raise RuntimeError(f"Error: could not fetch secret {secret_name} from secrets manager")
         else:
             return response
 
@@ -76,11 +75,11 @@ def get_admin_emails() -> str:
     return ",".join(email_list)
 
 
-def get_deployed_lambdas(quiet=True):
+def get_deployed_lambdas(quiet: bool = True):
     """
     Generator returning names of lambda functions
 
-    :param quiet: (boolean) if true, don't print warning messages
+    :param quiet: (boolean) if true, don't print warnings about lambdas that can't be found
     """
     stage = os.environ["DSS_DEPLOYMENT_STAGE"]
 
@@ -97,24 +96,22 @@ def get_deployed_lambdas(quiet=True):
             lambda_client.get_function(FunctionName=name)
             yield name
         except lambda_client.exceptions.ResourceNotFoundException:
-            if quiet:
-                pass
-            else:
+            if not quiet:
                 logger.warning(f"{name} not deployed, or does not deploy a lambda function")
 
 
-def get_deployed_lambda_environment(lambda_name: str, quiet = True) -> dict:
+def get_deployed_lambda_environment(lambda_name: str, quiet: bool = True) -> dict:
     """Get the environment variables in a deployed lambda function"""
     try:
         lambda_client.get_function(FunctionName=lambda_name)
         c = lambda_client.get_function_configuration(FunctionName=lambda_name)
+    except lambda_client.exceptions.ResourceNotFoundException:
+        if not quiet:
+            logger.warning(f"{lambda_name} is not a deployed lambda function")
+        return {}
+    else:
         # above value is a dict, no need to convert
         return c["Environment"]["Variables"]
-    except lambda_client.exceptions.ResourceNotFoundException:
-        if quiet:
-            pass
-        else:
-            logger.warning(f"{lambda_name} is not a deployed lambda function")
 
 
 def set_deployed_lambda_environment(lambda_name: str, env: dict) -> None:
@@ -124,7 +121,7 @@ def set_deployed_lambda_environment(lambda_name: str, env: dict) -> None:
     )
 
 
-def get_local_lambda_environment(quiet=True) -> dict:
+def get_local_lambda_environment(quiet: bool = True) -> dict:
     """
     For each environment variable being set in deployed lambda functions, get the value of the
     environment variable from the local environment.
@@ -137,9 +134,7 @@ def get_local_lambda_environment(quiet=True) -> dict:
         try:
             env[name] = os.environ[name]
         except KeyError:
-            if quiet:
-                pass
-            else:
+            if not quiet:
                 logger.warning(
                     f"Warning: environment variable {name} is in the list of environment variables "
                     "to export to lambda functions, EXPORT_ENV_VARS_TO_LAMBDA, but variable is not "
@@ -150,7 +145,7 @@ def get_local_lambda_environment(quiet=True) -> dict:
 
 def set_lambda_var(env_var: str, value, lambda_name: str) -> None:
     """Set a single variable in the environment of the specified lambda function"""
-    environment = get_deployed_lambda_environment(lambda_name)
+    environment = get_deployed_lambda_environment(lambda_name, quiet=False)
     if env_var in environment:
         prev_value = environment[env_var]
     environment[env_var] = value
@@ -164,7 +159,7 @@ def set_lambda_var(env_var: str, value, lambda_name: str) -> None:
 
 def unset_lambda_var(env_var: str, value, lambda_name: str) -> None:
     """Unset a single variable in the environment of the specified lambda function"""
-    environment = get_deployed_lambda_environment(lambda_name)
+    environment = get_deployed_lambda_environment(lambda_name, quiet=False)
     try:
         prev_value = environment[env_var]
         del environment[env_var]
@@ -201,7 +196,7 @@ json_flag_options = dict(
 )
 def lambda_list(argv: typing.List[str], args: argparse.Namespace):
     """Print a list of names of each deployed lambda function"""
-    lambda_names = list(get_deployed_lambdas())
+    lambda_names = list(get_deployed_lambdas(quiet=args.json))
     if args.json:
         print(json.dumps(lambda_names, indent=4, default=str))
     else:
@@ -216,13 +211,7 @@ def lambda_list(argv: typing.List[str], args: argparse.Namespace):
         "--lambda-name": dict(
             required=False,
             help="specify the name of a lambda function whose environment will be listed"
-        ),
-        "--quiet": dict(
-            required=False,
-            action="store_true",
-            help="suppress warning messages if the lambda function cannot be found"
         )
-
     }
 )
 def labmda_environment(argv: typing.List[str], args: argparse.Namespace):
@@ -235,7 +224,7 @@ def labmda_environment(argv: typing.List[str], args: argparse.Namespace):
     # Iterate over lambda functions and get their environments
     d = {}
     for lambda_name in lambda_names:
-        lambda_env = get_deployed_lambda_environment(lambda_name, args.quiet)
+        lambda_env = get_deployed_lambda_environment(lambda_name, quiet=args.json)
         d[lambda_name] = lambda_env
 
     # Print environments

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -10,8 +10,6 @@ import argparse
 import logging
 import typing
 
-from botocore.exceptions import ClientError
-
 from dss.operations import dispatch
 from dss.operations.ssm_params import get_ssm_variable_prefix, fix_ssm_variable_prefix
 from dss.operations.ssm_params import set_ssm_parameter, unset_ssm_parameter
@@ -52,12 +50,8 @@ def get_admin_emails() -> str:
         # TODO: this functionality should be moved to dss/operations/secrets.py
         try:
             response = sm_client.get_secret_value(SecretId=secret_name)
-        except ClientError as e:
-            if 'Error' in e.response:
-                errtype = e.response['Error']['Code']
-                if errtype == 'ResourceNotFoundException':
-                    raise RuntimeError(f"Error: secret {secret_name} was not found!")
-            raise RuntimeError(f"Error: could not fetch secret {secret_name} from secrets manager")
+        except sm_client.exceptions.ResourceNotFoundException as e:
+            raise RuntimeError(f"Error: secret {secret_name} was not found!") from e
         else:
             return response
 

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -103,11 +103,18 @@ def get_deployed_lambdas(quiet=True):
                 logger.warning(f"{name} not deployed, or does not deploy a lambda function")
 
 
-def get_deployed_lambda_environment(lambda_name: str) -> dict:
+def get_deployed_lambda_environment(lambda_name: str, quiet = True) -> dict:
     """Get the environment variables in a deployed lambda function"""
-    c = lambda_client.get_function_configuration(FunctionName=lambda_name)
-    # above value is a dict, no need to convert
-    return c["Environment"]["Variables"]
+    try:
+        lambda_client.get_function(FunctionName=lambda_name)
+        c = lambda_client.get_function_configuration(FunctionName=lambda_name)
+        # above value is a dict, no need to convert
+        return c["Environment"]["Variables"]
+    except lambda_client.exceptions.ResourceNotFoundException:
+        if quiet:
+            pass
+        else:
+            logger.warning(f"{lambda_name} is not a deployed lambda function")
 
 
 def set_deployed_lambda_environment(lambda_name: str, env: dict) -> None:
@@ -200,3 +207,40 @@ def lambda_list(argv: typing.List[str], args: argparse.Namespace):
     else:
         for lambda_name in lambda_names:
             print(lambda_name)
+
+
+@lambda_params.action(
+    "environment",
+    arguments={
+        "--json": json_flag_options,
+        "--lambda-name": dict(
+            required=False,
+            help="specify the name of a lambda function whose environment will be listed"
+        ),
+        "--quiet": dict(
+            required=False,
+            action="store_true",
+            help="suppress warning messages if the lambda function cannot be found"
+        )
+
+    }
+)
+def labmda_environment(argv: typing.List[str], args: argparse.Namespace):
+    """Print out the current environment of deployed lambda functions"""
+    if args.lambda_name:
+        lambda_names = [args.lambda_name]  # single lambda function
+    else:
+        lambda_names = get_deployed_lambdas()  # all lambda functions
+
+    # Iterate over lambda functions and get their environments
+    d = {}
+    for lambda_name in lambda_names:
+        lambda_env = get_deployed_lambda_environment(lambda_name, args.quiet)
+        d[lambda_name] = lambda_env
+
+    # Print environments
+    if args.json:
+        print(json.dumps(d, indent=4, default=str))
+    else:
+        for lambda_name, lambda_env in d.items():
+            print_lambda_env(lambda_name, lambda_env)

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -61,12 +61,12 @@ def get_admin_emails() -> str:
         else:
             return response
 
-    gcp_var = "GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME"
+    gcp_var = os.environ["GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME"]
     gcp_secret_id = fix_secret_variable_prefix(gcp_var)
     response = fetch_secret_safely(gcp_secret_id)['SecretString']
     gcp_service_account_email = json.loads(response)['client_email']
 
-    admin_var = "ADMIN_USER_EMAILS_SECRETS_NAME"
+    admin_var = os.environ["ADMIN_USER_EMAILS_SECRETS_NAME"]
     admin_secret_id = fix_secret_variable_prefix(admin_var)
     response = fetch_secret_safely(admin_secret_id)['SecretString']
     email_list = [email.strip() for email in response.split(',') if email.strip()]

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -316,15 +316,34 @@ def lambda_update(argv: typing.List[str], args: argparse.Namespace):
     Update the stored (and optionally, deployed) lambda environment
     using variable values from the current environment.
     """
+    if args.force is False:
+        # Make sure the user really wants to do this
+        comfirm  = f"""
+        *** WARNING!!! ***
 
-    # Also..........
-    # ASK FOR CONFIRMATION!!!
+        Calling the lambda update function will overwrite the current
+        values of the lambda function environment stored in the
+        SSM store at $DSS_DEPLOY_STAGE/environment with local
+        values from environment variables on your machine.
+
+        Note:
+        - To do a dry run of this operation first, use the --dry-run flag.
+        - To ignore this warning, use the --force flag.
+        - To see the current environment stored in the SSM store, run:
+            ./dss-ops.py lambda environment
+
+        Are you really sure you want to update the SSM store environment?
+        (Type 'y' or 'yes' to confirm):
+        """
+        response = input(confirm)
+        if response.lower() not in ["y", "yes"]:
+            raise RuntimeError("You safely aborted the lambda update operation!")
 
     # Only elasticsearch endpoint and admin emails are updated dynamically,
     # everything else comes from the local environment.
     local_env = get_local_lambda_environment()
-    local_env["ABCDEFG_DSS_ES_ENDPOINT"] = get_elasticsearch_endpoint()
-    local_env["ABCDEFG_ADMIN_USER_EMAILS"] = get_admin_emails()
+    local_env["DSS_ES_ENDPOINT"] = get_elasticsearch_endpoint()
+    local_env["ADMIN_USER_EMAILS"] = get_admin_emails()
 
     if args.dry_run:
         if not args.quiet:

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -75,7 +75,7 @@ def set_ssm_parameter(env_var: str, value) -> None:
         print(f"Previous value: {prev_value}")
 
 
-def unset_ssm_parameter(env_var: str, value) -> None:
+def unset_ssm_parameter(env_var: str) -> None:
     """
     Unset a parameter in the SSM param store variable "environment".
 
@@ -159,4 +159,4 @@ def ssm_unset(argv: typing.List[str], args: argparse.Namespace):
         print(f"Dry-run deleting variable {env_var} from SSM store under $DSS_DEPLOYMENT_STAGE/environment:")
         print(f"    Name: {env_var}")
     else:
-        unset_ssm_parameter(env_var, value)
+        unset_ssm_parameter(env_var)

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -143,7 +143,7 @@ def ssm_set(argv: typing.List[str], args: argparse.Namespace):
     value = sys.stdin.read()
 
     if args.dry_run:
-        print("Dry-run creating variable in SSM store under $DSS_DEPLOYMENT_STAGE/environment:")
+        print("Dry-run setting variable in SSM store under $DSS_DEPLOYMENT_STAGE/environment:")
     else:
         set_ssm_parameter(env_var, value)
 

--- a/dss/operations/ssm_params.py
+++ b/dss/operations/ssm_params.py
@@ -57,41 +57,46 @@ def set_ssm_environment(env: dict) -> None:
     )
 
 
-def set_ssm_parameter(env_var: str, value) -> None:
+def set_ssm_parameter(env_var: str, value, quiet: bool = False) -> None:
     """
     Set a parameter in the SSM param store variable "environment".
 
     :param env_var: the name of the environment variable being set
     :param value: the value of the environment variable being set
+    :param bool quiet: suppress all output if true
     """
     environment = get_ssm_environment()
     prev_value = environment.get(env_var)
     environment[env_var] = value
     set_ssm_environment(environment)
-    print("Success! Set variable in SSM parameter store environment:")
-    print(f"    Name: {env_var}")
-    print(f"    Value: {value}")
-    if prev_value:
-        print(f"Previous value: {prev_value}")
+    if not quiet:
+        print("Success! Set variable in SSM parameter store environment:")
+        print(f"    Name: {env_var}")
+        print(f"    Value: {value}")
+        if prev_value:
+            print(f"Previous value: {prev_value}")
 
 
-def unset_ssm_parameter(env_var: str) -> None:
+def unset_ssm_parameter(env_var: str, quiet: bool = False) -> None:
     """
     Unset a parameter in the SSM param store variable "environment".
 
     :param env_var: the name of the environment variable being set
     :param value: the value of the environment variable being set
+    :param bool quiet: suppress all output if true
     """
     environment = get_ssm_environment()
     try:
         prev_value = environment[env_var]
         del environment[env_var]
         set_ssm_environment(environment)
-        print("Success! Unset variable in SSM store under $DSS_DEPLOYMENT_STAGE/environment:")
-        print(f"    Name: {env_var} ")
-        print(f"    Previous value: {prev_value}")
+        if not quiet:
+            print("Success! Unset variable in SSM store under $DSS_DEPLOYMENT_STAGE/environment:")
+            print(f"    Name: {env_var} ")
+            print(f"    Previous value: {prev_value}")
     except KeyError:
-        print(f"Nothing to unset for variable {env_var} in SSM store under $DSS_DEPLOYMENT_STAGE/environment")
+        if not quiet:
+            print(f"Nothing to unset for variable {env_var} in SSM store under $DSS_DEPLOYMENT_STAGE/environment")
 
 
 ssm_params = dispatch.target("params", arguments={}, help=__doc__)

--- a/scripts/dss-ops.py
+++ b/scripts/dss-ops.py
@@ -14,6 +14,7 @@ import dss.operations.checkout
 import dss.operations.storage
 import dss.operations.sync
 import dss.operations.ssm_params
+import dss.operations.lambda_params
 import dss.operations.elasticsearch
 import dss.operations.events
 import dss.operations.secrets

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -626,7 +626,7 @@ class TestOperations(unittest.TestCase):
                 #   (local operations only)
                 # lambda_update() then calls set_ssm_environment(),
                 #   which we mocked above into set_ssm
-                set_ssm = mock.MagicMock(return_value=None)
+                set_ssm = mock.MagicMock(return_value=None) # noqa
 
                 ssm.put_parameter = mock.MagicMock(return_value=None)
 
@@ -664,8 +664,8 @@ class TestOperations(unittest.TestCase):
                 # The function sm.get_secret_value() must return things in the right order
                 # Re-mock it before each call
                 email_side_effect = [
-                        self._wrap_secret(google_service_acct_secret),
-                        self._wrap_secret(admin_email_secret),
+                    self._wrap_secret(google_service_acct_secret),
+                    self._wrap_secret(admin_email_secret),
                 ]
 
                 # Dry run, then real (mocked) thing
@@ -705,7 +705,6 @@ class TestOperations(unittest.TestCase):
                 lambda_params.lambda_unset([], argparse.Namespace(name=testvar_name, dry_run=True, quiet=True))
                 lambda_params.lambda_unset([], argparse.Namespace(name=testvar_name, dry_run=False, quiet=True))
 
-
     def _wrap_ssm_env(self, e):
         """
         Package up the SSM environment the way AWS returns it.
@@ -730,7 +729,6 @@ class TestOperations(unittest.TestCase):
         Package up the secret the way AWS returns it.
         """
         return {"SecretString": val}
-
 
 
 @testmode.integration

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -544,6 +544,48 @@ class TestOperations(unittest.TestCase):
                 all_lams = json.loads("\n".join(output))
                 self.assertIn(f"dss-{stage}", all_lams)
 
+        with self.subTest("Get environments of each lambda function"):
+            with mock.patch("dss.operations.lambda_params.ssm_client") as ssm, \
+                    mock.patch("dss.operations.lambda_params.lambda_client") as lam:
+                # lambda_env function calls get_deployed_lambdas() which just looks locally for lambda names
+                # then it calls get_deployed_lambda_environment() on every lambda,
+                #   which calls lambda_client.get_function(),
+                #   then calls lambda_client.get_function_configuration(),
+                # then it calls set_ssm_environment() which calls ssm.put_parameter()
+
+                # Non-JSON, no lambda name specified
+                # TODO
+                # Non-JSON, lambda name specified
+                # TODO
+                # JSON, no lambda name specified
+                # TODO
+                # JSON, lambda name specified
+                # TODO
+
+        with self.subTest("Update (set) existing lambda parameters"):
+            with mock.patch("dss.operations.lambda_params.ssm_client") as ssm, \
+                    mock.patch("dss.operations.lambda_params.lambda_client") as lam:
+                # Mock the same way we did for create new param above.
+                # First we mock the SSM param store
+                ssm.get_parameter = mock.MagicMock(return_value=ssm_new_env)
+                ssm.put_parameter = mock.MagicMock(return_value=None)
+                # Next we mock the lambda client
+                lam.get_function = mock.MagicMock(return_value=None)
+                lam.get_function_configuration = mock.MagicMock(return_value=lam_new_env)
+                lam.update_function_configuration = mock.MagicMock(return_value=None)
+
+                with SwapStdin(testvar_value2):
+                    lambda_params.lambda_set(
+                        [], argparse.Namespace(name=testvar_name, dry_run=True)
+                    )
+                with SwapStdin(testvar_value2):
+                    lambda_params.lambda_set(
+                        [], argparse.Namespace(name=testvar_name, dry_run=False)
+                    )
+
+
+
+
 
     def _wrap_ssm_env(self, e):
         # Package up the SSM environment the way AWS returns it

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -561,6 +561,7 @@ class TestOperations(unittest.TestCase):
                 # TODO
                 # JSON, lambda name specified
                 # TODO
+                pass
 
         with self.subTest("Update (set) existing lambda parameters"):
             with mock.patch("dss.operations.lambda_params.ssm_client") as ssm, \

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -498,7 +498,8 @@ class TestOperations(unittest.TestCase):
         lam_new_env = self._wrap_lambda_env(new_env)
 
         with self.subTest("Create a new lambda parameter"):
-            with mock.patch("dss.operations.ssm_params.ssm_client") as ssm, SwapStdin(testvar_value):
+            with mock.patch("dss.operations.lambda_params.ssm_client") as ssm, \
+                    mock.patch("dss.operations.lambda_params.lambda_client") as lam:
 
                 # If this is not a dry run, lambda_set in params.py
                 # will update the SSM first, so we mock those first.
@@ -513,8 +514,11 @@ class TestOperations(unittest.TestCase):
                 lam.get_function_configuration = mock.MagicMock(return_value=lam_old_env)
                 lam.update_function_configuration = mock.MagicMock(return_value=None)
 
-                lambda_params.lambda_set([], argparse.Namespace(name=testvar_name, dry_run=True))
-                lambda_params.lambda_set([], argparse.Namespace(name=testvar_name, dry_run=False))
+                with SwapStdin(testvar_value):
+                    lambda_params.lambda_set([], argparse.Namespace(name=testvar_name, dry_run=False))
+
+                with SwapStdin(testvar_value):
+                    lambda_params.lambda_set([], argparse.Namespace(name=testvar_name, dry_run=True))
 
 
     def _wrap_ssm_env(self, e):


### PR DESCRIPTION
This PR adds functionality to the dss-ops.py script that allows operators to list, set, and unset deployed lambda functions and their environments (environment variables).

This PR is part of #2299 and is a reworked version of (part of) a PR that was abandoned (#2324). This PR is much simpler and should be easier/faster to review.

This closes #2389