### PR TITLE
[DO NOT MERGE] Add explicit server tests to gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,12 @@ unit_tests:
   script:
     - make -j4 parallel_test
 
+test_server:
+  extends: .tests
+  script:
+    - make tests/test_server.py
+    - make -j4 tests/test_server.py
+
 test_search:
   extends: .tests
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,9 @@ jobs:
     - MAKE_ARGS="-j4 parallel_test"
   - stage: test
     env:
+    - MAKE_ARGS="-j1 tests/test_visitation.py"
+  - stage: test
+    env:
     - MAKE_ARGS="-j1 tests/test_search.py"
   - stage: test
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,12 @@ jobs:
     - MAKE_ARGS="-j1 tests/test_search.py"
   - stage: test
     env:
+    - MAKE_ARGS="-j1 tests/test_server.py"
+  - stage: test
+    env:
+    - MAKE_ARGS="-j4 tests/test_server.py"
+  - stage: test
+    env:
     - MAKE_ARGS="-j1 tests/test_indexer.py"
     - DSS_UNITTEST_OPTS="-v TestAWSIndexer"
   - stage: test

--- a/dss/config.py
+++ b/dss/config.py
@@ -417,14 +417,14 @@ class Config:
 
     @staticmethod
     def get_authz_url():
-        if Config._CURRENT_CONFIG == BucketConfig.NORMAL:
-            if Config._AUTH_URL is None:
-                Config._AUTH_URL = Config._get_required_envvar("AUTH_URL")
-            return Config._AUTH_URL
-        elif (Config._CURRENT_CONFIG == BucketConfig.TEST or Config._CURRENT_CONFIG == BucketConfig.TEST_FIXTURE):
+        if Config._CURRENT_CONFIG in [BucketConfig.TEST, BucketConfig.TEST_FIXTURE]:
             host = "127.0.0.1"
             port = "54321"
             return f"http://{host}:{port}"
+        else:
+            if Config._AUTH_URL is None:
+                Config._AUTH_URL = Config._get_required_envvar("AUTH_URL")
+            return Config._AUTH_URL
 
     @staticmethod
     def get_ServiceAccountManager() -> security.DCPServiceAccountManager:

--- a/dss/config.py
+++ b/dss/config.py
@@ -3,6 +3,7 @@ import functools
 import json
 import os
 import typing
+from dss.util import networking
 from contextlib import contextmanager
 from enum import Enum, EnumMeta, auto
 
@@ -416,9 +417,14 @@ class Config:
 
     @staticmethod
     def get_authz_url():
-        if Config._AUTH_URL is None:
-            Config._AUTH_URL = Config._get_required_envvar("AUTH_URL")
-        return Config._AUTH_URL
+        if Config._CURRENT_CONFIG == BucketConfig.NORMAL:
+            if Config._AUTH_URL is None:
+                Config._AUTH_URL = Config._get_required_envvar("AUTH_URL")
+            return Config._AUTH_URL
+        elif (Config._CURRENT_CONFIG == BucketConfig.TEST or Config._CURRENT_CONFIG == BucketConfig.TEST_FIXTURE):
+            host = "127.0.0.1"
+            port = "54321"
+            return f"http://{host}:{port}"
 
     @staticmethod
     def get_ServiceAccountManager() -> security.DCPServiceAccountManager:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ import os
 import sys
 from io import StringIO
 
-from dss import Config
+from dss import Config, BucketConfig
 from dss.api import bundles
 from dss.util.version import datetime_to_version_format
 from dss.util import get_gcp_credentials_file

