### PR TITLE
Add Elasticsearch reindex operation

### DIFF
--- a/dss/operations/elasticsearch.py
+++ b/dss/operations/elasticsearch.py
@@ -54,8 +54,7 @@ def index(argv: typing.List[str], args: argparse.Namespace):
     def _forward_keys(pfx):
         with SQSMessenger(index_queue_url) as sqsm:
             for key in handle.list(replica.bucket, pfx):
-                # sqsm.send(json.dumps(dict(replica=args.replica, key=key)))
-                print(key)
+                sqsm.send(json.dumps(dict(replica=args.replica, key=key)))
 
     with ThreadPoolExecutor(max_workers=10) as e:
         futures = [e.submit(_forward_keys, f"bundles/{args.prefix}{c}") for c in hexdigits.lower()]

--- a/dss/operations/elasticsearch.py
+++ b/dss/operations/elasticsearch.py
@@ -56,8 +56,9 @@ def index(argv: typing.List[str], args: argparse.Namespace):
             for key in handle.list(replica.bucket, pfx):
                 sqsm.send(json.dumps(dict(replica=args.replica, key=key)))
 
+    hex_chars = set(hexdigits.lower())
     with ThreadPoolExecutor(max_workers=10) as e:
-        futures = [e.submit(_forward_keys, f"bundles/{args.prefix}{c}") for c in hexdigits.lower()]
+        futures = [e.submit(_forward_keys, f"bundles/{args.prefix}{c}") for c in hex_chars]
         for f in as_completed(futures):
             f.result()
 


### PR DESCRIPTION
This adds an operation to the `dss/operations` framework to bulk queue SQS messages to the indexer lambda for each key in `bundles/{pfx}`.

Usage:
```
scripts/dss-ops.py elasticsearch index-prefix --replica {replica} --prefix 0
```