### PR TITLE
[EASY] Add help to dss-ops subcommands

### DIFF
--- a/dss/operations/__init__.py
+++ b/dss/operations/__init__.py
@@ -43,7 +43,7 @@ class _target:
         def register_action(obj):
             parser = dispatcher.targets[self.target_name]['subparser'].add_parser(
                 name,
-                description=obj.__doc__,
+                help=obj.__doc__,
                 formatter_class=RawTextHelpFormatter
             )
             action_arguments = dispatcher.targets[self.target_name]['arguments'].copy()


### PR DESCRIPTION
This fixes a bug in the `dss-ops.py` script that prevented docstrings for sub-parser sub-commands from being printed.

Before:

```
$ ./scripts/dss-ops.py secrets -h
usage: dss-ops.py secrets [-h] {list,get,set,delete} ...

positional arguments:
  {list,get,set,delete}

optional arguments:
  -h, --help            show this help message and exit
```

After:

```
$ ./scripts/dss-ops.py secrets -h
usage: dss-ops.py secrets [-h] {list,get,set,delete} ...

positional arguments:
  {list,get,set,delete}
    list                Print a list of names of every secret variable in the
                        secrets manager for the DSS secrets manager for
                        $DSS_DEPLOYMENT_STAGE.
    get                 Get the value of the secret variable specified by
                        secret_name.
    set                 Set the value of the secret variable.
    delete              Delete the value of the secret variable specified by
                        the --secret-name flag from the secrets manager

optional arguments:
  -h, --help            show this help message and exit
```
