### PR TITLE
Periodically check for replica consistency (again)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,14 +214,14 @@ verify_sync_partial:on-schedule:
       - schedules
   before_script:
     - VERIFY_SECRET_NAME="${DSS_SECRETS_STORE}/${DSS_DEPLOYMENT_STAGE}/${DSS_VERIFY_SECRETS_NAME}"
-    - LAST_VERIFIED="$(python scripts/dss-ops.py secrets get --secret-names ${VERIFY_SECRET_NAME} --json | jq -r '.[]')"
+    - LAST_VERIFIED="$(python scripts/dss-ops.py secrets get ${VERIFY_SECRET_NAME})"
     - NEW_LAST_VERIFIED="$(python -c 'import datetime; from dss.util.version import datetime_to_version_format; \
                                       print(datetime_to_version_format(datetime.datetime.utcnow()))')"
   script:
     - python scripts/dss-ops.py sync verify-sync-all --source-replica aws --destination-replica gcp \
           --since "${LAST_VERIFIED}" | tee verify_log
   after_script:
-    - python scripts/dss-ops.py secrets set --secret-name "${VERIFY_SECRET_NAME}" --secret-value "${NEW_LAST_VERIFIED}"
+    - echo -n "${NEW_LAST_VERIFIED}" | python scripts/dss-ops.py secrets set "${VERIFY_SECRET_NAME}"
     - test "$(cat verify_log | wc -l)" -eq 0  # If any inconsistencies, fail pipeline
 
 verify_sync_full:on-schedule:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 image: humancellatlas/dss-build-box
 # The Docker image `humancellatlas/dss-build-box` is created through a manual process from
-# `${DSS_HOME}/allspark.Dockerfile`. See the contents of `${DSS_HOME}/allspark.Dockerfile` # creation and usage instructions.
+# `${DSS_HOME}/allspark.Dockerfile`. See the contents of `${DSS_HOME}/allspark.Dockerfile`
+# creation and usage instructions.
 
 variables:
   GIT_SUBMODULE_STRATEGY: normal
@@ -16,6 +17,7 @@ stages:
   - integration_test
   - scale_and_performance
   - release
+  - verify_sync
 
 before_script:
   - date && date -u
@@ -202,3 +204,31 @@ force_release_prod:
   only:
     - staging
 
+# This cron job needs to be manually configured using the Gitlab web UI to run
+# periodically. See here for discussion on the proposed schedule:
+# https://github.com/HumanCellAtlas/data-store/pull/2412#issuecomment-528573935
+verify_sync_partial:on-schedule:
+  stage: verify_sync
+  only:
+    refs:
+      - schedules
+  before_script:
+    - VERIFY_SECRET_NAME="${DSS_SECRETS_STORE}/${DSS_DEPLOYMENT_STAGE}/${DSS_VERIFY_SECRETS_NAME}"
+    - LAST_VERIFIED="$(python scripts/dss-ops.py secrets get --secret-names ${VERIFY_SECRET_NAME} --json | jq -r '.[]')"
+    - NEW_LAST_VERIFIED="$(python -c 'import datetime; from dss.util.version import datetime_to_version_format; \
+                                      print(datetime_to_version_format(datetime.datetime.utcnow()))')"
+  script:
+    - python scripts/dss-ops.py sync verify-sync-all --source-replica aws --destination-replica gcp \
+          --since "${LAST_VERIFIED}" | tee verify_log
+  after_script:
+    - python scripts/dss-ops.py secrets set --secret-name "${VERIFY_SECRET_NAME}" --secret-value "${NEW_LAST_VERIFIED}"
+    - test "$(cat verify_log | wc -l)" -eq 0  # If any inconsistencies, fail pipeline
+
+verify_sync_full:on-schedule:
+  stage: verify_sync
+  only:
+    refs:
+      - schedules
+  extends: verify_sync_partial:on-schedule
+  script:
+    - python scripts/dss-ops.py sync verify-sync-all --source-replica aws --destination-replica gcp | tee verify_log

--- a/dss/operations/sync.py
+++ b/dss/operations/sync.py
@@ -58,7 +58,7 @@ def verify_sync_all(argv: typing.List[str], args: argparse.Namespace):
     # while the date returned by the S3 API is offset-aware, so we need to add
     # timezone information manually.
     objects_to_check = list_objects_since(args.source_replica, cutoff.replace(tzinfo=datetime.timezone.utc))
