### PR TITLE
Improve events operations, bump flashflood to 0.4.1

### DIFF
--- a/dss/events/__init__.py
+++ b/dss/events/__init__.py
@@ -8,12 +8,15 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 
-from flashflood import FlashFlood, FlashFloodEventNotFound
+from flashflood import FlashFlood, FlashFloodEventNotFound, JournalID
 
 from dss.util.aws import resources
 from dss.config import Config, Replica
 from dss.storage.identifiers import TOMBSTONE_SUFFIX
 from dss.util.version import datetime_from_timestamp
+
+
+logger = logging.getLogger(__name__)
 
 # TODO: What happens when an event is recorder with timestamp erlier tha latest journal?
 
@@ -124,3 +127,42 @@ def _dot_to_underscore_and_strip_numeric_suffix(name: str) -> str:
             name = parts[0]
         name += "_json"
     return name
+
+def journal_flashflood(prefix: str, number_of_events: int=1000, start_from_journal_id: JournalID=None):
+    """
+    Compile new events into journals.
+    """
+    ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), prefix)
+    journals = list()
+    for journal_id in list_new_flashflood_journals(prefix, start_from_journal_id):
+        # TODO: Add interface method to flash-flood to avoid private attribute access
+        journals.append(ff._Journal.from_id(journal_id))
+        if number_of_events == len(journals):
+            ff.combine_journals(journals)
+            break
+
+def list_new_flashflood_journals(prefix: str, start_from_journal_id: JournalID=None) -> typing.Iterator[JournalID]:
+    """
+    List new journals.
+    Listing can optionally begin with `start_from_journal_id`
+    """
+    ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), prefix)
+    # TODO: Add interface method to flash-flood to avoid private attribute access
+    journals = ff._Journal.list(list_from=start_from_journal_id)
+    if start_from_journal_id:
+        next_journal = next(journals)
+        if "new" == start_from_journal_id.version:
+            yield start_from_journal_id
+        if "new" == next_journal.version:
+            yield next_journal
+    for journal_id in journals:
+        if "new" == journal_id.version:
+            yield journal_id
+
+def update_flashflood(prefix: str, number_of_updates_to_apply=1000):
+    """
+    Apply event updates to existing journals.
+    This is typically called after journaling is complete.
+    """
+    ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), prefix)
+    ff.update(number_of_updates_to_apply)

--- a/dss/events/__init__.py
+++ b/dss/events/__init__.py
@@ -128,7 +128,9 @@ def _dot_to_underscore_and_strip_numeric_suffix(name: str) -> str:
         name += "_json"
     return name
 
-def journal_flashflood(prefix: str, number_of_events: int=1000, start_from_journal_id: JournalID=None):
+def journal_flashflood(prefix: str,
+                       number_of_events: int=1000,
+                       start_from_journal_id: JournalID=None) -> typing.Optional[JournalID]:
     """
     Compile new events into journals.
     """