--- a/tests/infra/mock_fusillade.py
+++ b/tests/infra/mock_fusillade.py
@@ -1,0 +1,159 @@
+import chalice.config
+import functools
+import os
+import sys
+import signal
+import types
+import requests
+import cgi
+import json
+import subprocess
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from chalice.cli import CLIFactory
+from chalice.local import LocalDevServer, ChaliceRequestHandler
+import socketserver
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from dss import Config, BucketConfig
+
+
+def get_multiprocess_mock_fusillade_pid_file():
+    # Check a known location for PID file
+    return os.path.join(pkg_root, ".mock_fusillade_pid")
+
+
+def start_multiprocess_mock_fusillade_server():
+    """Use Popen to start the mock fusillade server and stash the PID in a file"""
+    pid_file = get_multiprocess_mock_fusillade_pid_file()
+    if not os.path.isfile(pid_file):
+        # Start a new mock fusillade server process
+        cmd = os.path.join(pkg_root, "tests", "infra", "mock_fusillade_start.py")
+        p = subprocess.Popen([cmd])
+        # Write pid to file
+        with open(pid_file, "w") as f:
+            f.write(str(p.pid))
+    time.sleep(3)
+    return
+
+
+def stop_multiprocess_mock_fusillade_server():
+    """Kill the mock fusillade server and remove the PID file"""
+    pid_file = get_multiprocess_mock_fusillade_pid_file()
+    if os.path.isfile(pid_file):
+        with open(pid_file, "r") as f:
+            pid = f.read()
+        os.kill(pid, signal.SIGTERM)
+    subprocess.call(["rm", "-f", pid_file])
+
+
+class MockFusilladeServer(BaseHTTPRequestHandler):
+    """
+    Create a mock Fusillade auth server endpoint so that any operation that tries to check
+    permissions with Fusillade will be handled correctly; we keep it simple and accept/reject
+    based on whether the principal (user) is on the whitelist or not.
+    """
+
+    _address = "127.0.0.1"
+    _port = None
+    _server = None
+    _request = None
+    _whitelist = ["valid@ucsc.edu", "travis-test@human-cell-atlas-travis-test.iam.gserviceaccount.com"]
+
+    @classmethod
+    def startServing(cls):
+        Config.set_config(BucketConfig.TEST)
+        cls.stash_oidc_group_claim()
+        cls.stash_openid_provider()
+        cls._port = cls.get_port()
+        # Allow multiple servers to be created/destroyed during tests
+        HTTPServer.allow_reuse_address = True
+        cls._server = HTTPServer((cls._address, cls._port), cls)
+        cls._server.serve_forever()
+
+    @classmethod
+    def stopServing(cls):
+        pass
+        # cls._server.shutdown()
+        # del cls._server  # Required to create new servers
+        # cls._thread.join()
+        # cls.restore_oidc_group_claim()
+        # cls.restore_openid_provider()
+
+    @classmethod
+    def get_port(cls):
+        authz_url = Config.get_authz_url()
+        split_authz_url = authz_url.split(":")
+        if len(split_authz_url) == 3:
+            return int(split_authz_url[-1])
+        else:
+            raise RuntimeError(
+                f"Error: AuthZ URL {authz_url} is malformed for tests, need a port number.\n "
+                "Check test configuration values and dss/config.py get_authz_url()."
+            )
+
+    @classmethod
+    def get_endpoint(cls):
+        cls._port = cls.get_port()
+        endpoint = f"http://{cls._address}:{cls._port}"
+        return endpoint
+
+    @classmethod
+    def stash_oidc_group_claim(cls):
+        """Stash the OIDC_GROUP_CLAIM env var and replace it with a test value"""
+        key = "OIDC_GROUP_CLAIM"
+        cls._old_oidc_group_claim = os.environ.pop(key, "EMPTY")
+        os.environ[key] = "https://auth.data.humancellatlas.org/group"
+
+    @classmethod
+    def restore_oidc_group_claim(cls):
+        """Restore the OIDC_GROUP_CLAIM env var when mock fusillade server is done"""
+        key = "OIDC_GROUP_CLAIM"
+        os.environ[key] = cls._old_oidc_group_claim
+
+    @classmethod
+    def stash_openid_provider(cls):
+        """Stash the OPENID_PROVIDER env var and replace it with a test value"""
+        key = "OPENID_PROVIDER"
+        cls._old_openid_provider = os.environ.pop(key, "EMPTY")
+        os.environ[key] = "https://humancellatlas.auth0.com/"
+
+    @classmethod
+    def restore_openid_provider(cls):
+        """Restore the OPENID_PROVIDER env var when mock fusillade server is done"""
+        key = "OPENID_PROVIDER"
+        os.environ[key] = cls._old_openid_provider
+
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+
+    def do_POST(self):
+        ctype, pdict = cgi.parse_header(self.headers.get("content-type"))
+        # Enforce rule: JSON only
+        if ctype != "application/json":
+            self.send_response(400)
+            self.end_headers()
+            return
+        # Convert received JSON to dict
+        length = int(self.headers.get("content-length"))
+        message = json.loads(self.rfile.read(length))
+        # Only allow if principal is on whitelist
+        if message["principal"] in self._whitelist:
+            message["result"] = True
+        else:
+            message["result"] = False
+        # Send it back
+        self._set_headers()
+        self.wfile.write(bytes(json.dumps(message), "utf8"))
+
+    # def log_request(self, *args, **kwargs):
+    #     """
+    #     If this empty method is defined, it overrides the (otherwise noisy) log messages
+    #     from the HTTP server as it starts, stops, and receives requests.
+    #     """
+    #     # Quiet plz
+    #     pass

