### PR TITLE
Add fusillade stage and setup fusillade step to CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,8 @@ setup_fusillade:
     - fi
     - cat ./roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
     - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force testing
+  except:
+    - schedules
 
 deploy:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,3 +187,4 @@ force_release_prod:
     RELEASE_COMMAND: scripts/release.sh staging prod --force
   only:
     - staging
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ setup_fusillade:
 # need to source data-store environment one more time, in case dcp-fusillade overwrites vars
 # (e.g. AWS_DEFAULT_REGION)
     - source environment
-    - dcp-fusillade/scripts/setup_fusillade.py --dry-run --file roles.json dev # change to testing l8r
+    - dcp-fusillade/scripts/setup_fusillade.py --dry-run --file roles.json testing
 
 deploy:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,8 @@ setup_fusillade:
 # need to source data-store environment one more time, in case dcp-fusillade overwrites vars
 # (e.g. AWS_DEFAULT_REGION)
     - source environment
-    - dcp-fusillade/scripts/setup_fusillade.py --file roles.json --force testing
+    - cat ./data-store/roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
+    - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force testing
 
 deploy:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ setup_fusillade:
 # need to source data-store environment one more time, in case dcp-fusillade overwrites vars
 # (e.g. AWS_DEFAULT_REGION)
     - source environment
-    - cat ./data-store/roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
+    - cat ./roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
     - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force testing
 
 deploy:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ setup_fusillade:
 # need to source data-store environment one more time, in case dcp-fusillade overwrites vars
 # (e.g. AWS_DEFAULT_REGION)
     - source environment
-    - dcp-fusillade/scripts/setup_fusillade.py --file roles.json testing
+    - dcp-fusillade/scripts/setup_fusillade.py --file roles.json --force testing
 
 deploy:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ variables:
 stages:
   - trufflehog
   - test
+  - fusillade
   - deploy
   - integration_test
   - scale_and_performance
@@ -72,6 +73,18 @@ test_subscriptions:
   extends: .tests
   script:
     - make -j1 tests/test_subscriptions.py
+
+setup_fusillade:
+  stage: fusillade
+  script:
+    - git clone -b master https://github.com/HumanCellAtlas/dcp-fusillade.git
+    - cd dcp-fusillade
+    - source environment
+    - cd ..
+# need to source data-store environment one more time, in case dcp-fusillade overwrites vars
+# (e.g. AWS_DEFAULT_REGION)
+    - source environment
+    - dcp-fusillade/scripts/setup_fusillade.py --dry-run --file roles.json dev # change to testing l8r
 
 deploy:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,7 +84,7 @@ setup_fusillade:
 # need to source data-store environment one more time, in case dcp-fusillade overwrites vars
 # (e.g. AWS_DEFAULT_REGION)
     - source environment
-    - dcp-fusillade/scripts/setup_fusillade.py --dry-run --file roles.json testing
+    - dcp-fusillade/scripts/setup_fusillade.py --file roles.json testing
 
 deploy:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,9 +81,11 @@ setup_fusillade:
     - cd dcp-fusillade
     - source environment
     - cd ..
-# need to source data-store environment one more time, in case dcp-fusillade overwrites vars
-# (e.g. AWS_DEFAULT_REGION)
+# need to re-source data-store environment in case dcp-fusillade overwrites vars (e.g. AWS_DEFAULT_REGION)
     - source environment
+    - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then
+    -   source environment.$CI_COMMIT_REF_NAME
+    - fi
     - cat ./roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
     - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force testing
 
@@ -95,7 +97,7 @@ deploy:
     - scripts/set_version.sh
   environment:
     name: $CI_COMMIT_REF_NAME
-    # TODO: incluude url when GitLab fixes it's wonky interpolation rules
+    # TODO: include url when GitLab fixes it's wonky interpolation rules
     # Variable created in this file (outside of `variables`) are not interpolated,
     # causing GitLabs environment mechanism to fail silently.
     # issue: https://gitlab.com/gitlab-com/support-forum/issues/2814

--- a/roles.json
+++ b/roles.json
@@ -19,7 +19,7 @@
               "dss:GetBundle",
               "dss:PostCheckout"
             ],
-            "Resource": "arn:hca:dss:${stage}:*:bundles/*"
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
           },
           {
             "Sid": "read_collections",
@@ -90,7 +90,7 @@
               "dss:PatchBundle",
               "dss:PutBundle"
             ],
-            "Resource": "arn:hca:dss:${stage}:*:bundles/*"
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
           },
           {
             "Sid": "modify_files",
@@ -123,7 +123,7 @@
             "Action": [
               "dss:GetCollections"
             ],
-            "Resource": "arn:hca:dss:{stage}:*:${fus:user}/collections"
+            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections"
           },
           {
             "Sid": "modify_collection",
@@ -134,7 +134,7 @@
               "dss:GetCollection",
               "dss:PatchCollection"
             ],
-            "Resource": "arn:hca:dss:{stage}:*:${fus:user}/collections/{uuid}"
+            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections/{uuid}"
           }
         ]
       }
@@ -152,7 +152,7 @@
               "dss:PatchBundle",
               "dss:PutBundle"
             ],
-            "Resource": "arn:hca:dss:${stage}:*:bundles/*"
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
           },
           {
             "Sid": "modify_files",
@@ -162,7 +162,7 @@
               "dss:HeadFiles",
               "dss:PutFiles"
             ],
-            "Resource": "arn:hca:dss:${stage}:*:files/*"
+            "Resource": "arn:hca:dss:${stage}:*:file/*"
           },
           {
             "Sid": "read_checkout",
@@ -178,7 +178,7 @@
             "Action": [
               "dss:GetCollections"
             ],
-            "Resource": "arn:hca:dss:{stage}:*:*/collections"
+            "Resource": "arn:hca:dss:${stage}:*:*/collections"
           },
           {
             "Sid": "modify_collection",
@@ -189,7 +189,7 @@
               "dss:GetCollection",
               "dss:PatchCollection"
             ],
-            "Resource": "arn:hca:dss:{stage}:*:*/collections/{uuid}"
+            "Resource": "arn:hca:dss:${stage}:*:*/collections/{uuid}"
           },
           {
             "Sid": "modify_subscription",


### PR DESCRIPTION
This PR addresses HumanCellAtlas/dcp-fusillade#7.

### Test plan

These changes are to the integration system on Allspark, so it needs to be in a PR in order for it to be tested. The changes made to the Fusillade deployment also need to be tested, but will not be tested using anything added in this pull request.

### Deployment instructions & migrations

Each stage of the DSS will use a script in HumanCellAtlas/dcp-fusillade to set up Fusillade with the roles defined in `roles.json` in this repo. 

Either each DSS stage will use the `testing` stage of Fusillade as the target for the setup script, or each DSS stage will use the corresponding stage of Fusillade (staging->staging, integration->integration). This needs some clarification.

### Release notes

TBA