### PR TITLE
[test] Disable codecov upload on PR builds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+    notify:
+        after_n_builds: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 - make $MAKE_ARGS
 
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+- if [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 if: tag IS blank # don't build tags
 

--- a/README.md
+++ b/README.md
@@ -525,3 +525,4 @@ See our [Security Policy](https://github.com/HumanCellAtlas/.github/blob/master/
 ## Contributing
 
 External contributions are welcome. Please review the [Contributing Guidelines](CONTRIBUTING.md)
+


### PR DESCRIPTION
Codecov has been returning weird results for some builds, usually
trending lower (saying that code coverage has dropped by some
ridiculous amount). I think this is because Codecov is getting
confused by all the different reports being uploaded - five from
the PR build, and another five from the branch build.

Here's an example of Codecov conflating reports from different
builds:

https://codecov.io/gh/HumanCellAtlas/data-store/commit/2fcdaa2c27de001e6a436371950d0caecdb40d3d/builds

Closes #2692