### PR TITLE
Dss Sync Filter: Integration Test Refactor

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -96,7 +96,7 @@ class DSSSyncMixin:
         self.assertEqual(s3_blob.content_type, gs_blob.content_type)
 
 
-@testmode.integration
+@testmode.standalone
 class TestSyncUtils(unittest.TestCase, DSSSyncMixin):
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)


### PR DESCRIPTION
Removes special `blob_keys` used within sync tests to pass through filter.