### PR TITLE
Testing upload, get_bundle, and checkout with different replicas

### DIFF
--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -73,13 +73,13 @@ class Smoketest(BaseSmokeTest):
                 self.subscription_delete(replica, subscription_id)
 
         with self.subTest(f"{starting_replica.name}: Create the bundle"):
-            upload_response = self.upload_bundle(replica, test_bucket, self.bundle_dir)
+            upload_response = self.upload_bundle(starting_replica, test_bucket, self.bundle_dir)
             bundle_uuid = upload_response['bundle_uuid']
             bundle_version = upload_response['version']
             file_count = len(upload_response['files'])
 
         with self.subTest(f"{starting_replica.name}: Download that bundle"):
-            self._test_get_bundle(replica, bundle_uuid)
+            self._test_get_bundle(starting_replica, bundle_uuid)
 
         with self.subTest(f"{starting_replica.name}: Initiate a bundle checkout"):
             checkout_response = self.checkout_initiate(replica, bundle_uuid)
@@ -88,7 +88,7 @@ class Smoketest(BaseSmokeTest):
             self._test_replica_sync(replica, bundle_uuid)
 
         with self.subTest(f"{starting_replica.name}: Wait for the checkout to complete and assert its success"):
-            self._test_checkout(replica, bundle_uuid, bundle_version,
+            self._test_checkout(starting_replica, bundle_uuid, bundle_version,
                                 checkout_job_id, checkout_bucket, file_count)
 
         for replica in self.replicas:


### PR DESCRIPTION
Previously we were only performing these tests on the last replica set here: https://github.com/HumanCellAtlas/data-store/blob/4b10ceea51249995cbe89ba9f109dcb980188a01/tests/test_smoketest.py#L61