### PR TITLE
Add Fusillade to IAM auditing functionality in dss-ops script

### DIFF
--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -18,6 +18,25 @@ from dss.operations import dispatch
 from dss.util.aws.clients import iam as iam_client  # type: ignore
 
 
+"""
+This module is quite long, so here is a table of contents and summary.
+
+Table of Contents:
+- fusillade utility functions
+- functions to dump/list all policies
+    - cloud providers have separate, parallel sets of methods
+    - all cloud providers have an extract method to extract policy information
+    - all cloud providers have wrapper methods to list/dump the information
+- functions to dump/list policies grouped by asset type
+    - an asset is a user, a group, or a role
+    - these functions have a different logical structure from the above
+    - aws has a single function to list policies grouped by asset
+    - fusillade has separate functions for each type of asset: users, groups, and roles
+- dss-ops command line utility functionality
+    - list action
+"""
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -119,9 +119,7 @@ def get_fus_role_attached_policies(fus_client, action, role):
     try:
         inline_policies = json.loads(inline_policies_strpayload["IAMPolicy"])
     except (KeyError, TypeError):
-        # @chmreid TODO: use logger.warning?
         pass
-
     else:
         if isinstance(inline_policies, dict):
             if "Id" not in inline_policies:
@@ -454,7 +452,7 @@ def list_fus_group_policies(fus_client, do_headers: bool = True):
         # inline_policies = fus_client.call_api(f'/v1/group/{group}','policies')
 
         # Next get managed policies (attached via roles)
-        roles_membership = fus_client.call_api(f"/v1/group/{group}/roles", "roles")
+        roles_membership = list(fus_client.paginate(f"/v1/group/{group}/roles", "roles"))
         for role in roles_membership:
             attached_names = get_fus_role_attached_policies(fus_client, "list", role)
             for attached_name in attached_names:

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -8,6 +8,7 @@ import typing
 import argparse
 import json
 import logging
+from functools import lru_cache
 
 from botocore.exceptions import ClientError
 
@@ -21,10 +22,95 @@ logger = logging.getLogger(__name__)
 SEPARATOR = " : "
 
 
-def _make_aws_api_labels_dict_entry(*args):
+# ---
+# Fusillade utility functions/classes
+# ---
+class FusilladeClient(object):
+    """
+    Fusillade client.
+    A simple wrapper around an authorization URL and a header.
+    """
+    AUTH_DEPLOYMENTS = {
+        'dev': "https://auth.dev.data.humancellatlas.org",
+        'integration': "https://auth.integration.data.humancellatlas.org",
+        'staging': "https://auth.staging.data.humancellatlas.org",
+        "testing": "https://auth.testing.data.humancellatlas.org",
+        "production": "https://auth.data.humancellatlas.org"
+    }
+
+    def __init__(self, stage=None):
+        if stage==None:
+            RuntimeError("You must provide a stage argument to FusilladeClient(stage)")
+        auth_url, headers = self.get_auth_url_headers(stage)
+        self.auth_url = auth_url
+        self.headers = headers
+
+    def get_auth_url_headers(self,stage):
+        """
+        Get authorization url and headers to allow Fusillade requests.
+        """
+        auth_url = self.AUTH_DEPLOYMENTS[stage]
+
+        # @chmreid TODO: what permissions does this require?
+        secret="deployer_service_account.json"
+        secret_id = '/'.join(['dcp', 'fusillade', stage, secret])
+        service_account = DCPServiceAccountManager.from_secrets_manager(
+            secret_id,
+            "https://auth.data.humancellatlas.org/"
+        )
+        # Create the headers using the DCP service account manager
+        headers = {'Content-Type': "application/json"}
+        headers.update(**service_account.get_authorization_header())
+
+        # This info will be used to create a
+        # Fusillade client (a simple wrapper
+        # around these two strings...)
+        return auth_url, headers
+
+    @lru_cache(maxsize=128)
+    def call_api(self, path, key):
+        auth_url = self.auth_url
+        headers = self.headers
+        resp = requests.get(f"{auth_url}{path}", headers=headers)
+        resp.raise_for_status()
+        return resp.json()[key]
+
+    @lru_cache(maxsize=128)
+    def paginate(self, path, key=None):
+        """
+        Pagination utility for Fusillade
+        """
+        auth_url = self.auth_url
+        headers = self.headers
+        resp = requests.get(f"{auth_url}{path}", headers=headers)
+        resp.raise_for_status()
+        items = []
+        while "Link" in resp.headers:
+            items.extend(resp.json()[key])
+            next_url = resp.headers['Link'].split(';')[0][1:-1]
+            resp = requests.get(next_url, headers=headers)
+            resp.raise_for_status()
+        else:
+            if key==None:
+                items.extend(resp.json())
+            else:
+                items.extend(resp.json()[key])
+        return items
+
+
+# ---
+# AWS utility functions and variables
+# ---
+def _make_aws_api_labels_dict_entry(*args) -> typing.Dict[str,str]:
     """
     Convenience function to unpack 4 values into a dictionary of labels, useful for processing
     API results.
+
+    :params arg[0]: label of asset type
+    :params arg[1]: label of asset name
+    :params arg[2]: label of asset details
+    :params arg[3]: label of asset policy details
+    :returns: dictionary of organized labels
     """
     assert len(args) == 4, "Error: need 4 arguments!"
     return dict(
@@ -32,7 +118,8 @@ def _make_aws_api_labels_dict_entry(*args):
     )
 
 
