### PR TITLE
[easy] Add GCP function error handling.

### DIFF
--- a/scripts/deploy_gcf.py
+++ b/scripts/deploy_gcf.py
@@ -189,7 +189,9 @@ for t in range(600):
         sys.stderr.write(f'ERROR!  While deploying Google cloud function: {response["metadata"]["target"]}\n'
                          f'{response["error"]}\n'
                          f'See: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto '
-                         f'for status codes. ^\n')
+                         f'for status codes. ^\n'
+                         f'Error code 10 seems to be a common return code when Google messes up internally: '
+                         f'https://github.com/GoogleCloudPlatform/cloud-functions-go/issues/30\n')
         break
     sys.stderr.write(".")
     sys.stderr.flush()

--- a/scripts/deploy_gcf.py
+++ b/scripts/deploy_gcf.py
@@ -182,8 +182,14 @@ except google.cloud.exceptions.Conflict:
 sys.stderr.write("Waiting for deployment...")
 sys.stderr.flush()
 for t in range(600):
-    if gcf_conn.api_request("GET", f"/{deploy_op['name']}").get("response", {}).get("status") == "READY":
+    response = gcf_conn.api_request("GET", f"/{deploy_op['name']}")
+    if response.get("response", {}).get("status") == "READY":
         break
+    if response.get("error"):
+        sys.stderr.write(f'ERROR!  While deploying Google cloud function: {response["metadata"]["target"]}\n'
+                         f'{response["error"]}\n'
+                         f'See: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto '
+                         f'for status codes. ^\n')
     sys.stderr.write(".")
     sys.stderr.flush()
     time.sleep(5)

--- a/scripts/deploy_gcf.py
+++ b/scripts/deploy_gcf.py
@@ -190,6 +190,7 @@ for t in range(600):
                          f'{response["error"]}\n'
                          f'See: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto '
                          f'for status codes. ^\n')
+        break
     sys.stderr.write(".")
     sys.stderr.flush()
     time.sleep(5)


### PR DESCRIPTION
Google cloud functions were failing for a few hours due to google cloud function flakiness.  This error handling should hopefully save time in the future trying to figure out why google cloud functions are breaking for no good reason.