-    with concurrent.futures.ThreadPoolExecutor(max_workers=25) as exec:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=25) as exec_:
         for chunk in _chunk(objects_to_check, 1024):
             # To call :func:`verify_sync`, we need to perform some argument
             # parsing and simulate command-line invocation.
@@ -68,7 +68,7 @@ def verify_sync_all(argv: typing.List[str], args: argparse.Namespace):
                 '--destination-replica', args.destination_replica,
                 '--keys', *chunk
             ]
-            exec.submit(verify_sync, _args, dispatch.parser.parse_args(_args))
+            exec_.submit(verify_sync, _args, dispatch.parser.parse_args(_args))
 
 
 @sync.action("verify-sync",

--- a/dss/operations/sync.py
+++ b/dss/operations/sync.py
@@ -44,9 +44,9 @@ def verify_sync_all(argv: typing.List[str], args: argparse.Namespace):
         replica = Replica[replica]
         handle = Config.get_blobstore_handle(replica)
         for prefix in (BUNDLE_PREFIX, FILE_PREFIX, BLOB_PREFIX):
-            for name, metadata in handle.list_v2(replica.bucket, prefix=prefix):
+            for key, metadata in handle.list_v2(replica.bucket, prefix=prefix):
                 if metadata[BlobMetadataField.LAST_MODIFIED] > since:
-                    yield name
+                    yield key
 
     def _chunk(it, size):
         """Split an iterable into chunks of `size` (https://stackoverflow.com/a/22045226)"""

--- a/environment
+++ b/environment
@@ -134,6 +134,7 @@ DSS_ZONE_NAME="dev.data.humancellatlas.org."
 PYTHONWARNINGS=ignore:ResourceWarning,ignore::UserWarning:zipfile:
 DSS_SECRETS_STORE="dcp/dss"
 DSS_PARAMETER_STORE="dcp/dss"
+DSS_VERIFY_SECRETS_NAME="last_verified"
 EVENT_RELAY_AWS_USERNAME="dss-event-relay-${DSS_DEPLOYMENT_STAGE}"
 EVENT_RELAY_AWS_ACCESS_KEY_SECRETS_NAME="event-relay-user-aws-access-key"
 GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME="gcp-credentials.json"
@@ -175,7 +176,7 @@ DSS_XRAY_TRACE=0
 DSS_GCP_SERVICE_ACCOUNT_NAME="travis-test"
 
 # This list manages the GCP Users and serviceAccounts able to access direct URLs on the GS checkout bucket.
-# Other GCP entities must use presigned urls, or checkout to an external GS bucket they have access to. 
+# Other GCP entities must use presigned urls, or checkout to an external GS bucket they have access to.
 DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS="serviceAccount:619310558212-compute@developer.gserviceaccount.com,serviceAccount:caas-account@broad-dsde-mint-dev.iam.gserviceaccount.com,serviceAccount:caas-prod-account-for-dev@broad-dsde-mint-dev.iam.gserviceaccount.com,group:GROUP_All_Users@firecloud.org"
 
 AWS_SDK_LOAD_CONFIG=1 # Needed for Terraform to correctly use AWS assumed roles

--- a/infra/build_deploy_config.py
+++ b/infra/build_deploy_config.py
@@ -4,8 +4,6 @@ Build the Terraform deployment configuration files using environment variable va
 Requires a Google service account (but only to get the GCP project ID).
 """
 import os
-import glob
-import json
 import boto3
 import argparse
 from google.cloud.storage import Client
@@ -82,6 +80,7 @@ env_vars_to_infra = [
     "DSS_FLASHFLOOD_BUCKET_PROD",
     "DSS_FLASHFLOOD_BUCKET_STAGING",
     "DSS_SECRETS_STORE",
+    "DSS_VERIFY_SECRETS_NAME",
     "DSS_ZONE_NAME",
     "ES_ALLOWED_SOURCE_IP_SECRETS_NAME",
     "GCP_DEFAULT_REGION",

--- a/infra/secretsmanager/main.tf
+++ b/infra/secretsmanager/main.tf
@@ -1,0 +1,27 @@
+locals {
+  verify_secret_name = "${var.DSS_SECRETS_STORE}/${var.DSS_DEPLOYMENT_STAGE}/${var.DSS_VERIFY_SECRETS_NAME}"
+  tags = "${map(
+  "Name"      , "${var.DSS_INFRA_TAG_SERVICE}-secrets",
+  "owner"     , "${var.DSS_INFRA_TAG_OWNER}",
+  "managedBy" , "terraform",
+  "project"   , "${var.DSS_INFRA_TAG_PROJECT}",
+  "env"       , "${var.DSS_DEPLOYMENT_STAGE}",
+  "service"   , "${var.DSS_INFRA_TAG_SERVICE}"
+  )}"
+}
+
+resource "aws_secretsmanager_secret" "last_verified" {
+  name        = local.verify_secret_name
+  description = "Time of last replica verification"
+  tags        = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "last_verified_init" {
+  secret_id      = local.verify_secret_name
+  secret_string  = "1970-01-01T000000.000000Z"  # arbitrarily small
+  version_stages = ["AWSCURRENT"]
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+  depends_on     = [aws_secretsmanager_secret.last_verified]
+}

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -317,6 +317,21 @@ class TestOperations(unittest.TestCase):
         with io.BytesIO(data) as fh:
             gs_blob.upload_from_file(fh, content_type="application/octet-stream")
 
+    def test_verify_sync(self):
+        """
+        Naive test of `dss-ops.py sync verify-sync`. `verify-sync` is an
+        amalgamate of other targets that are already tested in this file,
+        so just running it and seeing if it fails or not should be a
+        sufficient test case.
+        """
+        dss.Config.set_config(dss.BucketConfig.NORMAL)
+        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+        sync.verify_sync_all([], argparse.Namespace(
+            source_replica='aws',
+            destination_replica='gcp',
+            since=datetime_to_version_format(yesterday)
+        ))
+
     def test_iam_aws_list_policies(self):
 
         def _get_aws_list_policies_kwargs(**kwargs):
@@ -333,23 +348,6 @@ class TestOperations(unittest.TestCase):
             for kw, val in kwargs.items():
                 custom_kwargs[kw] = val
             return custom_kwargs
-
-    def test_verify_sync(self):
-        """
-        Naive test of `dss-ops.py sync verify-sync`. `verify-sync` is an
-        amalgamate of other targets that are already tested in this file,
-        so just running it and seeing if it fails or not should be a
-        sufficient test case.
-        """
-        dss.Config.set_config(dss.BucketConfig.NORMAL)
-        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
-        sync.verify_sync_all([], argparse.Namespace(
-            source_replica='aws',
-            destination_replica='gcp',
-            since=datetime_to_version_format(yesterday)
-        ))
-
-    def test_iam_aws(self):
 
         def _get_fake_policy_document():
             """Utility function to get a fake policy document for mocking the AWS API"""

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -25,6 +25,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from tests import skip_on_travis
 from tests.infra import testmode
+import dss
 from dss.operations import DSSOperationsCommandDispatch
 from dss.operations.util import map_bucket_results
 from dss.operations import checkout, storage, sync, secrets, lambda_params, iam, events
@@ -332,6 +333,23 @@ class TestOperations(unittest.TestCase):
             for kw, val in kwargs.items():
                 custom_kwargs[kw] = val
             return custom_kwargs
+
+    def test_verify_sync(self):
+        """
+        Naive test of `dss-ops.py sync verify-sync`. `verify-sync` is an
+        amalgamate of other targets that are already tested in this file,
+        so just running it and seeing if it fails or not should be a
+        sufficient test case.
+        """
+        dss.Config.set_config(dss.BucketConfig.NORMAL)
+        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+        sync.verify_sync_all([], argparse.Namespace(
+            source_replica='aws',
+            destination_replica='gcp',
+            since=datetime_to_version_format(yesterday)
+        ))
+
+    def test_iam_aws(self):
 
         def _get_fake_policy_document():
             """Utility function to get a fake policy document for mocking the AWS API"""


### PR DESCRIPTION
Current limitations:
- Only checks if GCP is missing anything on AWS (not if AWS is missing anything on GCP)

How it works:
- Adds a `dss-ops.py` target `verify-sync-all` that runs `verify-sync` against all keys in a given bucket (optionally newer than a given DSS_VERSION)
- The datetime of the last replica verification is stored in SSM
- If any inconsistencies are found, the pipeline will fail.
- `.gitlab-ci.yml` is configured with two jobs - one job that verifies all blobs/files/bundles, and a job that verifies only new blobs/files/bundles.
- Gitlab will be configured to notify someone if either of the verification jobs fail. (I would appreciate feedback on who should be notified.)
- Gitlab will be configured to run both of these jobs periodically. (I would appreciate feedback on how often each check should be run.)

Does not cl*se #1680; Gitlab will need to be configured after this PR is merged. See [this comment](https://github.com/HumanCellAtlas/data-store/pull/2412#issuecomment-528573935) for schedule

This is a follow up to #2412 