-def _get_aws_api_labels_dict():
+def _get_aws_api_labels_dict() -> typing.Dict[str,str]:
+    """Store the labels used to unwrap JSON results from the AWS API"""
     labels = {
         "user": _make_aws_api_labels_dict_entry("User", "UserName", "UserDetailList", "UserPolicyList"),
         "group": _make_aws_api_labels_dict_entry("Group", "GroupName", "GroupDetailList", "GroupPolicyList"),
@@ -42,16 +129,17 @@ def _get_aws_api_labels_dict():
 
 
 # ---
-# All policies
+# Dump/list all policies
 # ---
-def extract_aws_policies(action, client, managed):
+def extract_aws_policies(action: str, client, managed: bool):
     """
     Call the AWS IAM API to retrieve policies and perform an action with them.
 
     :param action: what action to take with the IAM policies (list, dump)
     :param client: the boto client to use
     :param managed: (boolean) if true, include AWS-managed policies
-    :returns: a list of items (policy names if action is list
+    :returns: a list of items whose type depends on the action param
+        (policy names if action is list, json documents if action is dump)
     """
     master_list = []  # holds main results
 
@@ -75,8 +163,7 @@ def extract_aws_policies(action, client, managed):
         # Sort names, remove duplicates
         master_list = sorted(list(set(master_list)))
     elif action == "dump":
-        # Sort strings and remove duplicates,
-        # then convert back to dictionaries
+        # Convert to strings, remove dupes, convert to back dicts
         master_list = list(set(master_list))
         master_list = [json.loads(j) for j in master_list]
 
@@ -84,27 +171,90 @@ def extract_aws_policies(action, client, managed):
     return master_list
 
 
-def list_aws_policies(client, managed):
-    """Extract a list of policies"""
+def list_aws_policies(client, managed: bool):
+    """Return a list of names of AWS policies"""
     return extract_aws_policies("list", client, managed)
 
 
-def dump_aws_policies(client, managed):
-    """Dump policy documents to JSON"""
+def dump_aws_policies(client, managed: bool):
+    """Return a list of dictionaries containing AWS policy documents"""
     return extract_aws_policies("dump", client, managed)
 
 
+def extract_fus_policies(action: str, client):
+    """
+    Call the Fusillade API to retrieve policies and perform an action with them.
+
+    :param action: what action to take (list, dump)
+    :param client: the Fusillade client to use
+    :returns: a list of items whose type depends on the action param
+        (policy names if action is list, json documents if action is dump)
+    """
+    master_list = []
+
+    users = list(fus_client.paginate('/v1/users', 'users'))
+    groups = list(fus_client.paginate('/v1/groups', 'groups'))
+    roles = list(fus_client.paginate('/v1/roles', 'roles'))
+    for user in users:
+        membership = {
+            'group': fus_client.call_api(f'/v1/user/{user}/groups', 'groups'),
+            'role': fus_client.call_api(f'/v1/user/{user}/roles', 'roles')
+        }
+        managed_policies = []
+        for asset_type in ['group','role']:
+            api_url = f'/v1/{asset_type}/'
+            for asset in membership[asset_type]:
+                managed_policy = fus_client.call_api(api_url+asset, 'policies')
+                try:
+                    iam_policy = managed_policy["IAMPolicy"]
+                except (KeyError, TypeError):
+                    pass
+                else:
+                    d = json.loads(iam_policy)
+                    managed_policies.append(d)
+
+        if action=='list':
+            # Extract policy name
+            for policy in managed_policies:
+                if 'Id' not in policy:
+                    d['Id'] = 'UNNAMED_POLICY'
+                master_list.append((user,policy['Id']))
+        elif action=='dump':
+            # Export policy json document
+            master_list.append(policy)
+
+    if action == "list":
+        # Sort names, remove duplicates
+        master_list = sorted(list(set(master_list)))
+    elif action == "dump":
+        # Convert to strings, remove dupes, convert to back dicts
+        master_list = list(set(master_list))
+        master_list = [json.loads(j) for j in master_list]
+
+    return master_list
+
+
+def list_fus_policies(fus_client) -> typing.List[str]:
+    """Return a list of names of Fusillade policies"""
+    return extract_fus_policies("list", fus_client)
+
+
+def dump_fus_policies(fus_client):
+    """Return a list of dictionaries containing Fusillade policy documents"""
+    return extract_fus_policies("dump", fus_client)
+
+
 # ---
-# Policies grouped by asset type
+# List policies grouped by asset type
 # ---
-def list_aws_policies_grouped(asset_type, client, managed):
+def list_aws_policies_grouped(asset_type: str, client, managed: bool):
     """
     Call the AWS IAM API to retrieve policies grouped by asset and create a list of policy names.
 
     :param asset_type: the type of asset to group policies by
     :param client: the boto client to use
     :param managed: (boolean) if true, include AWS-managed policies
-    :returns: a list of items of the form (asset_name, policy_name)
+    :returns: list of tuples of two strings in the form (asset_name, policy_name)
     """
     extracted_list = []
 
@@ -181,6 +331,114 @@ def list_aws_role_policies(*args):
     return list_aws_policies_grouped("role", *args)
 
 
+def list_fus_user_policies(fus_client):
+    """
+    Call the Fusillade API to retrieve policies grouped by user.
+
+    :param fus_client: the Fusillade API client
+    :returns: list of tuples of two strings in the form (user_name, policy_name)
+    """
+    users = list(fus_client.paginate('/v1/users', 'users'))
+    groups = list(fus_client.paginate('/v1/groups', 'groups'))
+    roles = list(fus_client.paginate('/v1/roles', 'roles'))
+
+    result = []
+
+    for user in users:
+        # First get inline policies - these are directly attached to the user
+        # @chmreid TODO: figure out the type/structure of this api call
+        #inline_policies = fus_client.call_api(f'/v1/user/{user}','policies')
+
+        # Next get managed policies - these are policies attached via roles or groups
+        membership = {
+            'group': fus_client.call_api(f'/v1/user/{user}/groups', 'groups'),
+            'role': fus_client.call_api(f'/v1/user/{user}/roles', 'roles')
+        }
+        managed_policies = []
+        for asset_type in ['group','role']:
+            api_url = f'/v1/{asset_type}/'
+            for asset in membership[asset_type]:
+                managed_policy = fus_client.call_api(api_url+asset, 'policies')
+                try:
+                    iam_policy = managed_policy["IAMPolicy"]
+                except (KeyError, TypeError):
+                    pass
+                else:
+                    d = json.loads(iam_policy)
+                    if 'Id' not in iam_policy:
+                        d['Id'] = 'UNNAMED_POLICY'
+                    managed_policies.append(d)
+
+        for policy in managed_policies:
+            result.append((user,policy['Id']))
+
+    return result
+
+
+def list_fus_group_policies(fus_client):
+    """
+    Call the Fusillade API to retrieve policies grouped by group.
+
+    :param fus_client: the Fusillade API client
+    :returns: list of tuples of two strings in the form (group_name, policy_name)
+    """
+    groups = [j for j in fus_client.paginate('/v1/group', 'groups')]
+    roles = [j for j in fus_client.paginate('/v1/role', 'roles')]
+
+    result = []
+
+    for group in groups:
+        # First get inline policies directly attached
+        # @chmreid TODO: figure out the type/structure of this api call
+        #inline_policies = fus_client.call_api(f'/v1/group/{group}','policies')
+
+        # Next get managed policies (attached via roles)
+        managed_policies = []
+        roles_membership = fus_client.call_api(f'/v1/group/{group}/roles', 'roles')
+        for role in roles_membership:
+            managed_policy = fus_client.call_api(f'/v1/role/{role}', 'policies')
+            try:
+                iam_policy = managed_policy["IAMPolicy"]
+            except (KeyError, TypeError):
+                pass
+            else:
+                d = json.loads(iam_policy)
+                if 'Id' not in iam_policy:
+                    d['Id'] = 'UNNAMED_POLICY'
+                managed_policies.append(d)
+
+        for policy in managed_policies:
+            result.append((group,policy['Id']))
+
+    return result
+
+
+def list_fus_role_policies(fus_client):
+    """
+    Call the Fusillade API to retrieve policies grouped by role.
+
+    :param fus_client: the Fusillade API client
+    :returns: list of tuples of two strings in the form (role_name, policy_name)
+    """
+    groups = [j for j in fus_client.paginate('/v1/group', 'groups')]
+    roles = [j for j in fus_client.paginate('/v1/role', 'roles')]
+
+    result = []
+
+    for role in roles:
+        # Get inline policies directly attached
+        # @chmreid TODO: figure out the type/structure of this api call
+        inline_policies = fus_client.call_api(f'/v1/role/{role}','policies')
+
+        for policy in inline_policies:
+            result.append((role,policy['Id']))
+
+    return result
+
+
+# ---
+# dss-ops.py command line utility
+# ---
 iam = dispatch.target("iam", arguments={}, help=__doc__)
 
 
@@ -202,6 +460,10 @@ iam = dispatch.target("iam", arguments={}, help=__doc__)
             action="store_true",
             help="If output file already exists, overwrite it (default is not to overwrite)",
         ),
