### PR TITLE
Gentle refactor of tombstoning code

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -1,4 +1,3 @@
-import io
 import os
 import json
 import time
@@ -137,6 +136,7 @@ def get(
 
     response.headers['X-OpenAPI-Paginated-Content-Key'] = 'bundle.files'
     return response
+
 
 @dss_handler
 def enumerate(replica: str,
@@ -278,8 +278,7 @@ def delete(uuid: str, replica: str, json_request_body: dict, version: str = None
     bundle_prefix = tombstone_id.to_key_prefix()
     tombstone_object_data = _create_tombstone_data(
         email=email,
-        reason=json_request_body.get('reason'),
-        version=version,
+        reason=json_request_body.get('reason')
     )
 
     handle = Config.get_blobstore_handle(Replica[replica])
@@ -376,14 +375,9 @@ def detect_filename_collisions(bundle_file_metadata):
             )
 
 
-def _create_tombstone_data(email: str, reason: str, version: typing.Optional[str]) -> dict:
-    # Future-proofing the case in which garbage collection is added
-    data = dict(
-        email=email,
-        reason=reason,
-        admin_deleted=True,
-    )
-    # optional params
-    if version is not None:
-        data.update(version=version)
-    return data
+def _create_tombstone_data(email: str, reason: str, details: typing.Optional[dict]) -> dict:
+    return {
+        'email': email,
+        'reason': reason,
+        'admin_deleted': True
+    }

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -13,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dss import DSSException, dss_handler, DSSForbiddenException
 from dss.api.search import PerPageBounds
 from dss.config import Config, Replica
+from dss.storage import Tombstone
 from dss.storage.blobstore import idempotent_save, test_object_exists, ObjectTest
 from dss.storage.bundles import get_bundle_manifest, save_bundle_manifest, enumerate_available_bundles
 from dss.storage.checkout import CheckoutError, TokenError
@@ -276,10 +277,7 @@ def delete(uuid: str, replica: str, json_request_body: dict, version: str = None
     uuid = uuid.lower()
     tombstone_id = BundleTombstoneID(uuid=uuid, version=version)
     bundle_prefix = tombstone_id.to_key_prefix()
-    tombstone_object_data = _create_tombstone_data(
-        email=email,
-        reason=json_request_body.get('reason')
-    )
+    tombstone_object_data = Tombstone(email=email, reason=json_request_body.get('reason'))._asdict()
 
     handle = Config.get_blobstore_handle(Replica[replica])
     if not test_object_exists(handle, Replica[replica].bucket, bundle_prefix, test_type=ObjectTest.PREFIX):
@@ -373,11 +371,3 @@ def detect_filename_collisions(bundle_file_metadata):
                 f"Duplicate file name detected: {name}. This test fails on the first occurance. Please check bundle "
                 "layout to ensure no duplicated file names are present."
             )
-
-
-def _create_tombstone_data(email: str, reason: str, details: typing.Optional[dict]) -> dict:
-    return {
-        'email': email,
-        'reason': reason,
-        'admin_deleted': True
-    }

--- a/dss/storage/__init__.py
+++ b/dss/storage/__init__.py
@@ -1,0 +1,11 @@
+from typing import NamedTuple, Optional
+
+
+class Tombstone(NamedTuple):
+    """
+    Tombstone object compliant with RFC #4 (Deletion of data in the DCP).
+    See HumanCellAtlas/dcp-community.
+    """
+    email: str
+    reason: str
+    details: Optional[dict] = {}


### PR DESCRIPTION
This is the first of several PRs needed to implement the file deletion API (#2409). This PR refactors a tombstone helper function to be consistent with the deletion RFC and relocates it in preparation for use with files (and not just bundles).