### PR TITLE
Add method to list bundle zombies

### DIFF
--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -203,7 +203,7 @@ _unversioned_tombstone_key_regex = re.compile(f"^(bundles)/({UUID_PATTERN}).{TOM
 def get_tombstoned_bundles(replica: Replica, tombstone_key: str) -> typing.Iterator[str]:
     """
     Return the bundle fqid(s) associated with a versioned or unversioned tombstone, as verified on object storage.
-    Note that an unversioned tombstone returns keys associated with bundles not previosly, as show in the example
+    Note that an unversioned tombstone returns keys associated with bundles not previously, as show in the example
     below.
 
     bundles/uuid.version1

--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 import json
 import typing
 import time
+import re
 from collections import OrderedDict
 
 import cachetools
@@ -10,8 +11,8 @@ from cloud_blobstore import BlobNotFoundError, BlobStore
 
 from dss import Config, Replica
 from dss.api.search import PerPageBounds
-from dss.storage.identifiers import DSS_BUNDLE_KEY_REGEX, DSS_BUNDLE_TOMBSTONE_REGEX, TOMBSTONE_SUFFIX, BUNDLE_PREFIX, \
-    BundleTombstoneID, BundleFQID
+from dss.storage.identifiers import (DSS_BUNDLE_KEY_REGEX, DSS_BUNDLE_TOMBSTONE_REGEX, TOMBSTONE_SUFFIX, BUNDLE_PREFIX,
+                                     BundleTombstoneID, BundleFQID, UUID_PATTERN, VERSION_PATTERN)
 from dss.storage.blobstore import test_object_exists, idempotent_save
 from dss.util import multipart_parallel_upload
 
@@ -196,3 +197,41 @@ class Living():
 
         for bundle_fqid in self._living_fqids_in_bundle_info():
             yield bundle_fqid
+
+_versioned_tombstone_key_regex = re.compile(f"^(bundles)/({UUID_PATTERN}).({VERSION_PATTERN}).{TOMBSTONE_SUFFIX}$")
+_unversioned_tombstone_key_regex = re.compile(f"^(bundles)/({UUID_PATTERN}).{TOMBSTONE_SUFFIX}$")
+def get_tombstoned_bundles(replica: Replica, tombstone_key: str) -> typing.Iterator[str]:
+    """
+    Return the bundle fqid(s) associated with a versioned or unversioned tombstone, as verified on object storage.
+    Note that an unversioned tombstone returns keys associated with bundles not previosly, as show in the example
+    below.
+
+    bundles/uuid.version1
+    bundles/uuid.version2
+    bundles/uuid.version2.dead
+    bundles/uuid.version3
+    bundles/uuid.version3.dead
+    bundles/uuid.dead
+
+    For the above listing:
+        `get_tombstoned_bundles(replica, bundles/uuid.version2.dead)` -> `bundles/uuid.version2`
+        `get_tombstoned_bundles(replica, bundles/uuid.dead)` -> `[bundles/uuid.version1]`
+    """
+    handle = Config.get_blobstore_handle(replica)
+    if _versioned_tombstone_key_regex.match(tombstone_key):
+        pfx = tombstone_key.split(f".{TOMBSTONE_SUFFIX}")[0]
+        prev_key = ""
+        for key in handle.list(replica.bucket, pfx):
+            if key == f"{prev_key}.{TOMBSTONE_SUFFIX}":
+                yield prev_key
+            prev_key = key
+    elif _unversioned_tombstone_key_regex.match(tombstone_key):
+        pfx = tombstone_key.split(f".{TOMBSTONE_SUFFIX}")[0]
+        prev_key = ""
+        for key in handle.list(replica.bucket, pfx):
+            if key != f"{prev_key}.{TOMBSTONE_SUFFIX}" and not prev_key.endswith(TOMBSTONE_SUFFIX):
+                if prev_key:
+                    yield prev_key
+            prev_key = key
+    else:
+        raise ValueError(f"{tombstone_key} is not a tombstone key")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -7,15 +7,60 @@ import string
 import unittest
 from uuid import uuid4
 from unittest import mock
+from random import random, randint
+from datetime import datetime, timedelta
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
-from dss.storage.identifiers import UUID_REGEX
-from dss.storage.bundles import enumerate_available_bundles
+from dss import Replica
+from dss.util.version import datetime_to_version_format
+from dss.storage.identifiers import UUID_REGEX, TOMBSTONE_SUFFIX
+from dss.storage.bundles import enumerate_available_bundles, get_tombstoned_bundles
 from dss.logging import configure_test_logging
 from tests.infra import testmode, MockStorageHandler
+
+
+class MockCloudBlobstoreHandle:
+    bundle_uuid: str = None
+    tombstoned_bundles: list = None
+    untombstoned_bundles: list = None
+    tombstones: list = None
+    listing: list = None
+
+    @classmethod
+    def list(cls, bucket, pfx):
+        for fqid in cls.listing:
+            yield fqid
+
+    @classmethod
+    def gen_bundle_listing(cls,
+                           number_of_versions: int,
+                           versioned_tombstone_probability: float=0.0,
+                           unversioned_tombstone_probability: float=0.0):
+        cls.bundle_uuid = str(uuid4())
+        untombstoned_bundles = list()
+        tombstoned_bundles = list()
+        tombstones = list()
+        for _ in range(number_of_versions):
+            random_date = datetime.utcnow() - timedelta(days=randint(0, 364),
+                                                        hours=randint(0, 23),
+                                                        minutes=randint(0, 59))
+            bundle_fqid = f"{cls.bundle_uuid}.{datetime_to_version_format(random_date)}"
+            bundle_key = f"bundles/{bundle_fqid}"
+            if random() <= versioned_tombstone_probability:
+                tombstones.append(f"{bundle_key}.{TOMBSTONE_SUFFIX}")
+                tombstoned_bundles.append(bundle_key)
+            else:
+                untombstoned_bundles.append(bundle_key)
+        cls.tombstoned_bundles = tombstoned_bundles
+        cls.untombstoned_bundles = untombstoned_bundles
+        cls.tombstones = tombstones
+        listing = untombstoned_bundles + tombstoned_bundles + tombstones
+        if random() <= unversioned_tombstone_probability:
+            listing.append(f"bundles/{cls.bundle_uuid}.{TOMBSTONE_SUFFIX}")
+        cls.listing = sorted(listing)
 
 
 def setUpModule():
@@ -69,6 +114,29 @@ class TestStorageBundles(unittest.TestCase):
     # TODO add test to enumerate list and ensure all bundles that should be present are there.
     # TODO: Add test for dss.storage.bundles.get_bundle_manifest
     # TODO: Add test for dss.storage.bundles.save_bundle_manifest
+
+    @mock.patch("dss.storage.bundles.Config.get_blobstore_handle", return_value=MockCloudBlobstoreHandle)
+    def test_get_tombstoned_bundles(self, _):
+        with self.subTest("Retrieve bundle fqid associated with versioned tombstone"):
+            mock_handle = MockCloudBlobstoreHandle
+            mock_handle.gen_bundle_listing(1, versioned_tombstone_probability=1.0)
+            for e in get_tombstoned_bundles(Replica.aws, mock_handle.tombstones[-1]):
+                self.assertEqual(mock_handle.tombstoned_bundles[0], e)
+
+        with self.subTest("Retrieve bundle fqids associated with unversioned tombstone"):
+            mock_handle.gen_bundle_listing(10,
+                                           versioned_tombstone_probability=0.5,
+                                           unversioned_tombstone_probability=1.0)
+            unversioned_tombstone_key = f"bundles/{mock_handle.bundle_uuid}.{TOMBSTONE_SUFFIX}"
+            listed_keys = {e for e in get_tombstoned_bundles(Replica.aws, unversioned_tombstone_key)}
+            expected_keys = {e for e in mock_handle.untombstoned_bundles}
+            self.assertEqual(listed_keys, expected_keys)
+
+        with self.subTest("Passing in non-tombstone key should raise"):
+            mock_handle.gen_bundle_listing(1, versioned_tombstone_probability=1.0)
+            with self.assertRaises(ValueError):
+                for e in get_tombstoned_bundles(Replica.aws, "asdf"):
+                    pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a method to list bundle keys associated with a tombstone key, in the following manner:

For this listing:
```
bundles/uuid.version1
bundles/uuid.version2
bundles/uuid.version2.dead
bundles/uuid.version3
bundles/uuid.version3.dead
bundles/uuid.dead
```

We should get these results:
`get_tombstoned_bundles(bundles/uuid.version2.dead)` -> `bundles/uuid.version2`
`get_tombstoned_bundles(bundles/uuid.dead)` -> `bundles/uuid.version1`

Note that the unversioned tombstone is associate with bundles _not previously tombstoned_.

This functionality will be useful for refactoring notify_v2 logic, and for forthcoming logic to remove tombstoned bundles from event streams.