+        "--include-managed": dict(
+            action="store_true",
+            help="Include policies provided and managed by the cloud provider"
+        ),
     },
 )
 def list_policies(argv: typing.List[str], args: argparse.Namespace):
@@ -210,7 +472,8 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
         if os.path.exists(args.output) and not args.force:
             raise RuntimeError(f"Error: cannot overwrite {args.output} without --force flag")
 
-    managed = False
+    managed = args.include_managed
+
     if args.cloud_provider == "aws":
 
         if args.group_by is None:
@@ -233,5 +496,23 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
             print(c)
         if args.output:
             sys.stdout = stdout_
+
+    elif args.cloud_provider == "fusillade":
+
+        stage = os.environ['DSS_DEPLOYMENT_STAGE']
+        client = FusilladeClient(stage=stage)
+
+        if args.group_by is None:
+            # list policies
+            list_fus_policies(client)
+        else:
+            # list policies grouped by asset
+            if args.group_by == "users":
+                list_fus_user_policies(client)
+            elif args.group_by == "groups":
+                list_fus_group_policies(client)
+            elif args.group_by == "roles":
+                list_fus_role_policies(client)
+
     else:
         raise RuntimeError(f"Error: IAM functionality not implemented for {args.cloud_provider}")

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -7,11 +7,13 @@ import select
 import typing
 import argparse
 import json
