### PR TITLE
Send X-OpenAPI-Paginated-Content-Key even when only one page is present

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -135,7 +135,7 @@ def get(
         response.headers['X-OpenAPI-Pagination'] = 'true'
         response.headers['Link'] = link
 
-    response.headers['X-OpenAPI-Paginated-Content-Key'] = 'bundles.files'
+    response.headers['X-OpenAPI-Paginated-Content-Key'] = 'bundle.files'
     return response
 
 @dss_handler

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -130,13 +130,13 @@ def get(
     if link is None:
         response = make_response(jsonify(response_body), requests.codes.ok)
         response.headers['X-OpenAPI-Pagination'] = 'false'
-        return response
     else:
         response = make_response(jsonify(response_body), requests.codes.partial)
         response.headers['X-OpenAPI-Pagination'] = 'true'
-        response.headers['X-OpenAPI-Paginated-Content-Key'] = 'files'
         response.headers['Link'] = link
-        return response
+
+    response.headers['X-OpenAPI-Paginated-Content-Key'] = 'bundles.files'
+    return response
 
 @dss_handler
 def enumerate(replica: str,

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -185,7 +185,7 @@ def enumerate(replica: str,
         response = make_response(jsonify(payload), requests.codes.partial)
         response.headers['Link'] = link
         response.headers['X-OpenAPI-Pagination'] = 'true'
-        response.headers['X-OpenAPI-Paginated-Content-Key'] = 'bundles'
+    response.headers['X-OpenAPI-Paginated-Content-Key'] = 'bundles'
     return response
 
 

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -77,12 +77,12 @@ def list_collections(per_page: int, start_at: int = 0):
         response = make_response(jsonify({'collections': collection_page}), requests.codes.partial)
         response.headers['Link'] = f"<{next_url}>; rel='next'"
         response.headers['X-OpenAPI-Pagination'] = 'true'
-        response.headers['X-OpenAPI-Paginated-Content-Key'] = 'collections'
     # single response returning all collections (or those remaining)
     else:
         collection_page = collections[start_at:]
         response = make_response(jsonify({'collections': collection_page}), requests.codes.ok)
         response.headers['X-OpenAPI-Pagination'] = 'false'
+    response.headers['X-OpenAPI-Paginated-Content-Key'] = 'collections'
     return response
 
 

--- a/dss/api/events.py
+++ b/dss/api/events.py
@@ -35,7 +35,7 @@ def list_events(replica: str, from_date: str=None, to_date: str=None, per_page: 
         response = make_response(jsonify(urls[:-1]), requests.codes.partial)
         response.headers['Link'] = link
         response.headers['X-OpenAPI-Pagination'] = 'true'
-        response.headers['X-OpenAPI-Paginated-Content-Key'] = 'event_streams'
+    response.headers['X-OpenAPI-Paginated-Content-Key'] = 'event_streams'
     return response
 
 @dss_handler

--- a/dss/api/search.py
+++ b/dss/api/search.py
@@ -85,7 +85,7 @@ def post(json_request_body: dict,
             next_url = _build_next_url(page, per_page, replica_enum, output_format)
             response.headers['Link'] = _build_link_header({next_url: {"rel": "next"}})
             response.headers['X-OpenAPI-Pagination'] = 'true'
-            response.headers['X-OpenAPI-Paginated-Content-Key'] = 'results'
+        response.headers['X-OpenAPI-Paginated-Content-Key'] = 'results'
         return response
 
 


### PR DESCRIPTION
X-OpenAPI-Paginated-Content-Key needs to be sent with every response
for methods that support pagination, even if there is only one
page. The client needs the key name metadata in
X-OpenAPI-Paginated-Content-Key to stream results without hardcoding
the key name.

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
