### PR TITLE
Move check of whether allspark is behind github to deploy stage only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,6 @@ stages:
 
 before_script:
   - export COMMITS_URL=${GITHUB_API}/repos/HumanCellAtlas/data-store/commits
-  - if not [[ CI_COMMIT_SHA == $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
 # TODO: figure out how to get the gitlab-runner to not clone the repo as root - Brian H
   - virtualenv ~/venv
   - source ~/venv/bin/activate
@@ -97,6 +96,8 @@ setup_fusillade:
 
 deploy:
   stage: deploy
+  before_script:
+    - if [[ CI_COMMIT_SHA != $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
   script:
     - make plan-infra
     - make deploy


### PR DESCRIPTION
This PR addresses #2546 and attempts to fix PR #2539 (which was abandoned).

It fixes this string in `gitlab-ci.yml`:

https://github.com/HumanCellAtlas/data-store/blob/0a4dfda6a354d90f4edc8e05306e1cb31551a586/.gitlab-ci.yml#L22

The bash statement above does the following:
- `http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME` passes the name of the current branch (in the Gitlab CI/CD) to the Github API
- `jq -r '.[0]["sha"]` parses out the SHA hash of the _latest_ commit (on Github) made to the branch with that name
- finally, checking whether this is equal to `$CI_COMMIT_SHA` is checking whether the Allspark CI/CD system is testing the newest/freshest commit on this branch (this assumes Github is the source of truth and Gitlab is just the mirror)
- the `not` bit is invalid bash syntax, so this check always fails

This PR does the following:
- fix the invalid syntax
- move the check out of the `before_script` for all stages, and move it into the `before_script` for the `deploy` stage
- @natanlao already tried fixing the invalid bash syntax and leaving it in place (see PR #2539), which caused non-deploy tests to fail every time. That's why this PR moves it to the `before_script` of the deploy stage only.
- Currently this check fails due to a syntax error, so regardless of its original intent, it does nothing
- This proposed fix may not be in line with the original intent of the check, so please suggest alternative approaches if you think they are more in line with the original thinking

Useful:
- List of environment variables defined in Gitlab CI/CD tests, plus example values: https://docs.gitlab.com/ee/ci/variables/