### PR TITLE
Fix API formatting issue

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -762,13 +762,21 @@ paths:
                 description: >
                   A collection of static form fields to be supplied in the request body, alongside the actual
                   notification payload. The value of each field must be a string. For example, if the subscriptions has
-                  this property set to `{"foo" : "bar"}`, the corresponding notification HTTP request body will be
+                  this property set to `{"foo" : "bar"}`, the corresponding notification HTTP request body will consist
+                  of a multipart frame with two frames,
 
                   ```
 
+                  ----------------2769baffc4f24cbc83ced26aa0c2f712
+
                   Content-Disposition: form-data; name="foo"
+
                   bar
+
+                  ----------------2769baffc4f24cbc83ced26aa0c2f712
+
                   Content-Disposition: form-data; name="payload"
+
                   {"transaction_id": "301c9079-3b20-4311-a131-bcda9b7f08ba", "subscription_id": ...
 
                   ```

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -766,14 +766,10 @@ paths:
 
                   ```
 
-                  --2769baffc4f24cbc83ced26aa0c2f712
                   Content-Disposition: form-data; name="foo"
-
                   bar
                   Content-Disposition: form-data; name="payload"
-
                   {"transaction_id": "301c9079-3b20-4311-a131-bcda9b7f08ba", "subscription_id": ...
-                  --2769baffc4f24cbc83ced26aa0c2f712--
 
                   ```
 


### PR DESCRIPTION
This fixes an issue with the API documentation. An improperly formatted string in the API documentation results in confusing output for the dcp-cli documentation:

<img width="745" alt="Screen Shot 2019-11-11 at 12 06 25" src="https://user-images.githubusercontent.com/53452777/68617273-cc1a8500-047b-11ea-85d8-284a41480e45.png">

Ref: "Named Arguments" section of dcp-cli documentation https://hca.readthedocs.io/en/latest/cli.html#put-subscription

Closes #443