### PR TITLE
DSS Bundle Enumeration: Test Refactor

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -988,8 +988,17 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
     def test_enumeration_bundles(self):
         bundle_uuid, bundle_version = self._put_bundle()
         res = self.app.get(f"/v1/bundles/all",
-                           params=dict(version=bundle_version, replica="aws", per_page=500))
+                           params=dict(version=bundle_version, replica="aws", per_page=10))
         self.assertIn(res.status_code, (requests.codes.okay, requests.codes.partial))
+        if res.status_code is requests.codes.partial:
+            body = res.json()
+            page_one = body['bundles']
+            link = urlparse(body['link'])
+            formatted_link = f'{link.path}?{link.query}'
+            res = self.app.get(formatted_link)
+            self.assertIn(res.status_code, (requests.codes.okay, requests.codes.partial))
+            for x in res.json()['bundles']:
+                self.assertNotIn(x, page_one)
 
 
 if __name__ == '__main__':

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -41,6 +41,7 @@ BUNDLE_GET_RETRY_COUNT = 60
 """For GET /bundles requests that require a retry, this is the maximum number of attempts we make."""
 
 
+@testmode.standalone
 class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadMixin):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -172,7 +172,7 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
                 # Make sure we're getting the expected response status code
                 if link_header:
                     self.assertEqual(resp_obj.response.headers['X-OpenAPI-Pagination'], 'true')
-                    self.assertEqual(resp_obj.response.headers['X-OpenAPI-Paginated-Content-Key'], 'files')
+                    self.assertEqual(resp_obj.response.headers['X-OpenAPI-Paginated-Content-Key'], 'bundle.files')
                     self.assertEqual(resp_obj.response.status_code, requests.codes.partial)
                 else:
                     self.assertEqual(resp_obj.response.headers['X-OpenAPI-Pagination'], 'false')

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -41,7 +41,6 @@ BUNDLE_GET_RETRY_COUNT = 60
 """For GET /bundles requests that require a retry, this is the maximum number of attempts we make."""
 
 
-@testmode.integration
 class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadMixin):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -170,9 +170,9 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
                 link_header = resp_obj.response.headers.get('Link')
 
                 # Make sure we're getting the expected response status code
+                self.assertEqual(resp_obj.response.headers['X-OpenAPI-Paginated-Content-Key'], 'bundle.files')
                 if link_header:
                     self.assertEqual(resp_obj.response.headers['X-OpenAPI-Pagination'], 'true')
-                    self.assertEqual(resp_obj.response.headers['X-OpenAPI-Paginated-Content-Key'], 'bundle.files')
                     self.assertEqual(resp_obj.response.status_code, requests.codes.partial)
                 else:
                     self.assertEqual(resp_obj.response.headers['X-OpenAPI-Pagination'], 'false')

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -135,22 +135,10 @@ class Smoketest(BaseSmokeTest):
         for replica in self.replicas:
             # Enumerations against the replicas should be done after the test_replica_sync to ensure consistency.
             with self.subTest(f'Testing Bundle Enumeration on {replica.name}'):
-                enumerate_bundles = list()
-                page_size = 10
+                page_size = 500
                 first_page = self.get_bundle_enumerations(replica.name, page_size)
-                print(first_page)
-                self.assertEqual(first_page['per_page'], 10)
+                self.assertEqual(first_page['per_page'], 500)
                 self.assertGreater(first_page['page_count'], 0)
-                if first_page['has_more'] is True:
-                    self.assertTrue(first_page['has_more'])
-                    self.assertTrue(first_page['token'])
-                    enumerate_bundles.extend(first_page['bundles'])
-                    next_page = self.get_bundle_enumerations(replica.name, page_size,
-                                                             search_after=first_page['search_after'],
-                                                             token=first_page['token'])
-                    self.assertEqual(next_page['per_page'], 10)
-                    enumerate_bundles.extend(next_page['bundles'])
-                    self.assertEqual(len(enumerate_bundles), (first_page['page_count'] + next_page['page_count']))
 
     def test_smoketest(self):
         for param in self.params:


### PR DESCRIPTION
move complex enumeration tests out of `tests/test_smoketest.py`, introduces more testing into `tests/test_bundles.py`
marks file for `@testmode.standalone`
addresses change to header in test