### PR TITLE
Hotfix for lambda params

### DIFF
--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -35,7 +35,7 @@ def get_ssm_variable_prefix() -> str:
     """
     store_name = os.environ["DSS_PARAMETER_STORE"]
     stage_name = os.environ["DSS_DEPLOYMENT_STAGE"]
-    store_prefix = f"{store_name}/{stage_name}"
+    store_prefix = f"/{store_name}/{stage_name}"
     return store_prefix
 
 
@@ -43,13 +43,19 @@ def fix_ssm_variable_prefix(param_name: str) -> str:
     """Add (if necessary) the variable store and stage prefix to the front of the name of an SSM store parameter"""
     prefix = get_ssm_variable_prefix()
 
-    # Strip leading/trailing slash
+    # Strip leading slash
     if param_name.startswith("/"):
         param_name = param_name[1:]
+
+    # Strip trailing slash
     if param_name.endswith("/"):
         param_name = param_name[:-1]
 
-    if not (param_name.startswith(prefix) or param_name.startswith("/" + prefix)):
+    if not (
+            param_name.startswith(prefix) 
+            or param_name.startswith("/" + prefix)
+            or param_name.startswith(prefix[1:])
+    ):
         param_name = f"{prefix}/{param_name}"
 
     return param_name

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -77,7 +77,7 @@ def set_ssm_environment(env: dict) -> None:
     """
     prefix = get_ssm_variable_prefix()
     ssm_client.put_parameter(
-        Name=f"/{prefix}/environment", Value=json.dumps(env), Type="String", Overwrite=True
+        Name=fix_ssm_variable_prefix("environment"), Value=json.dumps(env), Type="String", Overwrite=True
     )
 
 

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -52,7 +52,7 @@ def fix_ssm_variable_prefix(param_name: str) -> str:
         param_name = param_name[:-1]
 
     if not (
-            param_name.startswith(prefix) 
+            param_name.startswith(prefix)
             or param_name.startswith("/" + prefix)
             or param_name.startswith(prefix[1:])
     ):
@@ -75,7 +75,6 @@ def set_ssm_environment(env: dict) -> None:
     :param env: dict containing environment variables to set in SSM param store
     :returns: nothing
     """
-    prefix = get_ssm_variable_prefix()
     ssm_client.put_parameter(
         Name=fix_ssm_variable_prefix("environment"), Value=json.dumps(env), Type="String", Overwrite=True
     )

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -43,22 +43,10 @@ def fix_ssm_variable_prefix(param_name: str) -> str:
     """Add (if necessary) the variable store and stage prefix to the front of the name of an SSM store parameter"""
     prefix = get_ssm_variable_prefix()
 
-    # Strip leading slash
-    if param_name.startswith("/"):
-        param_name = param_name[1:]
-
     # Strip trailing slash
-    if param_name.endswith("/"):
-        param_name = param_name[:-1]
+    param_name = param_name.rstrip("/")
 
-    if not (
-            param_name.startswith(prefix)
-            or param_name.startswith("/" + prefix)
-            or param_name.startswith(prefix[1:])
-    ):
-        param_name = f"{prefix}/{param_name}"
-
-    return param_name
+    return f"{prefix}/" + param_name.replace(prefix, "", 1).lstrip("/")
 
 
 def get_ssm_environment() -> dict:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -454,16 +454,16 @@ class TestOperations(unittest.TestCase):
                 )
 
     def test_ssmparams_utilities(self):
-        prefix = f"{os.environ['DSS_PARAMETER_STORE']}/{os.environ['DSS_DEPLOYMENT_STAGE']}"
+        prefix = f"/{os.environ['DSS_PARAMETER_STORE']}/{os.environ['DSS_DEPLOYMENT_STAGE']}"
 
         var = "dummy_variable"
         new_var = fix_ssm_variable_prefix(var)
-        gold_var = f"/{prefix}/dummy_variable"
+        gold_var = f"{prefix}/dummy_variable"
         self.assertEqual(new_var, gold_var)
 
         var = "/dummy_variable"
         new_var = fix_ssm_variable_prefix(var)
-        gold_var = f"/{prefix}/dummy_variable"
+        gold_var = f"{prefix}/dummy_variable"
         self.assertEqual(new_var, gold_var)
 
         var = f"{prefix}/dummy_variable"

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -458,12 +458,12 @@ class TestOperations(unittest.TestCase):
 
         var = "dummy_variable"
         new_var = fix_ssm_variable_prefix(var)
-        gold_var = f"{prefix}/dummy_variable"
+        gold_var = f"/{prefix}/dummy_variable"
         self.assertEqual(new_var, gold_var)
 
         var = "/dummy_variable"
         new_var = fix_ssm_variable_prefix(var)
-        gold_var = f"{prefix}/dummy_variable"
+        gold_var = f"/{prefix}/dummy_variable"
         self.assertEqual(new_var, gold_var)
 
         var = f"{prefix}/dummy_variable"
@@ -471,7 +471,7 @@ class TestOperations(unittest.TestCase):
         gold_var = f"{prefix}/dummy_variable"
         self.assertEqual(new_var, gold_var)
 
-        var = f"/{prefix}/dummy_variable"
+        var = f"{prefix}/dummy_variable/"
         new_var = fix_ssm_variable_prefix(var)
         gold_var = f"{prefix}/dummy_variable"
         self.assertEqual(new_var, gold_var)


### PR DESCRIPTION
This fixes a problem with how lambda variable prefixes are set. The SSM store requires a leading /, while the secrets store does not. This update reflects that change in `dss/operations/lambda_params.py`.