--- a/tests/infra/mock_fusillade_start.py
+++ b/tests/infra/mock_fusillade_start.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+import server
+import time
+from mock_fusillade import MockFusilladeServer
+
+if __name__ == "__main__":
+    MockFusilladeServer.startServing()

--- a/tests/infra/mock_fusillade_start.py
+++ b/tests/infra/mock_fusillade_start.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import server
 import time
 from mock_fusillade import MockFusilladeServer
 

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -49,20 +49,16 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
 
     @classmethod
     def startServing(cls):
-        print("++++++++++ mock fusillade server starting now ++++++++++")
         cls._port = cls.get_port()
         cls._server = HTTPServer((cls._address, cls._port), cls)
         cls._thread = threading.Thread(target=cls._server.serve_forever, daemon=True)
         cls._thread.start()
         cls._request = []
-        print("++++++++++ mock fusillade server is serving ++++++++++")
 
     @classmethod
     def stopServing(cls):
-        print("++++++++++ mock fusillade server is stopping ++++++++++")
         cls._server.shutdown()
         cls._thread.join()
-        print("++++++++++ mock fusillade server stopped serving ++++++++++")
 
     def _set_headers(self):
         self.send_response(200)
@@ -70,7 +66,6 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self):
-        print("++++++++++ mock fusillade server got a request ++++++++++")
         ctype, pdict = cgi.parse_header(self.headers.get('content-type'))
         # Enforce rule: JSON only
         if ctype != 'application/json':
@@ -88,9 +83,12 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
         # Send it back
         self._set_headers()
         self.wfile.write(bytes(json.dumps(message), "utf8"))
-        print("++++++++++ mock fusillade server finished a request ++++++++++")
 
     # def log_request(self, *args, **kwargs):
+    #     """
+    #     If this empty method is defined, it overrides the (otherwise noisy) log messages
+    #     from the HTTP server as it starts, stops, and receives requests.
+    #     """
     #     # Quiet plz
     #     pass
 

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -68,22 +68,28 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
     @classmethod
     def stash_oidc_group_claim(cls):
         """Stash the OIDC_GROUP_CLAIM env var and replace it with a test value"""
-        cls._old_oidc_group_claim = os.environ.pop('OIDC_GROUP_CLAIM', 'EMPTY')
+        key = 'OIDC_GROUP_CLAIM'
+        cls._old_oidc_group_claim = os.environ.pop(key, 'EMPTY')
+        os.environ[key] = 'https://auth.data.humancellatlas.org/group'
 
     @classmethod
     def restore_oidc_group_claim(cls):
         """Restore the OIDC_GROUP_CLAIM env var when mock fusillade server is done"""
-        os.environ['OIDC_GROUP_CLAIM'] = cls._old_oidc_group_claim
+        key = 'OIDC_GROUP_CLAIM'
+        os.environ[key] = cls._old_oidc_group_claim
 
     @classmethod
     def stash_openid_provider(cls):
         """Stash the OPENID_PROVIDER env var and replace it with a test value"""
