### PR TITLE
Operation scripting for recording and journaling events

### DIFF
--- a/daemons/dss-operations/app.py
+++ b/daemons/dss-operations/app.py
@@ -23,6 +23,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 import dss
 import dss.operations.storage
+import dss.operations.events
 from dss.operations import dispatch
 
 logging.basicConfig(stream=sys.stdout)

--- a/dss/operations/events.py
+++ b/dss/operations/events.py
@@ -105,16 +105,3 @@ def delete_all(argv: typing.List[str], args: argparse.Namespace):
     Delete all events recorded or journaled into `prefix`
     """
     FlashFlood(resources.s3, Config.get_flashflood_bucket(), args.prefix)._destroy()
-
-def _get_bundle_metadata_document(replica: Replica,
-                                  key: str,
-                                  flashflood_prefix=None,
-                                  use_version_for_timestamp: bool=False):
-    if not key.startswith("bundles/"):
-        logger.warning(f"bundle metadata document not supported for '{key}'")
-        return None
-    try:
-        return
-    except BlobNotFoundError:
-        logger.error(f"Bundle not found for '{key}'")
-        return None

--- a/dss/operations/events.py
+++ b/dss/operations/events.py
@@ -1,16 +1,26 @@
 """
 JMESPath eventing and subscription admin tooling
 """
+import os
 import typing
 import argparse
 import json
 import logging
+from uuid import uuid4
+from datetime import datetime
 
 from cloud_blobstore import BlobNotFoundError
+from flashflood import FlashFlood
+from dcplib.aws.sqs import SQSMessenger
+from dcplib.aws.clients import logs
 
-from dss.config import Replica
+from dss.config import Config, Replica
+from dss.util.aws import resources
 from dss.operations import dispatch
-from dss.events import get_bundle_metadata_document
+from dss.events import get_bundle_metadata_document, record_event_for_bundle
+from dss.events.handlers.notify_v2 import _versioned_tombstone_key_regex, _unversioned_tombstone_key_regex
+from dss.storage.identifiers import TOMBSTONE_SUFFIX
+from dss.operations.util import map_bucket, monitor_logs, command_queue_url
 
 
 logger = logging.getLogger(__name__)
@@ -25,12 +35,86 @@ events = dispatch.target("events", help=__doc__)
                                          nargs="*",
                                          help="bundle keys to generate documents.")})
 def bundle_metadata_document(argv: typing.List[str], args: argparse.Namespace):
+    replica = Replica[args.replica]
     for key in args.keys:
-        if not key.startswith("bundles/"):
-            logger.warning(f"Unable to produce bundle metadata document for '{key}'")
-            continue
-        try:
-            md = get_bundle_metadata_document(Replica[args.replica], key)
-            print(json.dumps(md))
-        except BlobNotFoundError:
-            logger.error(f"Bundle not found for '{key}'")
+        md = get_bundle_metadata_document(replica, key)
+        if md is not None:
+            print(md)
+
+@events.action("record",
+               arguments={"--replica": dict(choices=[r.name for r in Replica],
+                                            required=True,
+                                            help="Source replica."),
+                          "--prefix": dict(required=True,
+                                           help="Destination flashflood prefix."),
+                          "--keys": dict(default=None,
+                                         nargs="*",
+                                         help="Record events for these bundles."),
+                          "--job-id": dict(default=None)})
+def record(argv: typing.List[str], args: argparse.Namespace):
+    """
+    Record events for `keys` into flashflood prefix `prefix`
+    If `keys` is omitted, record an event for each bundle in `replica` via lambda forwarding.
+    """
+    replica = Replica[args.replica]
+    job_id = args.job_id or f"{uuid4()}"
+    cmd_template = f"events record  --prefix {args.prefix} --replica {replica.name} --job-id {job_id} --keys {{}}"
+
+    if args.keys is None:
+        start_time = datetime.now()
+
+        def forward_keys(keys):
+            with SQSMessenger(command_queue_url) as sqsm:
+                tombstone_id = None
+                for key in keys:
+                    if _versioned_tombstone_key_regex.match(key):
+                        continue
+                    elif _unversioned_tombstone_key_regex.match(key):
+                        fqid = key.rsplit("/")[0]
+                        tombstone_id = fqid.replace(f".{TOMBSTONE_SUFFIX}", "")
+                        continue
+                    else:
+                        if tombstone_id and tombstone_id in key:
+                            continue
+                        else:
+                            tombstone_id = None
+                            sqsm.send(cmd_template.format(key))
+
+        handle = Config.get_blobstore_handle(replica)
+        map_bucket(forward_keys, handle, replica.bucket, f"bundles/")
+        monitor_logs(logs, job_id, start_time)
+    else:
+        for key in args.keys:
+            msg = json.dumps(dict(action="record event", job_id=job_id, replica=replica.name, key=key))
+            record_event_for_bundle(Replica[args.replica], key, (args.prefix,))
+            print(msg)
+
+@events.action("journal",
+               arguments={"--prefix": dict(required=True,
+                                           help="flashflood prefix to journal events"),
+                          "--minimum-number-of-events": dict(default=100),
+                          "--minimum-size": dict(default=1024 * 1024)})
+def journal(argv: typing.List[str], args: argparse.Namespace):
+    ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), args.prefix)
+    ff.journal(int(args.number_of_events))
+
+@events.action("destroy",
+               arguments={"--prefix": dict(required=True)})
+def delete_all(argv: typing.List[str], args: argparse.Namespace):
+    """
+    Delete all events recorded or journaled into `prefix`
+    """
+    FlashFlood(resources.s3, Config.get_flashflood_bucket(), args.prefix)._destroy()
+
+def _get_bundle_metadata_document(replica: Replica,
+                                  key: str,
+                                  flashflood_prefix=None,
+                                  use_version_for_timestamp: bool=False):
+    if not key.startswith("bundles/"):
+        logger.warning(f"bundle metadata document not supported for '{key}'")
+        return None
+    try:
+        return
+    except BlobNotFoundError:
+        logger.error(f"Bundle not found for '{key}'")
+        return None

--- a/dss/operations/events.py
+++ b/dss/operations/events.py
@@ -31,7 +31,7 @@ events = dispatch.target("events", help=__doc__)
 
 @events.action("bundle-metadata-document",
                arguments={"--replica": dict(choices=[r.name for r in Replica], required=True),
-                          "--keys": dict(default=None,
+                          "--keys": dict(required=True,
                                          nargs="*",
                                          help="bundle keys to generate documents.")})
 def bundle_metadata_document(argv: typing.List[str], args: argparse.Namespace):

--- a/dss/operations/util.py
+++ b/dss/operations/util.py
@@ -1,11 +1,18 @@
 import os
+import sys
 import traceback
+import argparse
 import logging
 import typing
+import time
+from functools import wraps
+from datetime import datetime, timedelta
 
 from cloud_blobstore import BlobStore
+from dcplib.aws.sqs import SQSMessenger
 
 from dss.util.aws.clients import sts  # type: ignore
+from dss.config import Config, Replica
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
@@ -39,3 +46,20 @@ def map_bucket_results(func: typing.Callable, handle: BlobStore, bucket: str, ba
 def map_bucket(*args, **kwargs):
     for _ in map_bucket_results(*args, **kwargs):
         pass
+
+LOG_MONITOR_SLEEP_DURATION = 10
+
+def monitor_logs(logs_client, job_id: str, start_time: datetime):
+    start = new_start = int(1000 * (datetime.timestamp(datetime.utcnow())))
+    log_group = f"/aws/lambda/dss-operations-{os.environ['DSS_DEPLOYMENT_STAGE']}"
+    paginator = logs_client.get_paginator('filter_log_events')
+    while True:
+        for info in paginator.paginate(logGroupName=log_group, startTime=start, filterPattern=f'"{job_id}"'):
+            for e in info['events']:
+                print(e['message'])
+                new_start = e['timestamp'] + 1
+        if start == new_start:
+            sys.stderr.write(f"no new CloudWatch log messages, sleeping {LOG_MONITOR_SLEEP_DURATION}s" + os.linesep)
+            time.sleep(LOG_MONITOR_SLEEP_DURATION)
+        else:
+            start = new_start

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ enum-compat==0.0.2
 Faker==2.0.2
 fasteners==0.15
 flake8==3.7.8
-flash-flood==0.2.1
+flash-flood==0.3.0
 Flask==1.1.1
 furl==2.0.0
 future==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.15.2
 elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 fasteners==0.15
-flash-flood==0.2.1
+flash-flood==0.3.0
 Flask==1.1.1
 furl==2.0.0
 future==0.17.1

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -21,4 +21,4 @@ requests-http-signature >= 0.0.3
 aws-xray-sdk >= 1.0
 pyjwt >= 1.6.4
 pyyaml >= 4.2b1, <= 5.1.0
-flash-flood >= 0.2.1
+flash-flood >= 0.3.0


### PR DESCRIPTION
This adds commands to the data-store operations scripting for events:
- record: record events for a list of keys, or for every bundle in replica
- journal: compile flashflood events into journals
- update: apply event updates to the event journals