### PR TITLE
Improve security in dss-ops secrets handling

### DIFF
--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -16,6 +16,7 @@ from dss.operations import dispatch
 from dss.operations.ssm_params import get_ssm_variable_prefix, fix_ssm_variable_prefix
 from dss.operations.ssm_params import set_ssm_parameter, unset_ssm_parameter
 from dss.operations.ssm_params import set_ssm_environment
+from dss.operations.secrets import fix_secret_variable_prefix
 
 from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore
 from dss.util.aws.clients import es as es_client  # type: ignore
@@ -33,33 +34,6 @@ def get_elasticsearch_endpoint() -> str:
 
 
 def get_admin_emails() -> str:
-
-    def get_secret_variable_prefix() -> str:
-        # TODO: this functionality should be moved to dss/operations/secrets.py
-        store_name = os.environ["DSS_SECRETS_STORE"]
-        stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
-        store_prefix = f"{store_name}/{stage_name}"
-        return store_prefix
-
-    def fix_secret_variable_prefix(secret_name: str) -> str:
-        # TODO: this functionality should be moved to dss/operations/secrets.py
-        prefix = get_secret_variable_prefix()
-        if not (secret_name.startswith(prefix) or secret_name.startswith("/" + prefix)):
-            secret_name = f"{prefix}/{secret_name}"
-        return secret_name
-
-    def fetch_secret_safely(secret_name: str) -> dict:
-        # TODO: this functionality should be moved to dss/operations/secrets.py
-        try:
-            response = sm_client.get_secret_value(SecretId=secret_name)
-        except ClientError as e:
-            if 'Error' in e.response:
-                errtype = e.response['Error']['Code']
-                if errtype == 'ResourceNotFoundException':
-                    raise RuntimeError(f"Error: secret {secret_name} was not found!")
-            raise RuntimeError(f"Error: could not fetch secret {secret_name} from secrets manager")
-        else:
-            return response
 
     gcp_var = os.environ["GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME"]
     gcp_secret_id = fix_secret_variable_prefix(gcp_var)
@@ -179,8 +153,12 @@ lambda_params = dispatch.target("lambda", arguments={}, help=__doc__)
 json_flag_options = dict(
     default=False, action="store_true", help="format the output as JSON if this flag is present"
 )
-dryrun_flag_options = dict(default=False, action="store_true", help="do a dry run of the actual operation")
-quiet_flag_options = dict(default=False, action="store_true", help="suppress output")
+dryrun_flag_options = dict(
+    default=False, action="store_true", help="do a dry run of the actual operation"
+)
+quiet_flag_options = dict(
+    default=False, action="store_true", help="suppress output"
+)
 
 
 @lambda_params.action(
@@ -314,8 +292,8 @@ def lambda_update(argv: typing.List[str], args: argparse.Namespace):
     Update the stored (and optionally, deployed) lambda environment
     using variable values from the current environment.
     """
-    if args.force is False:
-        # Make sure the user really wants to do this
+    if not args.force and not args.dry_run:
+        # Prompt the user to make sure they really want to do this
         confirm = f"""
         *** WARNING!!! ***
 

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -16,7 +16,7 @@ from dss.operations import dispatch
 from dss.operations.ssm_params import get_ssm_variable_prefix, fix_ssm_variable_prefix
 from dss.operations.ssm_params import set_ssm_parameter, unset_ssm_parameter
 from dss.operations.ssm_params import set_ssm_environment
-from dss.operations.secrets import fix_secret_variable_prefix
+from dss.operations.secrets import fix_secret_variable_prefix, fetch_secret_safely
 
 from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore
 from dss.util.aws.clients import es as es_client  # type: ignore

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -17,19 +17,50 @@ from dss.util.aws.clients import secretsmanager  # type: ignore
 logger = logging.getLogger(__name__)
 
 
-def get_secretsmanager_prefix(args):
+def get_secret_store_prefix() -> str:
     """
-    Use information from the environment to assemble
-    the necessary prefix for accessing variables in
-    the SecretsManager.
+    Use information from the environment to assemble the necessary prefix for accessing variables in the
+    SecretsManager.
     """
     store_name = os.environ["DSS_SECRETS_STORE"]
     stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
-    store_prefix = f"{store_name}/{stage_name}/"
+    store_prefix = f"{store_name}/{stage_name}"
     return store_prefix
 
 
+def fix_secret_variable_prefix(secret_name: str) -> str:
+    """
+    Given a secret name, check if it already has the secrets store prefix.
+    """
+    prefix = get_secret_store_prefix()
+    if not (secret_name.startswith(prefix) or secret_name.startswith("/" + prefix)):
+        secret_name = f"{prefix}/{secret_name}"
+    return secret_name
+
+
+def fetch_secret_safely(secret_name: str) -> dict:
+    """
+    Fetch a secret from the store safely, raising errors if the secret is not found or is marked for deletion.
+    """
+    try:
+        response = sm_client.get_secret_value(SecretId=secret_name)
+    except ClientError as e:
+        if "Error" in e.response:
+            errtype = e.response["Error"]["Code"]
+            if errtype == "ResourceNotFoundException":
+                raise RuntimeError(f"Error: secret {secret_name} was not found!")
+        raise RuntimeError(f"Error: could not fetch secret {secret_name} from secrets manager")
+    else:
+        return response
+
+
 events = dispatch.target("secrets", arguments={}, help=__doc__)
+
+
+json_flag_options = dict(
+    default=False, action="store_true", help="format the output as JSON if this flag is present"
+)
+dryrun_flag_options = dict(default=False, action="store_true", help="do a dry run of the actual operation")
 
 
 @events.action(
@@ -38,16 +69,16 @@ events = dispatch.target("secrets", arguments={}, help=__doc__)
         "--json": dict(
             default=False,
             action="store_true",
-            help="format the output as JSON if this flag is present",
+            help="format the output as a JSON list if this flag is present",
         )
     },
 )
 def list_secrets(argv: typing.List[str], args: argparse.Namespace):
     """
-    Print a list of names of every secret variable in the secrets manager
-    for the given store and stage.
+    Print a list of names of every secret variable in the secrets manager for the DSS secrets manager
+    for $DSS_DEPLOYMENT_STAGE.
     """
