### PR TITLE
Add Mock Fusillade server to test_bundle and test_api

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,13 +12,22 @@ import requests
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
-from dss.config import Replica
+from dss.config import Replica, BucketConfig, Config
 import dss
 from dss.util import UrlBuilder
 from dss.util.version import datetime_to_version_format
 from tests.infra import DSSAssertMixin, DSSUploadMixin, DSSStorageMixin, TestBundle, testmode
-from tests.infra.server import ThreadedLocalServer
+from tests.infra.server import ThreadedLocalServer, MockFusilladeHandler
 from tests import get_auth_header
+
+
+def setUpModule():
+    Config.set_config(BucketConfig.TEST)
+    MockFusilladeHandler.start_serving()
+
+
+def tearDownModule():
+    MockFusilladeHandler.stop_serving()
 
 
 @testmode.standalone

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -33,12 +33,21 @@ from dss.storage.hcablobstore import compose_blob_key
 from dss.util.version import datetime_to_version_format
 from dss.storage.bundles import get_bundle_manifest
 from tests.infra import DSSAssertMixin, DSSUploadMixin, ExpectedErrorFields, get_env, testmode, TestAuthMixin
-from tests.infra.server import ThreadedLocalServer
+from tests.infra.server import ThreadedLocalServer, MockFusilladeHandler
 from tests import eventually, get_auth_header
 
 
 BUNDLE_GET_RETRY_COUNT = 60
 """For GET /bundles requests that require a retry, this is the maximum number of attempts we make."""
+
+
+def setUpModule():
+    Config.set_config(BucketConfig.TEST)
+    MockFusilladeHandler.start_serving()
+
+
+def tearDownModule():
+    MockFusilladeHandler.stop_serving()
 
 
 @testmode.standalone


### PR DESCRIPTION
Adds the Mock Fusillade Server to `tests/test_bundle.py` and `tests/test_api.py`