### PR TITLE
Remove duplicated keys in API spec

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -2828,12 +2828,10 @@ definitions:
         description: The event journal identifier.
         type: string
       from_date:
-        type: string
         format: DSS_VERSION
         description: DSS_VERSION format timestamp of the first event in the journal.
         type: string
       to_date:
-        type: string
         format: DSS_VERSION
         description: DSS_VERSION format timestamp of the last event in the journal.
         type: string


### PR DESCRIPTION
Swagger validator chokes on duplicate `type` declarations in `EventsManifest.events.items.properties`.

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
