### PR TITLE
Fix incorrect test for string equality

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ stages:
 
 before_script:
   - export COMMITS_URL=${GITHUB_API}/repos/HumanCellAtlas/data-store/commits
-  - if not [[ CI_COMMIT_SHA == $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
+  - if [[ CI_COMMIT_SHA != $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
 # TODO: figure out how to get the gitlab-runner to not clone the repo as root - Brian H
   - virtualenv ~/venv
   - source ~/venv/bin/activate


### PR DESCRIPTION
For example, `Ctrl-F` / `Cmd-F` for this in [this Allspark log](https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/data-store/-/jobs/52364):

```
$ export COMMITS_URL=${GITHUB_API}/repos/HumanCellAtlas/data-store/commits
$ if not [[ CI_COMMIT_SHA == $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
/bin/bash: line 91: not: command not found
```

(I can't figure out how to link to a log line number in Gitlab?)