### PR TITLE
Back up collections, subscriptions (closes #1661)

### DIFF
--- a/infra/collections_db/main.tf
+++ b/infra/collections_db/main.tf
@@ -17,6 +17,10 @@ resource "aws_dynamodb_table" "collections-db-aws" {
   hash_key     = "hash_key"
   range_key    = "sort_key"
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   attribute {
     name = "hash_key"
     type = "S"

--- a/infra/subscription_v2_db/main.tf
+++ b/infra/subscription_v2_db/main.tf
@@ -12,7 +12,7 @@ locals {
 
 locals {
   replicas = ["aws", "gcp"]
-} 
+}
 
 resource "aws_dynamodb_table" "subscriptions-aws" {
   count        = "${length(local.replicas)}"
@@ -20,6 +20,10 @@ resource "aws_dynamodb_table" "subscriptions-aws" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "hash_key"
   range_key    = "sort_key"
+
+  point_in_time_recovery {
+    enabled = true
+  }
 
   attribute {
     name = "hash_key"


### PR DESCRIPTION
Closes #1661.

Backs up the collection and subscription DynamoDB tables by enabling point-in-time recovery (PITR).
The original ticket specified backing up v1 subscriptions, which are backed by ElasticSearch, which is being deprecated. Because DynamoDB is severless, the need to back up data in the event of a component failure is reduced.

Because PITR restores take are not fast (can take hours), the main use case of these backups seems to be to protect against unintentional wide-scale deletion of data.