-        cls._old_openid_provider = os.environ.pop('OPENID_PROVIDER', 'EMPTY')
+        key = 'OPENID_PROVIDER'
+        cls._old_openid_provider = os.environ.pop(key, 'EMPTY')
+        os.environ[key] = 'https://humancellatlas.auth0.com/'
 
     @classmethod
     def restore_openid_provider(cls):
         """Restore the OPENID_PROVIDER env var when mock fusillade server is done"""
-        os.environ['OPENID_PROVIDER'] = cls._old_openid_provider
+        key = 'OPENID_PROVIDER'
+        os.environ[key] = cls._old_openid_provider
 
     def _set_headers(self):
         self.send_response(200)

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -36,8 +36,9 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
         cls.stash_openid_provider()
         cls._port = cls.get_port()
         cls._server = HTTPServer((cls._address, cls._port), cls)
-        cls._thread = threading.Thread(target=cls._server.serve_forever, daemon=True)
-        cls._thread.start()
+        if cls._thread is None:
+            cls._thread = threading.Thread(target=cls._server.serve_forever, daemon=True)
+            cls._thread.start()
         cls._request = []
 
     @classmethod

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -26,7 +26,7 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
     _server = None
     _thread = None
     _request = None
-    _whitelist = ['valid@ucsc.edu']
+    _whitelist = ['valid@ucsc.edu','travis-test@human-cell-atlas-travis-test.iam.gserviceaccount.com']
     _blacklist = ['invalid@ucsc.edu']
 
     @classmethod

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -49,16 +49,20 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
 
     @classmethod
     def startServing(cls):
+        print("++++++++++ mock fusillade server starting now ++++++++++")
         cls._port = cls.get_port()
         cls._server = HTTPServer((cls._address, cls._port), cls)
         cls._thread = threading.Thread(target=cls._server.serve_forever, daemon=True)
         cls._thread.start()
         cls._request = []
+        print("++++++++++ mock fusillade server is serving ++++++++++")
 
     @classmethod
     def stopServing(cls):
+        print("++++++++++ mock fusillade server is stopping ++++++++++")
         cls._server.shutdown()
         cls._thread.join()
+        print("++++++++++ mock fusillade server stopped serving ++++++++++")
 
     def _set_headers(self):
         self.send_response(200)
@@ -66,6 +70,7 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self):
+        print("++++++++++ mock fusillade server got a request ++++++++++")
         ctype, pdict = cgi.parse_header(self.headers.get('content-type'))
         # Enforce rule: JSON only
         if ctype != 'application/json':
@@ -83,10 +88,11 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
         # Send it back
         self._set_headers()
         self.wfile.write(bytes(json.dumps(message), "utf8"))
+        print("++++++++++ mock fusillade server finished a request ++++++++++")
 
-    def log_request(self, *args, **kwargs):
-        # Quiet plz
-        pass
+    #def log_request(self, *args, **kwargs):
+    #    # Quiet plz
+    #    pass
 
 
 class SilentHandler(ChaliceRequestHandler):

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -90,9 +90,9 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
         self.wfile.write(bytes(json.dumps(message), "utf8"))
         print("++++++++++ mock fusillade server finished a request ++++++++++")
 
-    #def log_request(self, *args, **kwargs):
-    #    # Quiet plz
-    #    pass
+    # def log_request(self, *args, **kwargs):
+    #     # Quiet plz
+    #     pass
 
 
 class SilentHandler(ChaliceRequestHandler):

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -47,16 +47,17 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
     @classmethod
     @synchronized(lock)
     def startServing(cls):