+import requests
 import logging
 from functools import lru_cache
 
 from botocore.exceptions import ClientError
 
+from dcplib.security import DCPServiceAccountManager
 from dss.operations import dispatch
 from dss.util.aws.clients import iam as iam_client  # type: ignore
 
@@ -62,9 +64,7 @@ class FusilladeClient(object):
         headers = {'Content-Type': "application/json"}
         headers.update(**service_account.get_authorization_header())
 
-        # This info will be used to create a
-        # Fusillade client (a simple wrapper
-        # around these two strings...)
+        # This info will be used to create a Fusillade client (a simple wrapper around these 2 strings)
         return auth_url, headers
 
     @lru_cache(maxsize=128)
@@ -181,12 +181,12 @@ def dump_aws_policies(client, managed: bool):
     return extract_aws_policies("dump", client, managed)
 
 
-def extract_fus_policies(action: str, client):
+def extract_fus_policies(action: str, fus_client):
     """
     Call the Fusillade API to retrieve policies and perform an action with them.
 
     :param action: what action to take (list, dump)
-    :param client: the Fusillade client to use
+    :param fus_client: the Fusillade client to use
     :returns: a list of items whose type depends on the action param
         (policy names if action is list, json documents if action is dump)
     """
@@ -217,8 +217,8 @@ def extract_fus_policies(action: str, client):
             # Extract policy name
             for policy in managed_policies:
                 if 'Id' not in policy:
