### PR TITLE
Move check of whether allspark is behind github to prod stage only

### DIFF
--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -16,7 +16,7 @@ stages:
 before_script:
   - date && date -u
   - export COMMITS_URL=${GITHUB_API}/repos/HumanCellAtlas/data-store/commits
-  - if not [[ CI_COMMIT_SHA == $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
+  - if [[ CI_COMMIT_SHA != $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
 # TODO: figure out how to get the gitlab-runner to not clone the repo as root - Brian H
   - cp -r /HumanCellAtlas/data-store ~/data-store && cd ~/data-store
   - git reset --hard HEAD

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,6 @@ stages:
 
 before_script:
   - date && date -u
-  - export COMMITS_URL=${GITHUB_API}/repos/HumanCellAtlas/data-store/commits
-  - if not [[ CI_COMMIT_SHA == $(http GET $COMMITS_URL sha==$CI_COMMIT_REF_NAME | jq -r '.[0]["sha"]') ]]; then exit 1; fi
 # TODO: figure out how to get the gitlab-runner to not clone the repo as root - Brian H
   - virtualenv ~/venv
   - source ~/venv/bin/activate


### PR DESCRIPTION
This PR addresses #2546 and attempts to fix PR #2539 (which was abandoned) and #2585 (which we decided was not the right approach).

This PR removes this problematic line from `.gitlab-ci.yml`:

https://github.com/HumanCellAtlas/data-store/blob/master/.gitlab-ci.yml#L22

It keeps this line in `.gitlab-ci-prod.yml` but fixes the syntax:

https://github.com/HumanCellAtlas/data-store/blob/master/.gitlab-ci-prod.yml#L19

Removes `not` and replaces `==` with `!=`

Useful:
- List of environment variables defined in Gitlab CI/CD tests, plus example values: https://docs.gitlab.com/ee/ci/variables/
- PR #1423 (commit 8b0b44c) originally added this line, the intent seems to be to prevent Allspark from deploying when Allspark and Github are out of sync
- [This comment](https://github.com/HumanCellAtlas/data-store/pull/2585#issuecomment-553155929) from @natanlao about why this check is being removed from `.gitlab-ci.yml`