-        Config.set_config(BucketConfig.TEST)
-        cls.stash_oidc_group_claim()
-        cls.stash_openid_provider()
-        cls._port = cls.get_port()
-        # Allow multiple servers to be created/destroyed during tests
-        HTTPServer.allow_reuse_address = True
-        cls._server = HTTPServer((cls._address, cls._port), cls)
-        cls._thread = threading.Thread(target=cls._server.serve_forever, daemon=True)
-        cls._thread.start()
-        cls._request = []
+        if cls._server is None:
+            Config.set_config(BucketConfig.TEST)
+            cls.stash_oidc_group_claim()
+            cls.stash_openid_provider()
+            cls._port = cls.get_port()
+            # Allow multiple servers to be created/destroyed during tests
+            HTTPServer.allow_reuse_address = True
+            cls._server = HTTPServer((cls._address, cls._port), cls)
+            cls._thread = threading.Thread(target=cls._server.serve_forever, daemon=True)
+            cls._thread.start()
+            cls._request = []
 
     @classmethod
     @synchronized(lock)

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -19,7 +19,7 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
     """
     Create a mock Fusillade auth server endpoint so that any operation that tries to check
     permissions with Fusillade will be handled correctly; we keep it simple and accept/reject
-    based on whether the principal (user) is on the whitelist or the blacklist.
+    based on whether the principal (user) is on the whitelist or not.
     """
     _address = "127.0.0.1"
     _port = None
@@ -27,7 +27,6 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
     _thread = None
     _request = None
     _whitelist = ['valid@ucsc.edu', 'travis-test@human-cell-atlas-travis-test.iam.gserviceaccount.com']
-    _blacklist = ['invalid@ucsc.edu']
 
     @classmethod
     def startServing(cls):

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -35,7 +35,8 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
         cls.stash_oidc_group_claim()
         cls.stash_openid_provider()
         cls._port = cls.get_port()
-        cls._server = HTTPServer((cls._address, cls._port), cls)
+        if cls._server is None:
+            cls._server = HTTPServer((cls._address, cls._port), cls)
         if cls._thread is None:
             cls._thread = threading.Thread(target=cls._server.serve_forever, daemon=True)
             cls._thread.start()

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -31,6 +31,7 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
 
     @classmethod
     def startServing(cls):
+        print("++++++++++ starting mock fusillade server ++++++++++")
         Config.set_config(BucketConfig.TEST)
         cls.stash_oidc_group_claim()
         cls.stash_openid_provider()
@@ -42,6 +43,7 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
 
     @classmethod
     def stopServing(cls):
+        print("++++++++++ stopping mock fusillade server ++++++++++")
         cls._server.shutdown()
         cls._thread.join()
         cls.restore_oidc_group_claim()

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -31,7 +31,6 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
 
     @classmethod
     def startServing(cls):
-        print("++++++++++ starting mock fusillade server ++++++++++")
         Config.set_config(BucketConfig.TEST)
         cls.stash_oidc_group_claim()
         cls.stash_openid_provider()
@@ -43,7 +42,6 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
 
     @classmethod
     def stopServing(cls):
-        print("++++++++++ stopping mock fusillade server ++++++++++")
         cls._server.shutdown()
         cls._thread.join()
         cls.restore_oidc_group_claim()

--- a/tests/infra/server.py
+++ b/tests/infra/server.py
@@ -26,7 +26,7 @@ class ThreadedMockFusilladeServer(BaseHTTPRequestHandler):
     _server = None
     _thread = None
     _request = None
-    _whitelist = ['valid@ucsc.edu','travis-test@human-cell-atlas-travis-test.iam.gserviceaccount.com']
+    _whitelist = ['valid@ucsc.edu', 'travis-test@human-cell-atlas-travis-test.iam.gserviceaccount.com']
     _blacklist = ['invalid@ucsc.edu']
 
     @classmethod

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -29,6 +29,7 @@ from tests.fixtures.cloud_uploader import GSUploader, S3Uploader, Uploader
 from tests.infra import DSSAssertMixin, DSSUploadMixin, ExpectedErrorFields, get_env, generate_test_key, testmode, \
     TestAuthMixin
 from tests.infra.server import ThreadedLocalServer
+from tests.infra.server import ThreadedMockFusilladeServer as MockFusillade
 
 
 # Max number of retries
@@ -47,10 +48,13 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
             'hca-dss-sha1': '####',
             'hca-dss-sha256': '$$$$'
         }
+        Config.set_config(BucketConfig.TEST)
+        MockFusillade.startServing()
 
     @classmethod
     def tearDownClass(cls):
         cls.app.shutdown()
