### PR TITLE
Fix syntax errors in Fusillade roles.json

### DIFF
--- a/roles.json
+++ b/roles.json
@@ -1,226 +1,224 @@
 {
-  "roles": [
-    {
-      "dss_reader": {
-        "policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "read_checkout",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetCheckout"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:checkout/*"
-            },
-            {
-              "Sid": "read_bundles",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetBundle",
-                "dss:PostCheckout"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:bundle/*"
-            },
-            {
-              "Sid": "read_collections",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetCollection"
-              ],
-              "Resource": [
-                "arn:hca:dss:${stage}:*:collections/*",
-                "arn:hca:dss:${stage}:*:${fus:user}/collections/*"
-              ]
-            },
-            {
-              "Sid": "read_files",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetFiles",
-                "dss:HeadFiles"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:files/*"
-            },
-            {
-              "Sid": "query",
-              "Effect": "Allow",
-              "Action": [
-                "dss:PostSearch"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:query"
-            }
-          ]
-        }
-      },
-      "dss_subscriber": {
-        "policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "modify_subscription",
-              "Effect": "Allow",
-              "Action": [
-                "dss:PutSubscriptions",
-                "dss:GetSubscription",
-                "dss:DeleteSubscription"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:${fus:user}/subscription/*"
-            },
-            {
-              "Sid": "get_subscriptions",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetSubscriptions"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:${fus:user}/subscriptions"
-            }
-          ]
-        }
-      },
-      "dss_wrangler": {
-        "policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "modify_bundles",
-              "Effect": "Allow",
-              "Action": [
-                "dss:DeleteBundle",
-                "dss:GetBundle",
-                "dss:PatchBundle",
-                "dss:PutBundle"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:bundle/*"
-            },
-            {
-              "Sid": "modify_files",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetFiles",
-                "dss:HeadFiles",
-                "dss:PutFiles"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:files/*"
-            },
-            {
-              "Sid": "read_checkout",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetCheckout"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:checkout/*"
-            }
-          ]
-        }
-      },
-      "dss_collector": {
-        "policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "get_collections",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetCollections"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections"
-            },
-            {
-              "Sid": "modify_collection",
-              "Effect": "Allow",
-              "Action": [
-                "dss:PutCollection",
-                "dss:DeleteCollection",
-                "dss:GetCollection",
-                "dss:PatchCollection"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections/{uuid}"
-            }
-          ]
-        }
-      },
-      "dss_admin": {
-        "policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "modify_bundles",
-              "Effect": "Allow",
-              "Action": [
-                "dss:DeleteBundle",
-                "dss:GetBundle",
-                "dss:PatchBundle",
-                "dss:PutBundle"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:bundle/*"
-            },
-            {
-              "Sid": "modify_files",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetFiles",
-                "dss:HeadFiles",
-                "dss:PutFiles"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:file/*"
-            },
-            {
-              "Sid": "read_checkout",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetCheckout"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:checkout/*"
-            },
-            {
-              "Sid": "get_collections",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetCollections"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:*/collections"
-            },
-            {
-              "Sid": "modify_collection",
-              "Effect": "Allow",
-              "Action": [
-                "dss:PutCollection",
-                "dss:DeleteCollection",
-                "dss:GetCollection",
-                "dss:PatchCollection"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:*/collections/{uuid}"
-            },
-            {
-              "Sid": "modify_subscription",
-              "Effect": "Allow",
-              "Action": [
-                "dss:PutSubscriptions",
-                "dss:GetSubscription",
-                "dss:DeleteSubscription"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:*/subscription/*"
-            },
-            {
-              "Sid": "get_subscriptions",
-              "Effect": "Allow",
-              "Action": [
-                "dss:GetSubscriptions"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:*/subscriptions"
-            },
-            {
-              "Sid": "query",
-              "Effect": "Allow",
-              "Action": [
-                "dss:PostSearch"
-              ],
-              "Resource": "arn:hca:dss:${stage}:*:query"
-            }
-          ]
-        }
+  "roles": {
+    "dss_reader": {
+      "policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "read_checkout",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetCheckout"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:checkout/*"
+          },
+          {
+            "Sid": "read_bundles",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetBundle",
+              "dss:PostCheckout"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
+          },
+          {
+            "Sid": "read_collections",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetCollection"
+            ],
+            "Resource": [
+              "arn:hca:dss:${stage}:*:collections/*",
+              "arn:hca:dss:${stage}:*:${fus:user}/collections/*"
+            ]
+          },
+          {
+            "Sid": "read_files",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetFiles",
+              "dss:HeadFiles"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:files/*"
+          },
+          {
+            "Sid": "query",
+            "Effect": "Allow",
+            "Action": [
+              "dss:PostSearch"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:query"
+          }
+        ]
+      }
+    },
+    "dss_subscriber": {
+      "policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "modify_subscription",
+            "Effect": "Allow",
+            "Action": [
+              "dss:PutSubscriptions",
+              "dss:GetSubscription",
+              "dss:DeleteSubscription"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/subscription/*"
+          },
+          {
+            "Sid": "get_subscriptions",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetSubscriptions"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/subscriptions"
+          }
+        ]
+      }
+    },
+    "dss_wrangler": {
+      "policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "modify_bundles",
+            "Effect": "Allow",
+            "Action": [
+              "dss:DeleteBundle",
+              "dss:GetBundle",
+              "dss:PatchBundle",
+              "dss:PutBundle"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
+          },
+          {
+            "Sid": "modify_files",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetFiles",
+              "dss:HeadFiles",
+              "dss:PutFiles"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:files/*"
+          },
+          {
+            "Sid": "read_checkout",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetCheckout"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:checkout/*"
+          }
+        ]
+      }
+    },
+    "dss_collector": {
+      "policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "get_collections",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetCollections"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections"
+          },
+          {
+            "Sid": "modify_collection",
+            "Effect": "Allow",
+            "Action": [
+              "dss:PutCollection",
+              "dss:DeleteCollection",
+              "dss:GetCollection",
+              "dss:PatchCollection"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections/{uuid}"
+          }
+        ]
+      }
+    },
+    "dss_admin": {
+      "policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "modify_bundles",
+            "Effect": "Allow",
+            "Action": [
+              "dss:DeleteBundle",
+              "dss:GetBundle",
+              "dss:PatchBundle",
+              "dss:PutBundle"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
+          },
+          {
+            "Sid": "modify_files",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetFiles",
+              "dss:HeadFiles",
+              "dss:PutFiles"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:file/*"
+          },
+          {
+            "Sid": "read_checkout",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetCheckout"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:checkout/*"
+          },
+          {
+            "Sid": "get_collections",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetCollections"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:*/collections"
+          },
+          {
+            "Sid": "modify_collection",
+            "Effect": "Allow",
+            "Action": [
+              "dss:PutCollection",
+              "dss:DeleteCollection",
+              "dss:GetCollection",
+              "dss:PatchCollection"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:*/collections/{uuid}"
+          },
+          {
+            "Sid": "modify_subscription",
+            "Effect": "Allow",
+            "Action": [
+              "dss:PutSubscriptions",
+              "dss:GetSubscription",
+              "dss:DeleteSubscription"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:*/subscription/*"
+          },
+          {
+            "Sid": "get_subscriptions",
+            "Effect": "Allow",
+            "Action": [
+              "dss:GetSubscriptions"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:*/subscriptions"
+          },
+          {
+            "Sid": "query",
+            "Effect": "Allow",
+            "Action": [
+              "dss:PostSearch"
+            ],
+            "Resource": "arn:hca:dss:${stage}:*:query"
+          }
+        ]
       }
     }
-  ]
+  }
 }

