### PR TITLE
Revert "Update infrastructure to use dss-ops.py and not set_secret/fetch_secret"

### DIFF
--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -24,8 +24,8 @@ before_script:
   - pip install -r requirements-dev.txt
   - source environment
   - source environment.prod
-  - scripts/dss-ops.py secrets get --json --secret-name application_secrets.json > application_secrets.json
-  - scripts/dss-ops.py secrets get --json --secret-name gcp-credentials.json > gcp-credentials.json
+  - scripts/fetch_secret.sh application_secrets.json > application_secrets.json
+  - scripts/fetch_secret.sh gcp-credentials.json > gcp-credentials.json
   - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
 
 deploy:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,8 +28,8 @@ before_script:
   - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then
   -   source environment.$CI_COMMIT_REF_NAME
   - fi
-  - scripts/dss-ops.py secrets get --json --secret-name application_secrets.json > application_secrets.json
-  - scripts/dss-ops.py secrets get --json --secret-name gcp-credentials.json > gcp-credentials.json
+  - scripts/fetch_secret.sh application_secrets.json > application_secrets.json
+  - scripts/fetch_secret.sh gcp-credentials.json > gcp-credentials.json
   - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
 
 .tests:

--- a/README.md
+++ b/README.md
@@ -139,9 +139,7 @@ The DSS uses the [Amazon S3 backend](https://www.terraform.io/docs/backends/type
 	1) Run the command
 
 	   ```
-       ### WARNING: RUNNING THIS COMMAND WILL
-       ###          CLEAR EXISTING SCRET VALUE
-	   cat $DSS_HOME/application_secrets.json | ./scripts/dss-ops.py secrets set --secret-name $GOOGLE_APPLICATION_SECRETS_SECRETS_NAME
+	   cat $DSS_HOME/application_secrets.json | scripts/set_secret.py --secret-name $GOOGLE_APPLICATION_SECRETS_SECRETS_NAME
        ```
 
 1.  [Download](https://cloud.google.com/sdk/downloads) the `gcloud` command line utility.
@@ -160,7 +158,7 @@ The DSS uses the [Amazon S3 backend](https://www.terraform.io/docs/backends/type
 1.  Choose a region that has support for Cloud Functions and set `GCP_DEFAULT_REGION` to that region. See
     [the GCP locations list](https://cloud.google.com/about/locations/) for a list of supported regions.
 
-1.  Run `gcloud config set project PROJECT_ID` **where `PROJECT_ID` is the ID, not the name (i.e: hca-store-21555, NOT just hca-store) of the GCP project you selected earlier**.
+1.  Run `gcloud config set project PROJECT_ID` **where PROJECT_ID is the ID, not the name (i.e: hca-store-21555, NOT just hca-store) of the GCP project you selected earlier**.
 
 1.  Enable required APIs:
 
@@ -244,17 +242,15 @@ When deploying for the first time, a Google Cloud Platform service account must 
 1.  Run the command
 
     ```
-    cat $DSS_HOME/gcp-credentials.json | ./scripts/dss-ops.py secrets set --secret-name $GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME
+    cat $DSS_HOME/gcp-credentials.json | scripts/set_secret.py --secret-name $GOOGLE_APPLICATION_CREDENTIALS_SECRETS_NAME
     ```
 
 ### Setting admin emails
 
-Set admin account emails within AWS Secret Manager:
+Set admin account emails within AWS Secret Manager
 
 ```
-### WARNING: RUNNING THIS COMMAND WILL 
-###          CLEAR EXISTING SECRET VALUE
-echo -n 'user1@example.com,user2@example.com' |  ./scripts/dss-ops.py secrets set --secret-name $ADMIN_USER_EMAILS_SECRETS_NAME
+echo ' ' |  ./scripts/set_secret.py --secret-name $ADMIN_USER_EMAILS_SECRETS_NAME
  ```
 
 ### Deploying the DSS
@@ -290,9 +286,7 @@ t2.small.elasticsearch instance type is sufficient. Use the [`DSS_ES_`](./docs/e
 Add allowed IPs for ElasticSearch to the secret manager, use comma separated IPs:
 
 ```
-### WARNING: RUNNING THIS COMMAND WILL 
-###          CLEAR EXISTING SECRET VALUE
-echo -n '1.1.1.1,2.2.2.2' | ./scripts/dss-ops.py secret set --secret-name $ES_ALLOWED_SOURCE_IP_SECRETS_NAME
+echo ' ' | ./scripts/set_secret.py --secret-name $ES_ALLOWED_SOURCE_IP_SECRETS_NAME
 ```
 
 Use Terraform to deploy ES resource:

--- a/scripts/check_deployment_secrets.py
+++ b/scripts/check_deployment_secrets.py
@@ -90,11 +90,8 @@ class SecretsChecker(object):
         return json.loads(self.run_cmd(cmd, shell=False))
 
     def fetch_secret(self, secret_name):
-        ops_script = os.path.join(os.path.dirname(__file__), "dss-ops.py")
-        ops_verb = "secrets"
-        ops_args = f"{secret_name} --json"
-        cmd = f"{ops_script} {ops_verb} {ops_args}"
-        raw_response = self.run_cmd(cmd)
+        script_path = os.path.join(os.path.dirname(__file__), "fetch_secret.sh")
+        raw_response = self.run_cmd(f'{script_path} {secret_name}')
         try:
             secret = json.loads(raw_response)
         except json.decoder.JSONDecodeError:

--- a/scripts/create_config_aws_event_relay_user.py
+++ b/scripts/create_config_aws_event_relay_user.py
@@ -67,10 +67,9 @@ secret_info = {
 }
 subprocess.run(
     [
-        os.path.join(os.path.dirname(__file__), "dss-ops.py"),
-        "secrets",
-        "set",
-        secret_name,
+        os.path.join(os.path.dirname(__file__), "set_secret.py"),
+        "--secret-name",
+        f"{secret_name}"
     ],
-    input=json.dumps(secret_info).encode("utf-8"),
+    input=json.dumps(secret_info).encode("utf-8")
 )


### PR DESCRIPTION
Reverts HumanCellAtlas/data-store#2370

There is a problem creating/using local Google Cloud service credentials, so unit tests are failing. Reverting until the issue has been resolved.