### PR TITLE
Add simple bundle enumeration test

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -41,7 +41,6 @@ BUNDLE_GET_RETRY_COUNT = 60
 """For GET /bundles requests that require a retry, this is the maximum number of attempts we make."""
 
 
-@testmode.integration
 class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadMixin):
     @classmethod
     def setUpClass(cls):
@@ -807,6 +806,19 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
                         code="not_found",
                         status=requests.codes.not_found),
                     headers=get_auth_header())
+
+    def test_bundle_enumeration(self):
+        for replica in Replica:
+            with self.subTest(replica=replica):
+                url = str(UrlBuilder()
+                          .set(path="/v1/bundles/all")
+                          .add_query("replica", replica.name))
+
+                with override_bucket_config(BucketConfig.TEST):
+                    resp_obj = self.assertGetResponse(
+                        url,
+                        [requests.codes.ok, requests.codes.partial],
+                        headers=get_auth_header())
 
     def put_bundle(
             self,

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -142,8 +142,6 @@ class Smoketest(BaseSmokeTest):
                 self.assertEqual(first_page['per_page'], 10)
                 self.assertGreater(first_page['page_count'], 0)
                 if first_page['has_more'] is True:
-                    self.assertTrue(first_page['has_more'])
-                    self.assertTrue(first_page['token'])
                     enumerate_bundles.extend(first_page['bundles'])
                     next_page = self.get_bundle_enumerations(replica.name, page_size,
                                                              search_after=first_page['search_after'],


### PR DESCRIPTION
This test should be expanded to catch bundle enumeration errors before deployment.

This also changes bundle API tests back to unit tests. These tests are expected to run before deployment.