--- a/roles.json
+++ b/roles.json
@@ -1,224 +1,226 @@
 {
-  "roles": {
-    "dss_reader": {
-      "policy": {
-        "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Sid": "read_checkout",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetCheckout"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:checkout/*"
-          },
-          {
-            "Sid": "read_bundles",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetBundle",
-              "dss:PostCheckout"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
-          },
-          {
-            "Sid": "read_collections",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetCollection"
-            ],
-            "Resource": [
-              "arn:hca:dss:${stage}:*:collections/*",
-              "arn:hca:dss:${stage}:*:${fus:user}/collections/*"
-            ]
-          },
-          {
-            "Sid": "read_files",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetFiles",
-              "dss:HeadFiles"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:files/*"
-          },
-          {
-            "Sid": "query",
-            "Effect": "Allow",
-            "Action": [
-              "dss:PostSearch"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:query"
-          }
-        ]
-      }
-    },
-    "dss_subscriber": {
-      "policy": {
-        "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Sid": "modify_subscription",
-            "Effect": "Allow",
-            "Action": [
-              "dss:PutSubscriptions",
-              "dss:GetSubscription",
-              "dss:DeleteSubscription"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/subscription/*"
-          },
-          {
-            "Sid": "get_subscriptions",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetSubscriptions"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/subscriptions"
-          }
-        ]
-      }
-    },
-    "dss_wrangler": {
-      "policy": {
-        "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Sid": "modify_bundles",
-            "Effect": "Allow",
-            "Action": [
-              "dss:DeleteBundle",
-              "dss:GetBundle",
-              "dss:PatchBundle",
-              "dss:PutBundle"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
-          },
-          {
-            "Sid": "modify_files",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetFiles",
-              "dss:HeadFiles",
-              "dss:PutFiles"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:files/*"
-          },
-          {
-            "Sid": "read_checkout",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetCheckout"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:checkout/*"
-          }
-        ]
-      }
-    },
-    "dss_collector": {
-      "policy": {
-        "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Sid": "get_collections",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetCollections"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections"
-          },
-          {
-            "Sid": "modify_collection",
-            "Effect": "Allow",
-            "Action": [
-              "dss:PutCollection",
-              "dss:DeleteCollection",
-              "dss:GetCollection",
-              "dss:PatchCollection"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections/{uuid}"
-          }
-        ]
-      }
-    },
-    "dss_admin": {
-      "policy": {
-        "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Sid": "modify_bundles",
-            "Effect": "Allow",
-            "Action": [
-              "dss:DeleteBundle",
-              "dss:GetBundle",
-              "dss:PatchBundle",
-              "dss:PutBundle"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:bundle/*"
-          },
-          {
-            "Sid": "modify_files",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetFiles",
-              "dss:HeadFiles",
-              "dss:PutFiles"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:file/*"
-          },
-          {
-            "Sid": "read_checkout",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetCheckout"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:checkout/*"
-          },
-          {
-            "Sid": "get_collections",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetCollections"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:*/collections"
-          },
-          {
-            "Sid": "modify_collection",
-            "Effect": "Allow",
-            "Action": [
-              "dss:PutCollection",
-              "dss:DeleteCollection",
-              "dss:GetCollection",
-              "dss:PatchCollection"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:*/collections/{uuid}"
-          },
-          {
-            "Sid": "modify_subscription",
-            "Effect": "Allow",
-            "Action": [
-              "dss:PutSubscriptions",
-              "dss:GetSubscription",
-              "dss:DeleteSubscription"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:*/subscription/*"
-          },
-          {
-            "Sid": "get_subscriptions",
-            "Effect": "Allow",
-            "Action": [
-              "dss:GetSubscriptions"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:*/subscriptions"
-          },
-          {
-            "Sid": "query",
-            "Effect": "Allow",
-            "Action": [
-              "dss:PostSearch"
-            ],
-            "Resource": "arn:hca:dss:${stage}:*:query"
-          }
-        ]
+  "roles": [
+    {
+      "dss_reader": {
+        "policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "read_checkout",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetCheckout"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:checkout/*"
+            },
+            {
+              "Sid": "read_bundles",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetBundle",
+                "dss:PostCheckout"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:bundle/*"
+            },
+            {
+              "Sid": "read_collections",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetCollection"
+              ],
+              "Resource": [
+                "arn:hca:dss:${stage}:*:collections/*",
+                "arn:hca:dss:${stage}:*:${fus:user}/collections/*"
+              ]
+            },
+            {
+              "Sid": "read_files",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetFiles",
+                "dss:HeadFiles"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:files/*"
+            },
+            {
+              "Sid": "query",
+              "Effect": "Allow",
+              "Action": [
+                "dss:PostSearch"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:query"
+            }
+          ]
+        }
+      },
+      "dss_subscriber": {
+        "policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "modify_subscription",
+              "Effect": "Allow",
+              "Action": [
+                "dss:PutSubscriptions",
+                "dss:GetSubscription",
+                "dss:DeleteSubscription"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:${fus:user}/subscription/*"
+            },
+            {
+              "Sid": "get_subscriptions",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetSubscriptions"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:${fus:user}/subscriptions"
+            }
+          ]
+        }
+      },
+      "dss_wrangler": {
+        "policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "modify_bundles",
+              "Effect": "Allow",
+              "Action": [
+                "dss:DeleteBundle",
+                "dss:GetBundle",
+                "dss:PatchBundle",
+                "dss:PutBundle"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:bundle/*"
+            },
+            {
+              "Sid": "modify_files",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetFiles",
+                "dss:HeadFiles",
+                "dss:PutFiles"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:files/*"
+            },
+            {
+              "Sid": "read_checkout",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetCheckout"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:checkout/*"
+            }
+          ]
+        }
+      },
+      "dss_collector": {
+        "policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "get_collections",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetCollections"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections"
+            },
+            {
+              "Sid": "modify_collection",
+              "Effect": "Allow",
+              "Action": [
+                "dss:PutCollection",
+                "dss:DeleteCollection",
+                "dss:GetCollection",
+                "dss:PatchCollection"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:${fus:user}/collections/{uuid}"
+            }
+          ]
+        }
+      },
+      "dss_admin": {
+        "policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "modify_bundles",
+              "Effect": "Allow",
+              "Action": [
+                "dss:DeleteBundle",
+                "dss:GetBundle",
+                "dss:PatchBundle",
+                "dss:PutBundle"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:bundle/*"
+            },
+            {
+              "Sid": "modify_files",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetFiles",
+                "dss:HeadFiles",
+                "dss:PutFiles"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:file/*"
+            },
+            {
+              "Sid": "read_checkout",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetCheckout"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:checkout/*"
+            },
+            {
+              "Sid": "get_collections",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetCollections"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:*/collections"
+            },
+            {
+              "Sid": "modify_collection",
+              "Effect": "Allow",
+              "Action": [
+                "dss:PutCollection",
+                "dss:DeleteCollection",
+                "dss:GetCollection",
+                "dss:PatchCollection"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:*/collections/{uuid}"
+            },
+            {
+              "Sid": "modify_subscription",
+              "Effect": "Allow",
+              "Action": [
+                "dss:PutSubscriptions",
+                "dss:GetSubscription",
+                "dss:DeleteSubscription"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:*/subscription/*"
+            },
+            {
+              "Sid": "get_subscriptions",
+              "Effect": "Allow",
+              "Action": [
+                "dss:GetSubscriptions"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:*/subscriptions"
+            },
+            {
+              "Sid": "query",
+              "Effect": "Allow",
+              "Action": [
+                "dss:PostSearch"
+              ],
+              "Resource": "arn:hca:dss:${stage}:*:query"
+            }
+          ]
+        }
       }
     }
-  }
+  ]
 }


### PR DESCRIPTION
This fixes some bad formatting in the `roles.json` file, which defines Fusillade roles for this component