-    store_prefix = get_secretsmanager_prefix(args)
+    store_prefix = get_secret_store_prefix()
 
     paginator = secretsmanager.get_paginator("list_secrets")
 
@@ -74,111 +105,78 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 @events.action(
     "get",
     arguments={
-        "--secret-names": dict(
-            required=True,
-            nargs="*",
-            help="names of secrets to retrieve (separate multiple values with spaces)",
-        ),
-        "--json": dict(
+        "secret_name": dict(help="the name of the secret to retrieve (separate multiple values with spaces)"),
+        "--outfile": dict(required=False, type=str, help="specify an output file where the secret will be saved"),
+        "--force": dict(
             default=False,
             action="store_true",
-            help="format the output as JSON if this flag is present",
+            help="overwrite the output file, if it already exists; must be used with --output flag.",
         ),
     },
 )
 def get_secret(argv: typing.List[str], args: argparse.Namespace):
     """
-    Get the value of the secret variable (or list of variables) specified by
-    the --secret-names flag; separate multiple secret names using a space.
+    Get the value of the secret variable specified by secret_name.
     """
-    # Note: this function should not print anything except the final JSON,
-    # in case the user pipes the JSON output of this script to something else
+    # Note: this function should not print anything except the final JSON, in case the user pipes the JSON
+    # output of this script to something else
 
-    store_prefix = get_secretsmanager_prefix(args)
+    store_prefix = get_secret_store_prefix()
 
-    # Make sure something was specified for secret name(s)
-    if len(args.secret_names) == 0:
-        raise RuntimeError(
-            "Unable to set secret: no secret name was specified! Use the --secret-names flag."
-        )
+    if args.outfile:
+        if os.path.exists(args.outfile) and not args.force:
+            raise RuntimeError(
+                f"Error: file {args.outfile} already exists, use the --force flag to overwrite it"
+            )
+
+    secret_name = fix_secret_variable_prefix(args.secret_name)
+
+    # Attempt to obtain secret
+    try:
+        response = secretsmanager.get_secret_value(SecretId=secret_name)
+        secret_val = response["SecretString"]
+    except ClientError:
+        # A secret variable with that name does not exist
+        print(f"Error: Resource not found: {secret_name}")
     else:
-        secret_names = args.secret_names
-
-    # Tack on the store prefix if it isn't there already
-    for i in range(len(secret_names)):
-        secret_name = secret_names[i]
-        if not secret_name.startswith(store_prefix):
-            secret_names[i] = store_prefix + secret_name
-
-    # Determine if we should format output as JSON
-    use_json = False
-    if args.json is True:
-        use_json = True
-
-    for secret_name in secret_names:
-        # Attempt to obtain secret
-        try:
-            response = secretsmanager.get_secret_value(SecretId=secret_name)
-            secret_val = response["SecretString"]
-        except ClientError:
-            # A secret variable with that name does not exist
-            logger.warning(f"Resource not found: {secret_name}")
-        else:
-            # Get operation was successful, secret variable exists
-            if use_json:
-                # Sometimes secret_val can be a dictionary
-                try:
-                    secret_val = json.loads(secret_val)
-                except json.decoder.JSONDecodeError:
-                    pass
-                print(json.dumps({secret_name: secret_val}, indent=4))
-            else:
-                print(f"{secret_name}={secret_val}")
+        # Get operation was successful, secret variable exists
+        if args.outfile:
+            sys.stdout = open(args.outfile, "w")
+        print(secret_val)
+        if args.outfile:
+            sys.stdout = sys.__stdout__
 
 
 @events.action(
     "set",
     arguments={
-        "--secret-name": dict(
-            required=True, help="name of secret to set (limit 1 at a time)"
-        ),
-        "--secret-value": dict(
-            required=False,
-            default=None,
-            help="value of secret to set (optional, if not present then stdin will be used)",
-        ),
-        "--dry-run": dict(
-            default=False,
-            action="store_true",
-            help="do a dry run of the actual operation",
+        "secret_name": dict(help="name of secret to set (limit 1 at a time)"),
+        "--dry-run": dict(default=False, action="store_true", help="do a dry run of the actual operation"),
+        "--infile": dict(help="specify an input file whose contents is the secret value"),
+        "--force": dict(
+            default=False, action="store_true", help="force the action to happen (no interactive prompt)"
         ),
     },
 )
 def set_secret(argv: typing.List[str], args: argparse.Namespace):
-    """Set the value of the secret variable specified by the --secret-name flag"""
-    store_prefix = get_secretsmanager_prefix(args)
+    """Set the value of the secret variable."""
+    store_prefix = get_secret_store_prefix()
 
-    # Make sure a secret name was specified
-    if len(args.secret_name) == 0:
-        raise RuntimeError(
-            "Unable to set secret: no secret name was specified! Use the --secret-name flag."
-        )
-    secret_name = args.secret_name
+    secret_name = fix_secret_variable_prefix(args.secret_name)
 
-    # Tack on the store prefix if it isn't there already
-    if not secret_name.startswith(store_prefix):
-        secret_name = store_prefix + secret_name
-
-    # Decide what to use for input
-    if args.secret_value is not None:
-        secret_val = args.secret_value
+    # Decide what to use for infile
+    secret_val = None
+    if args.infile is not None:
+        if os.path.isfile(args.infile):
+            with open(args.infile, 'r') as f:
+                secret_val = f.read()
+        else:
+            raise RuntimeError(f"Error: specified input file {args.infile} does not exist!")
     else:
         # Use stdin (input piped to this script) as secret value.
         # stdin provides secret value, flag --secret-name provides secret name.
-        if not select.select([sys.stdin], [], [])[0]:
-            err_msg = f"No data in stdin, cannot set secret {secret_name} without "
-            err_msg += "a value from stdin or without --secret-value flag!"
-            raise RuntimeError(err_msg)
+        if not select.select([sys.stdin], [], [], 0.0)[0]:
+            raise RuntimeError("Error: stdin was empty! A secret value must be provided via stdin")
         secret_val = sys.stdin.read()
 
     # Create or update
@@ -188,50 +186,58 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
 
     except ClientError:
         # A secret variable with that name does not exist, so create it
-
         if args.dry_run:
-            # Create it for fakes
-            print(
-                f"Secret variable {secret_name} not found in secrets manager, dry-run creating it"
-            )
+            print(f"Secret variable {secret_name} not found in secrets manager, dry-run creating it")
         else:
-            # Create it for real
-            print(
-                f"Secret variable {secret_name} not found in secrets manager, creating it"
-            )
+            if args.infile:
+                print(f"Secret variable {secret_name} not found in secrets manager, creating from input file")
+            else:
+                print(f"Secret variable {secret_name} not found in secrets manager, creating from stdin")
             secretsmanager.create_secret(Name=secret_name, SecretString=secret_val)
 
     else:
         # Get operation was successful, secret variable exists
+        # Prompt the user before overwriting, unless --force flag present
+        if not args.force and not args.dry_run:
+            # Prompt the user to make sure they really want to do this
+            confirm = f"""
+            *** WARNING!!! ***
+
+            The secret you are setting currently has a value. Calling the
+            set secret function will overwrite the current value of the
+            secret!
+
+            Note:
+            - To do a dry run of this operation first, use the --dry-run flag.
+            - To ignore this warning, use the --force flag.
+
+            Are you really sure you want to update the secret?
+            (Type 'y' or 'yes' to confirm):
+            """
+            response = input(confirm)
+            if response.lower() not in ["y", "yes"]:
+                raise RuntimeError("You safely aborted the set secret operation!")
+
         if args.dry_run:
-            # Update it for fakes
-            print(
-                f"Secret variable {secret_name} found in secrets manager, dry-run updating it"
-            )
+            print(f"Secret variable {secret_name} found in secrets manager, dry-run updating it")
         else:
-            # Update it for real
-            print(
-                f"Secret variable {secret_name} found in secrets manager, updating it"
-            )
+            if args.infile:
+                print(f"Secret variable {secret_name} not found in secrets manager, updating from input file")
+            else:
+                print(f"Secret variable {secret_name} not found in secrets manager, updating from stdin")
             secretsmanager.update_secret(SecretId=secret_name, SecretString=secret_val)
 
 
 @events.action(
     "delete",
     arguments={
-        "--secret-name": dict(
-            required=True, help="name of secret to delete (limit 1 at a time)"
-        ),
+        "secret_name": dict(help="name of secret to delete (limit 1 at a time)"),
         "--force": dict(
             default=False,
             action="store_true",
             help="force the delete operation to happen non-interactively (no user prompt)",
         ),
-        "--dry-run": dict(
-            default=False,
-            action="store_true",
-            help="do a dry run of the actual operation",
-        ),
+        "--dry-run": dict(default=False, action="store_true", help="do a dry run of the actual operation"),
     },
 )
 def del_secret(argv: typing.List[str], args: argparse.Namespace):
@@ -239,27 +245,9 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
     Delete the value of the secret variable specified by the
     --secret-name flag from the secrets manager
     """
-    store_prefix = get_secretsmanager_prefix(args)
+    store_prefix = get_secret_store_prefix()
 
-    # Make sure a secret name was specified
-    if len(args.secret_name) == 0:
-        raise RuntimeError(
-            "Unable to set secret: no secret name was specified! Use the --secret-name flag."
-        )
-    secret_name = args.secret_name
-
-    # Tack on the store prefix if it isn't there already
-    if not secret_name.startswith(store_prefix):
-        secret_name = store_prefix + secret_name
-
-    if args.force is False:
-        # Make sure the user really wants to do this
-        confirm = f"""
-        Are you really sure you want to delete secret {secret_name}? (Type 'y' or 'yes' to confirm):
-        """
-        response = input(confirm)
-        if response.lower() not in ["y", "yes"]:
-            raise RuntimeError("You safely aborted the delete secret operation!")
+    secret_name = fix_secret_variable_prefix(args.secret_name)
 
     try:
         # Start by trying to get the secret variable
@@ -271,20 +259,27 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
 
     except secretsmanager.exceptions.InvalidRequestException:
         # Already deleted secret var
-        logger.warning(
-            f"Secret variable {secret_name} already marked for deletion in secrets manager!"
-        )
+        logger.warning(f"Secret variable {secret_name} already marked for deletion in secrets manager!")
 
     else:
         # Get operation was successful, secret variable exists
+        if not args.force and not args.dry_run:
+            # Make sure the user really wants to do this
+            confirm = f"""
+            *** WARNING!!! ****
+
+            You are about to delete secret {secret_name} from the secrets
+            manager. Are you sure you want to delete the secret?
+            (Type 'y' or 'yes' to confirm):
+            """
+            response = input(confirm)
+            if response.lower() not in ["y", "yes"]:
+                raise RuntimeError("You safely aborted the delete secret operation!")
+
         if args.dry_run:
             # Delete it for fakes
-            print(
-                f"Secret variable {secret_name} found in secrets manager, dry-run deleting it"
-            )
+            print(f"Secret variable {secret_name} found in secrets manager, dry-run deleting it")
         else:
             # Delete it for real
-            print(
-                f"Secret variable {secret_name} found in secrets manager, deleting it"
-            )
+            print(f"Secret variable {secret_name} found in secrets manager, deleting it")
             secretsmanager.delete_secret(SecretId=secret_name)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -107,7 +107,7 @@ def list_secrets(argv: typing.List[str], args: argparse.Namespace):
 @events.action(
     "get",
     arguments={
-        "secret_name": dict(help="the name of the secret to retrieve (separate multiple values with spaces)"),
+        "secret_name": dict(help="the name of the secret to retrieve"),
         "--outfile": dict(required=False, type=str, help="specify an output file where the secret will be saved"),
         "--force": dict(
             default=False,

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -304,7 +304,7 @@ class TestOperations(unittest.TestCase):
 
         with self.subTest("Create a new secret"):
             # Monkeypatch the secrets manager
-            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+            with mock.patch("dss.operations.secrets.sm_client") as sm:
                 # Creating a new variable will first call get, which will not find it
                 sm.get_secret_value = mock.MagicMock(return_value=None, side_effect=ClientError({}, None))
                 # Next we will use the create secret command
@@ -344,7 +344,7 @@ class TestOperations(unittest.TestCase):
                 subprocess.call(['rm', '-f', tempfile])
 
         with self.subTest("List secrets"):
-            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+            with mock.patch("dss.operations.secrets.sm_client") as sm:
                 # Listing secrets requires creating a paginator first,
                 # so mock what the paginator returns
                 class MockPaginator(object):
@@ -365,7 +365,7 @@ class TestOperations(unittest.TestCase):
                 self.assertIn(testvar_name, all_secrets_output)
 
         with self.subTest("Get secret value"):
-            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+            with mock.patch("dss.operations.secrets.sm_client") as sm:
                 # Requesting the variable will try to get secret value and succeed
                 sm.get_secret_value.return_value = {"SecretString": testvar_value}
                 # Now run get secret value in JSON mode and non-JSON mode
@@ -398,7 +398,7 @@ class TestOperations(unittest.TestCase):
                 subprocess.call(['rm', '-f', tempfile])
 
         with self.subTest("Update existing secret"):
-            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+            with mock.patch("dss.operations.secrets.sm_client") as sm:
                 # Updating the variable will try to get secret value and succeed
                 sm.get_secret_value = mock.MagicMock(return_value={"SecretString": testvar_value})
                 # Next we will call the update secret command
@@ -434,7 +434,7 @@ class TestOperations(unittest.TestCase):
                 subprocess.call(['rm', '-f', tempfile])
 
         with self.subTest("Delete secret"):
-            with mock.patch("dss.operations.secrets.secretsmanager") as sm:
+            with mock.patch("dss.operations.secrets.sm_client") as sm:
                 # Deleting the variable will try to get secret value and succeed
                 sm.get_secret_value = mock.MagicMock(return_value={"SecretString": testvar_value})
                 sm.delete_secret = mock.MagicMock(return_value=None)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -331,17 +331,23 @@ class TestOperations(unittest.TestCase):
                     )
 
                 # Provide secret via infile
-                with tempfile.NamedTemporaryFile(prefix='.dss-test-operations-temp-input') as f:
+                with tempfile.NamedTemporaryFile(prefix='dss-test-operations-new-secret-temp-input', mode='w') as f:
                     f.write(testvar_value)
                     secrets.set_secret(
-                        [], argparse.Namespace(secret_name=testvar_name, dry_run=False, infile=f.name, force=True)
+                        [],
+                        argparse.Namespace(
+                            secret_name=testvar_name, dry_run=False, infile=f.name, force=True, quiet=True
+                        ),
                     )
 
                 # Check error-catching with non-existent infile
-                missingfile = 'this-file-is-not-here'
+                mf = 'this-file-is-not-here'
                 with self.assertRaises(RuntimeError):
                     secrets.set_secret(
-                        [], argparse.Namespace(secret_name=testvar_name, dry_run=False, infile=missingfile, force=True)
+                        [],
+                        argparse.Namespace(
+                            secret_name=testvar_name, dry_run=False, infile=mf, force=True, quiet=True
+                        ),
                     )
 
         with self.subTest("List secrets"):
@@ -373,15 +379,7 @@ class TestOperations(unittest.TestCase):
                 # and verify variable name/value is in both.
 
                 # New output file
-                with tempfile.NamedTemporaryFile(prefix='.dss-test-operations-temp-output') as f:
-                    # Use a new, non-existent output file
-                    secrets.get_secret(
-                        [], argparse.Namespace(secret_name=testvar_name, outfile=f.name, force=False)
-                    )
-                    with open(f.name, 'r') as fr:
-                        file_contents = fr.read()
-                    self.assertIn(testvar_value, file_contents)
-
+                with tempfile.NamedTemporaryFile(prefix='dss-test-operations-get-secret-temp-output', mode='w') as f:
                     # Try to overwrite outfile without --force
                     with self.assertRaises(RuntimeError):
                         secrets.get_secret(
@@ -415,22 +413,28 @@ class TestOperations(unittest.TestCase):
                 with SwapStdin(testvar_value2):
                     secrets.set_secret(
                         [],
-                        argparse.Namespace(secret_name=testvar_name, dry_run=True, infile=None, force=True),
+                        argparse.Namespace(
+                            secret_name=testvar_name, dry_run=True, infile=None, force=True, quiet=True
+                        ),
                     )
 
                 # Use stdin
                 with SwapStdin(testvar_value2):
                     secrets.set_secret(
                         [],
-                        argparse.Namespace(secret_name=testvar_name, dry_run=False, infile=None, force=True),
+                        argparse.Namespace(
+                            secret_name=testvar_name, dry_run=False, infile=None, force=True, quiet=True
+                        ),
                     )
 
                 # Use input file
-                with tempfile.NamedTemporaryFile(prefix='.dss-test-operations-temp-input') as f:
+                with tempfile.NamedTemporaryFile(prefix='dss-test-operations-update-secret-temp-input', mode='w') as f:
                     f.write(testvar_value2)
                     secrets.set_secret(
                         [],
-                        argparse.Namespace(secret_name=testvar_name, dry_run=False, infile=f.name, force=True),
+                        argparse.Namespace(
+                            secret_name=testvar_name, dry_run=False, infile=f.name, force=True, quiet=True
+                        ),
                     )
 
         with self.subTest("Delete secret"):
@@ -442,12 +446,12 @@ class TestOperations(unittest.TestCase):
                 # Delete secret
                 # Dry run first
                 secrets.del_secret(
-                    [], argparse.Namespace(secret_name=testvar_name, force=True, dry_run=True)
+                    [], argparse.Namespace(secret_name=testvar_name, force=True, dry_run=True, quiet=True)
                 )
 
                 # Real thing
                 secrets.del_secret(
-                    [], argparse.Namespace(secret_name=testvar_name, force=True, dry_run=False)
+                    [], argparse.Namespace(secret_name=testvar_name, force=True, dry_run=False, quiet=True)
                 )
 
     def test_ssmparams_crud(self):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -343,7 +343,6 @@ class TestOperations(unittest.TestCase):
                 # Clean up
                 subprocess.call(['rm', '-f', tempfile])
 
-
         with self.subTest("List secrets"):
             with mock.patch("dss.operations.secrets.secretsmanager") as sm:
                 # Listing secrets requires creating a paginator first,

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -427,9 +427,9 @@ class TestOperations(unittest.TestCase):
 
                 # Use input file
                 with tempfile.NamedTemporaryFile(prefix='.dss-test-operations-temp-input') as f:
-                    f.write(tetvar_value2)
+                    f.write(testvar_value2)
                     secrets.set_secret(
-                        [], 
+                        [],
                         argparse.Namespace(secret_name=testvar_name, dry_run=False, infile=f.name, force=True),
                     )
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -383,6 +383,10 @@ class TestOperations(unittest.TestCase):
                 self.assertIn(testvar_value, file_contents)
 
                 # Output file already exists, use force
+                with self.assertRaises(RuntimeError):
+                    secrets.get_secret(
+                        [], argparse.Namespace(secret_name=testvar_name, outfile=tempfile, force=False)
+                    )
                 secrets.get_secret(
                     [], argparse.Namespace(secret_name=testvar_name, outfile=tempfile, force=True)
                 )
@@ -409,7 +413,7 @@ class TestOperations(unittest.TestCase):
                 with SwapStdin(testvar_value2):
                     secrets.set_secret(
                         [],
-                        argparse.Namespace(secret_name=testvar_name, dry_run=False, infile=None, force=True),
+                        argparse.Namespace(secret_name=testvar_name, dry_run=True, infile=None, force=True),
                     )
 
                 # Use stdin


### PR DESCRIPTION
This addresses #2374 (issue) as well as #2423 (issue), both related to improving the existing functionality for secrets handling in dss-ops.

This will also unblock #2359 (issue - remove and replace set_secrets and fetch_secrets from other operational toolling) and PR #2370 (associated pull request).

### Test plan

This implements new tests in `tests/test_operations.py`

### Deployment instructions & migrations

N/A