### PR TITLE
Suppress test output for passing tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ serial_test:
 # A pattern rule that runs a single test script
 #
 $(tests): %.py : mypy lint
-	coverage run -p --source=dss $*.py $(DSS_UNITTEST_OPTS)
+	coverage run -p --source=dss $*.py -b $(DSS_UNITTEST_OPTS)
 
 # Run standalone and integration tests
 #


### PR DESCRIPTION
Updates Makefile to invoke unittest with the `--buffer` option,
which buffers stdin and stdout for each tests and discards the
buffer if the test passes. Ideally, this will help make CI logs
more manageable.

I see that `DSS_UNITTEST_OPTS` can also be set, and that it
is configured in `.gitlab-ci.yml`, `.travis.yml`, etc. but I don't see
a reason that this shouldn't be default behavior.