+        MockFusillade.stopServing()
 
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -29,10 +29,7 @@ from tests.fixtures.cloud_uploader import GSUploader, S3Uploader, Uploader
 from tests.infra import DSSAssertMixin, DSSUploadMixin, ExpectedErrorFields, get_env, generate_test_key, testmode, \
     TestAuthMixin
 from tests.infra.server import ThreadedLocalServer
-from tests.infra.mock_fusillade import (
-    start_multiprocess_mock_fusillade_server,
-    stop_multiprocess_mock_fusillade_server,
-)
+from tests.infra.mock_fusillade import start_multiprocess_mock_fusillade_server
 
 
 # Max number of retries
@@ -42,10 +39,6 @@ FILE_GET_RETRY_COUNT = 10
 def setUpModule():
     Config.set_config(BucketConfig.TEST)
     start_multiprocess_mock_fusillade_server()
-
-
-def tearDownModule():
-    stop_multiprocess_mock_fusillade_server()
 
 
 @testmode.standalone

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -29,7 +29,10 @@ from tests.fixtures.cloud_uploader import GSUploader, S3Uploader, Uploader
 from tests.infra import DSSAssertMixin, DSSUploadMixin, ExpectedErrorFields, get_env, generate_test_key, testmode, \
     TestAuthMixin
 from tests.infra.server import ThreadedLocalServer
-from tests.infra.server import ThreadedMockFusilladeServer as MockFusillade
+from tests.infra.mock_fusillade import (
+    start_multiprocess_mock_fusillade_server,
+    stop_multiprocess_mock_fusillade_server,
+)
 
 
 # Max number of retries
@@ -37,11 +40,12 @@ FILE_GET_RETRY_COUNT = 10
 
 
 def setUpModule():
-    MockFusillade.startServing()
+    Config.set_config(BucketConfig.TEST)
+    start_multiprocess_mock_fusillade_server()
 
 
 def tearDownModule():
-    MockFusillade.stopServing()
+    stop_multiprocess_mock_fusillade_server()
 
 
 @testmode.standalone

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -36,6 +36,14 @@ from tests.infra.server import ThreadedMockFusilladeServer as MockFusillade
 FILE_GET_RETRY_COUNT = 10
 
 
+def setUpModule():
+    MockFusillade.startServing()
+
+
+def tearDownModule():
+    MockFusillade.stopServing()
+
+
 @testmode.standalone
 class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMixin):
     @classmethod

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -56,13 +56,10 @@ class TestFileApi(unittest.TestCase, TestAuthMixin, DSSUploadMixin, DSSAssertMix
             'hca-dss-sha1': '####',
             'hca-dss-sha256': '$$$$'
         }
-        Config.set_config(BucketConfig.TEST)
-        MockFusillade.startServing()
 
     @classmethod
     def tearDownClass(cls):
         cls.app.shutdown()
-        MockFusillade.stopServing()
 
     def setUp(self):
         dss.Config.set_config(dss.BucketConfig.TEST)

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -91,9 +91,6 @@ def setUpModule():
     else:
         NotificationRequestHandler = LocalNotificationRequestHandler
     NotificationRequestHandler.startServing()
-
-    # Start the mock Fusillade server
-    Config.set_config(BucketConfig.TEST)
     MockFusillade.startServing()
 
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -55,6 +55,7 @@ from tests import eventually, get_auth_header, get_bundle_fqid, get_file_fqid, g
 from tests.infra import DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, TestBundle, testmode
 from tests.infra.elasticsearch_test_case import ElasticsearchTestCase
 from tests.infra.server import ThreadedLocalServer
+from tests.infra.server import ThreadedMockFusilladeServer as MockFusillade
 from tests.sample_search_queries import smartseq2_paired_ends_vx_query, tombstone_query
 
 
@@ -108,6 +109,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         cls.blobstore = Config.get_blobstore_handle(cls.replica)
         cls.test_fixture_bucket = cls.replica.bucket
         Config.set_config(BucketConfig.TEST)
+        MockFusillade.startServing()
         cls.test_bucket = cls.replica.bucket
         cls.indexer_cls = Indexer.for_replica(cls.replica)
         cls.executor = ThreadPoolExecutor(len(DEFAULT_BACKENDS))
