### PR TITLE
Adding fusillade to bundle write operation

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -188,8 +188,10 @@ def enumerate(replica: str,
 
 
 @dss_handler
-@security.authorized_group_required(['hca'])
 def put(uuid: str, replica: str, json_request_body: dict, version: str):
+    security.assert_authorized(security.get_token_email(request.token_info),
+                               ["dss:PutBundle"],
+                               [f'arn:hca:dss:{Config.deployment_stage()}:*:bundle/{uuid}/{version}'])
     uuid = uuid.lower()
 
     files = build_bundle_file_metadata(Replica[replica], json_request_body['files'])
@@ -238,8 +240,10 @@ def bundle_file_id_metadata(bundle_file_metadata):
 
 
 @dss_handler
-@security.authorized_group_required(['hca'])
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
+    security.assert_authorized(security.get_token_email(request.token_info),
+                               ["dss:PatchBundle"],
+                               [f'arn:hca:dss:{Config.deployment_stage()}:*:bundle/{uuid}/{version}'])
     bundle = get_bundle_manifest(uuid, Replica[replica], version)
     if bundle is None:
         raise DSSException(404, "not_found", "Could not find bundle for UUID {}".format(uuid))
@@ -258,8 +262,10 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
 
 
 @dss_handler
-@security.authorized_group_required(['hca'])
 def delete(uuid: str, replica: str, json_request_body: dict, version: str = None):
+    security.assert_authorized(security.get_token_email(request.token_info),
+                               ["dss:DeleteBundle"],
+                               [f'arn:hca:dss:{Config.deployment_stage()}:*:bundle/{uuid}/{version}'])
     email = security.get_token_email(request.token_info)
 
     if email not in ADMIN_USER_EMAILS:

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -2,7 +2,6 @@
 import base64
 import json
 import logging
-import os
 
 import functools
 import jwt
@@ -10,12 +9,10 @@ import requests
 import typing
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
-from dcplib import security
 from flask import request
 
 from dss import Config
 from dss.error import DSSForbiddenException, DSSException
-from dss.util import get_gcp_credentials_file
 
 logger = logging.getLogger(__name__)
 

--- a/dss/util/security.py
+++ b/dss/util/security.py
@@ -124,20 +124,9 @@ def assert_authorized(principal: str,
                       actions: typing.List[str],
                       resources: typing.List[str]):
     resp = session.post(f"{Config.get_authz_url()}/v1/policies/evaluate",
-                        headers=DSS_AUTHZ.get_authorization_header(),
+                        headers=Config.get_ServiceAccountManager().get_authorization_header(),
                         json={"action": actions,
                               "resource": resources,
                               "principal": principal})
     if not resp.json()['result']:
         raise DSSForbiddenException()
-
-
-def create_DCPServiceAccountManager() -> security.DCPServiceAccountManager:
-    if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS'):
-        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = get_gcp_credentials_file().name
-    with open(os.environ['GOOGLE_APPLICATION_CREDENTIALS'], "r") as fh:
-        service_credentials = json.loads(fh.read())
-    return security.DCPServiceAccountManager(service_credentials, Config.get_audience())
-
-
-DSS_AUTHZ = create_DCPServiceAccountManager()

--- a/environment
+++ b/environment
@@ -16,6 +16,7 @@ export DSS_HOME="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
 EXPORT_ENV_VARS_TO_LAMBDA_ARRAY=(
     API_DOMAIN_NAME
+    AUTH_URL
     CHECKOUT_CACHE_CRITERIA
     DSS_AUTHORIZED_DOMAINS
     DSS_BLOB_PUBLIC_TTL_DAYS
@@ -35,6 +36,8 @@ EXPORT_ENV_VARS_TO_LAMBDA_ARRAY=(
     DSS_FLASHFLOOD_BUCKET
     DSS_VERSION
     DSS_XRAY_TRACE
+    DSS_AWS_FLASHFLOOD_PREFIX
+    DSS_GCP_FLASHFLOOD_PREFIX
     GCP_PROJECT_NAME
     GCP_DEFAULT_REGION
     OIDC_AUDIENCE
@@ -95,6 +98,7 @@ API_DOMAIN_NAME="dss.${DCP_DOMAIN}"
 TOKENINFO_FUNC=dss.util.security.verify_jwt
 # TODO remove https://dev.data.humancellatlas.org/ from OIDC_AUDIENCE once seperate deployments are made
 OIDC_AUDIENCE=https://dev.data.humancellatlas.org/,https://${DCP_DOMAIN}/
+AUTH_URL=https://auth.testing.data.humancellatlas.org
 OPENID_PROVIDER=https://humancellatlas.auth0.com/
 OIDC_EMAIL_CLAIM=https://auth.data.humancellatlas.org/email
 OIDC_GROUP_CLAIM=https://auth.data.humancellatlas.org/group

--- a/environment.integration
+++ b/environment.integration
@@ -17,6 +17,7 @@ ACM_CERTIFICATE_IDENTIFIER="390e82ea-a684-49f4-a4b3-857f22cee874"
 DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS="serviceAccount:1037839730885-compute@developer.gserviceaccount.com,serviceAccount:caas-account@broad-dsde-mint-test.iam.gserviceaccount.com,serviceAccount:caas-prod-account-for-test@broad-dsde-mint-test.iam.gserviceaccount.com,serviceAccount:caas-prod-account-for-int@broad-dsde-mint-integration.iam.gserviceaccount.com"
 DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE="org-humancellatlas-dss-{account_id}-${DSS_DEPLOYMENT_STAGE}-terraform"
 DSS_FLASHFLOOD_BUCKET=$DSS_FLASHFLOOD_BUCKET_INTEGRATION
+AUTH_URL=https://auth.integration.data.humancellatlas.org
 set +a
 
 if [[ -f "${DSS_HOME}/environment.integration.local" ]]; then

--- a/environment.prod
+++ b/environment.prod
@@ -21,6 +21,7 @@ DSS_ES_VOLUME_SIZE="512"  # Maximum volume size for m4.large.elasticsearch
 DSS_AUTHORIZED_DOMAINS="hca-dcp-production.iam.gserviceaccount.com hca-dcp-pipelines-prod.iam.gserviceaccount.com ${DSS_AUTHORIZED_DOMAINS}"
 DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE="org-humancellatlas-dss-{account_id}-${DSS_DEPLOYMENT_STAGE}-terraform"
 DSS_FLASHFLOOD_BUCKET=$DSS_FLASHFLOOD_BUCKET_PROD
+AUTH_URL=https://auth.data.humancellatlas.org
 set +a
 
 if [[ -f "${DSS_HOME}/environment.prod.local" ]]; then

--- a/environment.staging
+++ b/environment.staging
@@ -19,6 +19,7 @@ DSS_GCP_SERVICE_ACCOUNT_NAME="org-humancellatlas-staging"
 DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS="serviceAccount:154609999906-compute@developer.gserviceaccount.com,serviceAccount:caas-account@broad-dsde-mint-staging.iam.gserviceaccount.com,serviceAccount:caas-prod-account-for-staging@broad-dsde-mint-staging.iam.gserviceaccount.com"
 DSS_TERRAFORM_BACKEND_BUCKET_TEMPLATE="org-humancellatlas-dss-{account_id}-${DSS_DEPLOYMENT_STAGE}-terraform"
 DSS_FLASHFLOOD_BUCKET=$DSS_FLASHFLOOD_BUCKET_STAGING
+AUTH_URL=https://auth.staging.data.humancellatlas.org
 set +a
 
 if [[ -f "${DSS_HOME}/environment.staging.local" ]]; then

--- a/roles.json
+++ b/roles.json
@@ -19,7 +19,7 @@
               "dss:GetBundle",
               "dss:PostCheckout"
             ],
-            "Resource": "arn:hca:dss:${stage}:*:bundles/*"
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
           },
           {
             "Sid": "read_collections",
@@ -90,7 +90,7 @@
               "dss:PatchBundle",
               "dss:PutBundle"
             ],
-            "Resource": "arn:hca:dss:${stage}:*:bundles/*"
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
           },
           {
             "Sid": "modify_files",
@@ -123,7 +123,7 @@
             "Action": [
               "dss:GetCollections"
             ],
-            "Resource": "arn:hca:dss:{stage}:*:${fus:user}/collections"
+            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections"
           },
           {
             "Sid": "modify_collection",
@@ -134,7 +134,7 @@
               "dss:GetCollection",
               "dss:PatchCollection"
             ],
