### PR TITLE
[Fusillade Check 4/4] Add JSON linting step for Fusillade roles.json file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,7 @@ setup_fusillade:
     - else
     -   FUS_STAGE=$DSS_DEPLOYMENT_STAGE
     - fi
+    - python -m json.tool ./temp-roles.json > /dev/null || exit 1
     - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force $FUS_STAGE
   except:
     - schedules


### PR DESCRIPTION
This adds a line to `.gitlab-ci.yml` that runs a JSON linter against `roles.json`, the Fusillade roles in this repo, before applying them to Fusillade via the `setup_fusillade.py` script.

Closes #2579 