-                    d['Id'] = 'UNNAMED_POLICY'
-                master_list.append((user,policy['Id']))
+                    policy['Id'] = 'UNNAMED_POLICY'
+                master_list.append(policy['Id'])
         elif action=='dump':
             # Export policy json document
             master_list.append(policy)
@@ -251,7 +251,7 @@ def list_aws_policies_grouped(asset_type: str, client, managed: bool):
     """
     Call the AWS IAM API to retrieve policies grouped by asset and create a list of policy names.
 
-    :param asset_type: the type of asset to group policies by
+    :param asset_type: the type of asset to group policies by ("users", "groups", or "roles")
     :param client: the boto client to use
     :param managed: (boolean) if true, include AWS-managed policies
     :returns: list of tuples of two strings in the form (asset_name, policy_name)
@@ -311,7 +311,7 @@ def list_aws_policies_grouped(asset_type: str, client, managed: bool):
     extracted_list = sorted(list(set(extracted_list)))
 
     # Add headers to the final results list
-    extracted_list = [(extracted_list_label, "PolicyName")] + extracted_list
+    extracted_list = [(extracted_list_label, "Policy")] + extracted_list
 
     return extracted_list
 
@@ -372,6 +372,9 @@ def list_fus_user_policies(fus_client):
         for policy in managed_policies:
             result.append((user,policy['Id']))
 
+    # Add headers
+    result = [("User", "Policy")] + result
+
     return result
 
 
@@ -410,6 +413,9 @@ def list_fus_group_policies(fus_client):
         for policy in managed_policies:
             result.append((group,policy['Id']))
 
+    # Add headers
+    result = [("Group", "Policy")] + result
+
     return result
 
 
@@ -432,6 +438,9 @@ def list_fus_role_policies(fus_client):
 
         for policy in inline_policies:
             result.append((role,policy['Id']))
+
+    # Add headers
+    result = [("Role", "Policy")] + result
 
     return result
 
@@ -489,14 +498,6 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
             # Join the tuples
             contents = [SEPARATOR.join(c) for c in contents]
 
-        if args.output:
-            stdout_ = sys.stdout
-            sys.stdout = open(args.output, "w")
-        for c in contents:
-            print(c)
-        if args.output:
-            sys.stdout = stdout_
-
     elif args.cloud_provider == "fusillade":
 
         stage = os.environ['DSS_DEPLOYMENT_STAGE']
@@ -504,15 +505,27 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
 
         if args.group_by is None:
             # list policies
-            list_fus_policies(client)
+            contents = list_fus_policies(client)
         else:
             # list policies grouped by asset
             if args.group_by == "users":
-                list_fus_user_policies(client)
+                contents = list_fus_user_policies(client)
             elif args.group_by == "groups":
-                list_fus_group_policies(client)
+                contents = list_fus_group_policies(client)
             elif args.group_by == "roles":
-                list_fus_role_policies(client)
+                contents = list_fus_role_policies(client)
+
+            # Join the tuples
+            contents = [SEPARATOR.join(c) for c in contents]
 
     else:
         raise RuntimeError(f"Error: IAM functionality not implemented for {args.cloud_provider}")
+
+    # Print list to output
+    if args.output:
+        stdout_ = sys.stdout
+        sys.stdout = open(args.output, "w")
+    for c in contents:
+        print(c)
+    if args.output:
+        sys.stdout = stdout_

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -13,9 +13,6 @@ import typing
 from botocore.exceptions import ClientError
 
 from dss.operations import dispatch
-from dss.operations.ssm_params import get_ssm_variable_prefix, fix_ssm_variable_prefix
-from dss.operations.ssm_params import set_ssm_parameter, unset_ssm_parameter
-from dss.operations.ssm_params import set_ssm_environment
 from dss.operations.secrets import fix_secret_variable_prefix, fetch_secret_safely
 
 from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,13 +12,22 @@ import requests
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from dss.config import Replica
+from dss.config import Replica, BucketConfig, Config
 import dss
 from dss.util import UrlBuilder
 from dss.util.version import datetime_to_version_format
 from tests.infra import DSSAssertMixin, DSSUploadMixin, DSSStorageMixin, TestBundle, testmode
-from tests.infra.server import ThreadedLocalServer
+from tests.infra.server import ThreadedLocalServer, MockFusilladeHandler
 from tests import get_auth_header
+
+
+def setUpModule():
+    Config.set_config(BucketConfig.TEST)
+    MockFusilladeHandler.start_serving()
+
+
+def tearDownModule():
+    MockFusilladeHandler.stop_serving()
 
 
 @testmode.standalone

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -33,12 +33,21 @@ from dss.storage.hcablobstore import compose_blob_key
 from dss.util.version import datetime_to_version_format
 from dss.storage.bundles import get_bundle_manifest
 from tests.infra import DSSAssertMixin, DSSUploadMixin, ExpectedErrorFields, get_env, testmode, TestAuthMixin
-from tests.infra.server import ThreadedLocalServer
+from tests.infra.server import ThreadedLocalServer, MockFusilladeHandler
 from tests import eventually, get_auth_header
 
 
 BUNDLE_GET_RETRY_COUNT = 60
 """For GET /bundles requests that require a retry, this is the maximum number of attempts we make."""
+
+
+def setUpModule():
+    Config.set_config(BucketConfig.TEST)
+    MockFusilladeHandler.start_serving()
+
+
+def tearDownModule():
+    MockFusilladeHandler.stop_serving()
 
 
 @testmode.standalone

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -668,27 +668,6 @@ class TestOperations(unittest.TestCase):
         gold_var = f"{prefix}/dummy_variable"
         self.assertEqual(new_var, gold_var)
 
-    def test_ssmparams_crud(self):
-        # CRUD (create read update delete) test for setting environment variables in SSM param store
-        testvar_name = random_alphanumeric_string()
-        testvar_value = "Hello world!"
-
-        # Assemble environment to return
-        old_env = {"DUMMY_VARIABLE": "dummy_value"}
-        new_env = dict(**old_env)
-        new_env[testvar_name] = testvar_value
-        ssm_new_env = self._wrap_ssm_env(new_env)
-
-        with self.subTest("Print the SSM environment"):
-            with mock.patch("dss.operations.lambda_params.ssm_client") as ssm:
-                # listing params will call ssm.get_parameter to get the entire environment
-                ssm.get_parameter = mock.MagicMock(return_value=ssm_new_env)
-
-                # Now call our params.py module. Output var=value on each line.
-                with CaptureStdout() as output:
-                    lambda_params.ssm_environment([], argparse.Namespace(json=False))
-                self.assertIn(f"{testvar_name}={testvar_value}", output)
-
     def test_lambdaparams_crud(self):
         # CRUD (create read update delete) test for setting lambda function environment variables
         testvar_name = random_alphanumeric_string()
@@ -770,7 +749,7 @@ class TestOperations(unittest.TestCase):
                 #   then calls lambda_client.get_function_configuration()
                 lam.get_function_configuration = mock.MagicMock(return_value=lam_new_env)
 
-                # TODO: reduce copypasta
+                # @chmreid TODO: reduce copypasta
 
                 # Non-JSON, no lambda name specified
                 with CaptureStdout() as output:


### PR DESCRIPTION
This PR is made on the `chmreid-iam-ops` branch.

This PR splits up and isolates some of the fusillade-specific work in PR #2492. It is intended to make that pull request easier to review.

Also, PR #2501 adds tests for new fusillade IAM functionality to this pull request.