### PR TITLE
Only setup fusillade for main branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,10 @@ setup_fusillade:
     - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force testing
   except:
     - schedules
+  only:
+    - master
+    - integration
+    - staging
 
 deploy:
   stage: deploy


### PR DESCRIPTION
This prevents fusillade setup from running for feature branch CI/CD pipelines.