@@ -118,6 +120,7 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
     def tearDownClass(cls):
         cls.executor.shutdown(False)
         cls.app.shutdown()
+        MockFusillade.stopServing()
         super().tearDownClass()
 
     def setUp(self):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -55,10 +55,7 @@ from tests import eventually, get_auth_header, get_bundle_fqid, get_file_fqid, g
 from tests.infra import DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, TestBundle, testmode
 from tests.infra.elasticsearch_test_case import ElasticsearchTestCase
 from tests.infra.server import ThreadedLocalServer
-from tests.infra.mock_fusillade import (
-    start_multiprocess_mock_fusillade_server,
-    stop_multiprocess_mock_fusillade_server,
-)
+from tests.infra.mock_fusillade import start_multiprocess_mock_fusillade_server
 from tests.sample_search_queries import smartseq2_paired_ends_vx_query, tombstone_query
 
 
@@ -100,7 +97,6 @@ def setUpModule():
 
 def tearDownModule():
     NotificationRequestHandler.stopServing()
-    stop_multiprocess_mock_fusillade_server()
 
 
 class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, metaclass=ABCMeta):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -55,7 +55,10 @@ from tests import eventually, get_auth_header, get_bundle_fqid, get_file_fqid, g
 from tests.infra import DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, TestBundle, testmode
 from tests.infra.elasticsearch_test_case import ElasticsearchTestCase
 from tests.infra.server import ThreadedLocalServer
-from tests.infra.server import ThreadedMockFusilladeServer as MockFusillade
+from tests.infra.mock_fusillade import (
+    start_multiprocess_mock_fusillade_server,
+    stop_multiprocess_mock_fusillade_server,
+)
 from tests.sample_search_queries import smartseq2_paired_ends_vx_query, tombstone_query
 
 
@@ -91,12 +94,13 @@ def setUpModule():
     else:
         NotificationRequestHandler = LocalNotificationRequestHandler
     NotificationRequestHandler.startServing()
-    MockFusillade.startServing()
+    Config.set_config(BucketConfig.TEST)
+    start_multiprocess_mock_fusillade_server()
 
 
 def tearDownModule():
     NotificationRequestHandler.stopServing()
-    MockFusillade.stopServing()
+    stop_multiprocess_mock_fusillade_server()
 
 
 class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, metaclass=ABCMeta):

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -92,9 +92,14 @@ def setUpModule():
         NotificationRequestHandler = LocalNotificationRequestHandler
     NotificationRequestHandler.startServing()
 
+    # Start the mock Fusillade server
+    Config.set_config(BucketConfig.TEST)
+    MockFusillade.startServing()
+
 
 def tearDownModule():
     NotificationRequestHandler.stopServing()
+    MockFusillade.stopServing()
 
 
 class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DSSUploadMixin, metaclass=ABCMeta):
@@ -109,7 +114,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
         cls.blobstore = Config.get_blobstore_handle(cls.replica)
         cls.test_fixture_bucket = cls.replica.bucket
         Config.set_config(BucketConfig.TEST)
-        MockFusillade.startServing()
         cls.test_bucket = cls.replica.bucket
         cls.indexer_cls = Indexer.for_replica(cls.replica)
         cls.executor = ThreadPoolExecutor(len(DEFAULT_BACKENDS))