-            "Resource": "arn:hca:dss:{stage}:*:${fus:user}/collections/{uuid}"
+            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections/{uuid}"
           }
         ]
       }
@@ -152,7 +152,7 @@
               "dss:PatchBundle",
               "dss:PutBundle"
             ],
-            "Resource": "arn:hca:dss:${stage}:*:bundles/*"
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
           },
           {
             "Sid": "modify_files",
@@ -162,7 +162,7 @@
               "dss:HeadFiles",
               "dss:PutFiles"
             ],
-            "Resource": "arn:hca:dss:${stage}:*:files/*"
+            "Resource": "arn:hca:dss:${stage}:*:file/*"
           },
           {
             "Sid": "read_checkout",
@@ -178,7 +178,7 @@
             "Action": [
               "dss:GetCollections"
             ],
-            "Resource": "arn:hca:dss:{stage}:*:*/collections"
+            "Resource": "arn:hca:dss:${stage}:*:*/collections"
           },
           {
             "Sid": "modify_collection",
@@ -189,7 +189,7 @@
               "dss:GetCollection",
               "dss:PatchCollection"
             ],
-            "Resource": "arn:hca:dss:{stage}:*:*/collections/{uuid}"
+            "Resource": "arn:hca:dss:${stage}:*:*/collections/{uuid}"
           },
           {
             "Sid": "modify_subscription",

--- a/tests/infra/auth_tests_mixin.py
+++ b/tests/infra/auth_tests_mixin.py
@@ -1,10 +1,11 @@
 import requests
+
 from tests import get_auth_header
 from tests.infra import DSSAssertMixin
 
 
 class TestAuthMixin(DSSAssertMixin):
-    def _test_auth_errors(self, method: str, url: str, **kwargs):
+    def _test_auth_errors(self, method: str, url: str, skip_group_test=False, **kwargs):
         with self.subTest("Gibberish auth header"):  # type: ignore
             resp = self.assertResponse(method, url, requests.codes.unauthorized, headers=get_auth_header(False),
                                        **kwargs)
@@ -16,11 +17,13 @@ class TestAuthMixin(DSSAssertMixin):
             self.assertEqual(resp.response.headers['Content-Type'], "application/problem+json")
             self.assertEqual(resp.json['title'], 'No authorization token provided')
 
-        with self.subTest("unauthorized group"):  # type: ignore
-            resp = self.assertResponse(method, url, requests.codes.forbidden, headers=get_auth_header(group='someone'),
-                                       **kwargs)
-            self.assertEqual(resp.response.headers['Content-Type'], "application/problem+json")
-            self.assertEqual(resp.json['title'], 'User is not authorized to access this resource')
+        if not skip_group_test:
+            with self.subTest("unauthorized group"):  # type: ignore
+                resp = self.assertResponse(method, url, requests.codes.forbidden,
+                                           headers=get_auth_header(group='someone'),
+                                           **kwargs)
+                self.assertEqual(resp.response.headers['Content-Type'], "application/problem+json")
+                self.assertEqual(resp.json['title'], 'User is not authorized to access this resource')
 
         # Don't run this test for test_bundle and test_file because they don't need email
         if not url.split('/')[2] in ('files', 'bundles'):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -479,6 +479,7 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
                 builder.add_query("version", bundle_version)
             url = str(builder)
             self._test_auth_errors('put', url,
+                                   skip_group_test=True,
                                    json_request_body=dict(
                                        files=[
                                            dict(


### PR DESCRIPTION
fixes deployment issues cause by #2303 
### Test plan
- Added roles `dss-admin` and `dss_privilaged_user` roles to `fusillade-dev` using ./script/setup_authz.py.
- Added `travis-test` google service account as `fusillade_admin`, and `dss_admin` for `fusillade-dev`

### Deployment instructions & migrations
- Run ./script/setup_authz.py for each deployment of DSS.
- Make users `dss_privilaged_users` who need permission to delete and write bundles.

### Release notes
- add script to setup DSS with fusillade. A google service account that has permission to modify fusillade is required before running.
- Added a folder for to created, and manage dss related roles.
- Using fusillade to authorize bundle related write API requests
