### PR TITLE
Include error message in api logs

### DIFF
--- a/dss/error.py
+++ b/dss/error.py
@@ -75,20 +75,18 @@ def dss_handler(func):
                 code = ex.name
                 title = str(ex)
                 stacktrace = traceback.format_exc()
-                headers = None
             except DSSException as ex:
                 status = ex.status
                 code = ex.code
                 title = ex.message
                 stacktrace = traceback.format_exc()
-                headers = None
             except Exception as ex:
                 status = requests.codes.server_error
                 code = "unhandled_exception"
                 title = str(ex)
                 stacktrace = traceback.format_exc()
-                headers = None
-            logger.error(stacktrace)
+            headers = None
+            logger.error(json.dumps(dict(status=status, code=code, title=title, stacktrace=stacktrace)))
         else:
             status = requests.codes.unavailable
             code = "read_only"

--- a/dss/error.py
+++ b/dss/error.py
@@ -86,7 +86,7 @@ def dss_handler(func):
                 title = str(ex)
                 stacktrace = traceback.format_exc()
             headers = None
-            logger.error(json.dumps(dict(status=status, code=code, title=title, stacktrace=stacktrace)))
+            logger.error(json.dumps(dict(status=status, code=code, title=title, stacktrace=stacktrace), indent=4))
         else:
             status = requests.codes.unavailable
             code = "read_only"


### PR DESCRIPTION
This includes error information along with the stacktrace in API server logs. Previously only the stacktrace was logged, which does not perform string interpolation.