@@ -138,8 +140,8 @@ def journal_flashflood(prefix: str, number_of_events: int=1000, start_from_journ
         # TODO: Add interface method to flash-flood to avoid private attribute access
         journals.append(ff._Journal.from_id(journal_id))
         if number_of_events == len(journals):
-            ff.combine_journals(journals)
-            break
+            return ff.combine_journals(journals).id_
+    return None
 
 def list_new_flashflood_journals(prefix: str, start_from_journal_id: JournalID=None) -> typing.Iterator[JournalID]:
     """

--- a/dss/operations/events.py
+++ b/dss/operations/events.py
@@ -6,20 +6,22 @@ import typing
 import argparse
 import json
 import logging
+import traceback
 from uuid import uuid4
 from string import hexdigits
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from cloud_blobstore import BlobNotFoundError
-from flashflood import FlashFlood, FlashFloodJournalingError
+from flashflood import FlashFlood, JournalID
 from dcplib.aws.sqs import SQSMessenger
 from dcplib.aws.clients import logs
 
 from dss.config import Config, Replica
 from dss.util.aws import resources
 from dss.operations import dispatch
-from dss.events import get_bundle_metadata_document, record_event_for_bundle
+from dss.events import (get_bundle_metadata_document, record_event_for_bundle, journal_flashflood,
+                        update_flashflood, list_new_flashflood_journals)
 from dss.events.handlers.notify_v2 import _versioned_tombstone_key_regex, _unversioned_tombstone_key_regex
 from dss.storage.bundles import Living
 from dss.storage.identifiers import TOMBSTONE_SUFFIX
@@ -86,24 +88,49 @@ def record(argv: typing.List[str], args: argparse.Namespace):
 @events.action("journal",
                arguments={"--prefix": dict(required=True,
                                            help="flashflood prefix to journal events"),
-                          "--minimum-number-of-events": dict(default=1000, type=int),
-                          "--minimum-size": dict(default=1024 * 1024, type=int)})
+                          "--number-of-events": dict(default=None, type=int),
+                          "--starting-journal-id": dict(default=None),
+                          "--job-id": dict(default=None)})
 def journal(argv: typing.List[str], args: argparse.Namespace):
-    ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), args.prefix)
-    while True:
+    job_id = args.job_id or f"{uuid4()}"
+    cmd_template = (f"events journal --job-id {job_id} "
+                    f"--prefix {args.prefix} "
+                    f"--number-of-events {args.number_of_events} "
+                    f"--starting-journal-id {{}}")
+
+    if args.starting_journal_id is None:
+        start_time = datetime.now()
+        with SQSMessenger(command_queue_url) as sqsm:
+            journals = list()
+            for journal_id in list_new_flashflood_journals(args.prefix):
+                journals.append(journal_id)
+                if args.number_of_events == len(journals):
+                    print(f"Journaling from {journals[0]} with {args.number_of_events} events.")
+                    sqsm.send(cmd_template.format(journals[0]))
+                    journals = list()
+        monitor_logs(logs, job_id, start_time)
+    else:
+        msg = dict(action="journal", job_id=job_id, prefix=args.prefix, key=args.starting_journal_id)
         try:
-            ff.journal(args.minimum_number_of_events, args.minimum_size)
-        except FlashFloodJournalingError:
-            break
+            journal_flashflood(args.prefix, args.number_of_events, JournalID(args.starting_journal_id))
+        except Exception:
+            msg['ERROR'] = traceback.format_exc()
+        print(json.dumps(msg))
 
 @events.action("update",
                arguments={"--prefix": dict(required=True,
                                            help="flashflood prefix to journal events"),
-                          "--minimum-number-of-events": dict(default=1000, type=int),
-                          "--minimum-size": dict(default=1024 * 1024, type=int)})
+                          "--number-of-updates-to-apply": dict(default=None, type=int)})
 def update(argv: typing.List[str], args: argparse.Namespace):
+    update_flashflood(args.prefix, args.number_of_updates_to_apply)
+
+@events.action("list-journals",
+               arguments={"--prefix": dict(required=True,
+                                           help="flashflood prefix to journal events")})
+def list_journals(argv: typing.List[str], args: argparse.Namespace):
     ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), args.prefix)
-    ff.update()
+    for journal_id in ff.list_journals():
+        print(journal_id)
 
 @events.action("destroy",
                arguments={"--prefix": dict(required=True)})

--- a/dss/operations/events.py
+++ b/dss/operations/events.py
@@ -92,6 +92,11 @@ def record(argv: typing.List[str], args: argparse.Namespace):
                           "--starting-journal-id": dict(default=None),
                           "--job-id": dict(default=None)})
 def journal(argv: typing.List[str], args: argparse.Namespace):
+    """
+    Compile flashflood event journals. If `--starting-journal-id` is not provided, journal contents are
+    determined according to `--number-of-events` and queued into SQS for processing on AWS Lambda.
+    Otherwise the command is executed in the local environment.
+    """
     job_id = args.job_id or f"{uuid4()}"
     cmd_template = (f"events journal --job-id {job_id} "
                     f"--prefix {args.prefix} "
@@ -122,6 +127,10 @@ def journal(argv: typing.List[str], args: argparse.Namespace):
                                            help="flashflood prefix to journal events"),
                           "--number-of-updates-to-apply": dict(default=None, type=int)})
 def update(argv: typing.List[str], args: argparse.Namespace):
+    """
+    Updates and deletions requests flashflood event data are recorded but not applied until `ff.update()` is called.
+    This commmand causes flashflood to apply any available updates or deletions.
+    """
     update_flashflood(args.prefix, args.number_of_updates_to_apply)
 
 @events.action("list-journals",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ enum-compat==0.0.2
 Faker==2.0.2
 fasteners==0.15
 flake8==3.7.8
-flash-flood==0.4.0
+flash-flood==0.4.1
 Flask==1.1.1
 furl==2.0.0
 future==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.15.2
 elasticsearch==5.5.3
 elasticsearch-dsl==5.4.0
 fasteners==0.15
-flash-flood==0.4.0
+flash-flood==0.4.1
 Flask==1.1.1
 furl==2.0.0
 future==0.17.1

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -21,4 +21,4 @@ requests-http-signature >= 0.0.3
 aws-xray-sdk >= 1.0
 pyjwt >= 1.6.4
 pyyaml >= 4.2b1, <= 5.1.0
-flash-flood >= 0.4.0
+flash-flood >= 0.4.1

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -65,6 +65,24 @@ class TestEventsUtils(unittest.TestCase, DSSAssertMixin):
                     expected = ((resources.s3, Config.get_flashflood_bucket(), pfx),)
                     self.assertEqual(args, expected)
 
+    def test_journal_flashflood(self):
+        number_of_events = 5
+        ff = mock.MagicMock()
+        with mock.patch("dss.events.FlashFlood", return_value=ff):
+            with mock.patch("dss.events.list_new_flashflood_journals", return_value=range(17)):
+                events.journal_flashflood("pfx", number_of_events)
+                name, args, kwargs = ff.mock_calls[-1]
+                self.assertEqual("combine_journals", name)
+
+    # TODO: Add test for dss.events.list_new_flashflood_journals
+
+    def test_update_flashflood(self):
+        number_of_updates_to_apply = 3
+        ff = mock.MagicMock()
+        with mock.patch("dss.events.FlashFlood", return_value=ff):
+            events.update_flashflood("pfx", number_of_updates_to_apply)
+            name, args, kwargs = ff.mock_calls[0]
+            self.assertEqual(number_of_updates_to_apply, args[0])
 
 class TestEvents(unittest.TestCase, DSSAssertMixin):
     @classmethod


### PR DESCRIPTION
This adds a Lambda-parallelized event journaling operation, and a journal listing operation. It also centralizes some flashflood access calls to `dss/events/__init__.py`

flashflood is bumped to 0.4.1