### PR TITLE
[Easy] Set dss-indexer lambda concurrency to 200; increase timeout by 1 minute.

### DIFF
--- a/daemons/dss-index/.chalice/config.json
+++ b/daemons/dss-index/.chalice/config.json
@@ -10,7 +10,7 @@
     }
   },
   "version": "2.0",
-  "lambda_timeout": 300,
+  "lambda_timeout": 360,
   "lambda_memory_size": 1536,
-  "reserved_concurrent_executions": 400
+  "reserved_concurrent_executions": 200
 }

--- a/daemons/dss-index/.chalice/config.json
+++ b/daemons/dss-index/.chalice/config.json
@@ -11,5 +11,6 @@
   },
   "version": "2.0",
   "lambda_timeout": 300,
-  "lambda_memory_size": 1536
+  "lambda_memory_size": 1536,
+  "reserved_concurrent_executions": 400
 }

--- a/daemons/dss-notify/.chalice/config.json
+++ b/daemons/dss-notify/.chalice/config.json
@@ -10,6 +10,7 @@
     }
   },
   "version": "2.0",
-  "lambda_timeout": 300,
-  "lambda_memory_size": 1536
+  "lambda_timeout": 360,
+  "lambda_memory_size": 1536,
+  "reserved_concurrent_executions": 400
 }

--- a/daemons/dss-notify/.chalice/config.json
+++ b/daemons/dss-notify/.chalice/config.json
@@ -10,7 +10,6 @@
     }
   },
   "version": "2.0",
-  "lambda_timeout": 360,
-  "lambda_memory_size": 1536,
-  "reserved_concurrent_executions": 400
+  "lambda_timeout": 300,
+  "lambda_memory_size": 1536
 }


### PR DESCRIPTION
Partially addresses: https://github.com/HumanCellAtlas/data-store/issues/2583