@@ -120,7 +124,6 @@ class TestIndexerBase(ElasticsearchTestCase, DSSAssertMixin, DSSStorageMixin, DS
     def tearDownClass(cls):
         cls.executor.shutdown(False)
         cls.app.shutdown()
-        MockFusillade.stopServing()
         super().tearDownClass()
 
     def setUp(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,6 @@ from dss.util import security
 from dss import BucketConfig, Config, DeploymentStage
 
 
-@testmode.standalone
 class TestMockFusilladeServer(unittest.TestCase):
     """Test that the mock Fusillade server in dss/tests/infra/server.py is functioning properly"""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,11 +8,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from tests.infra import testmode
 from tests.infra.server import ThreadedLocalServer
-from tests.infra.mock_fusillade import (
-    start_multiprocess_mock_fusillade_server,
-    stop_multiprocess_mock_fusillade_server,
-    MockFusilladeServer,
-)
+from tests.infra.mock_fusillade import start_multiprocess_mock_fusillade_server, MockFusilladeServer
 import dss.error
 from dss.util import security
 from dss import BucketConfig, Config, DeploymentStage
@@ -39,10 +35,6 @@ class TestMockFusilladeServer(unittest.TestCase):
         for principal in ['invalid@email.com']:
             with self.assertRaises(dss.error.DSSForbiddenException):
                 security.assert_authorized(principal, actions, resources)
-
-    @classmethod
-    def tearDownClass(self):
-        stop_multiprocess_mock_fusillade_server()
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,8 +31,8 @@ class TestMockFusilladeServer(unittest.TestCase):
         for principal in MockFusillade._whitelist:
             security.assert_authorized(principal, actions, resources)
 
-        # Ensure blacklisted principals are denied access
-        for principal in MockFusillade._blacklist:
+        # Ensure non-whitelisted principals are denied access
+        for principal in ['invalid@email.com']:
             with self.assertRaises(dss.error.DSSForbiddenException):
                 security.assert_authorized(principal, actions, resources)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,7 +8,11 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from tests.infra import testmode
 from tests.infra.server import ThreadedLocalServer
-from tests.infra.server import ThreadedMockFusilladeServer as MockFusillade
+from tests.infra.mock_fusillade import (
+    start_multiprocess_mock_fusillade_server,
+    stop_multiprocess_mock_fusillade_server,
+    MockFusilladeServer,
+)
 import dss.error
 from dss.util import security
 from dss import BucketConfig, Config, DeploymentStage
@@ -20,15 +24,15 @@ class TestMockFusilladeServer(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         Config.set_config(BucketConfig.TEST)
-        MockFusillade.startServing()
-        self.auth_url = MockFusillade.get_endpoint()
+        start_multiprocess_mock_fusillade_server()
+        self.auth_url = MockFusilladeServer.get_endpoint()
 
     def test_get_policy(self):
         actions = ["dss:PutBundle"]
         resources = ["arn:hca:dss:dev:*:bundle/123456/0"]
 
         # Ensure whitelisted principals are granted access
-        for principal in MockFusillade._whitelist:
+        for principal in MockFusilladeServer._whitelist:
             security.assert_authorized(principal, actions, resources)
 
         # Ensure non-whitelisted principals are denied access
@@ -38,7 +42,7 @@ class TestMockFusilladeServer(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
-        MockFusillade.stopServing()
+        stop_multiprocess_mock_fusillade_server()
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import unittest
+import requests
+
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from tests.infra import testmode
+from tests.infra.server import ThreadedLocalServer
+from tests.infra.server import ThreadedMockFusilladeServer as MockFusillade
+import dss.error
+from dss.util import security
+from dss import BucketConfig, Config, DeploymentStage
+
+
+@testmode.standalone
+class TestMockFusilladeServer(unittest.TestCase):
+    """Test that the mock Fusillade server in dss/tests/infra/server.py is functioning properly"""
+
+    @classmethod
+    def setUpClass(self):
+        Config.set_config(BucketConfig.TEST)
+        MockFusillade.startServing()
+        self.auth_url = MockFusillade.get_endpoint()
+
+    def test_get_policy(self):
+        actions = ["dss:PutBundle"]
+        resources = ["arn:hca:dss:dev:*:bundle/123456/0"]
+
+        # Ensure whitelisted principals are granted access
+        for principal in MockFusillade._whitelist:
+            security.assert_authorized(principal, actions, resources)
+
+        # Ensure blacklisted principals are denied access
+        for principal in MockFusillade._blacklist:
+            with self.assertRaises(dss.error.DSSForbiddenException):
+                security.assert_authorized(principal, actions, resources)
+
+    @classmethod
+    def tearDownClass(self):
+        MockFusillade.stopServing()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR should not be merged. It explicitly adds `test_server.py` to the gitlab ci pipeline, both in serial and in parallel, to try and hunt down the reason for failing parallel tests in PR #2467. 