### PR TITLE
[Easy] Private event method should be public

### DIFF
--- a/dss/events/__init__.py
+++ b/dss/events/__init__.py
@@ -25,7 +25,7 @@ def get_bundle_metadata_document(replica: Replica,
                                  key: str,
                                  flashflood_prefix: str=None) -> dict:
     if key.endswith(TOMBSTONE_SUFFIX):
-        return _build_bundle_metadata_document(replica, key)
+        return build_bundle_metadata_document(replica, key)
     else:
         fqid = key.split("/", 1)[1]
         pfx = flashflood_prefix or replica.flashflood_prefix_read
@@ -61,7 +61,7 @@ def record_event_for_bundle(replica: Replica,
     fqid = key.split("/", 1)[1]
     if flashflood_prefixes is None:
         flashflood_prefixes = replica.flashflood_prefix_write
-    metadata_document = _build_bundle_metadata_document(replica, key)
+    metadata_document = build_bundle_metadata_document(replica, key)
     if use_version_for_timestamp:
         _, version = fqid.split(".", 1)
         event_date = datetime_from_timestamp(version)
@@ -73,7 +73,7 @@ def record_event_for_bundle(replica: Replica,
             ff.put(json.dumps(metadata_document).encode("utf-8"), event_id=fqid, date=event_date)
     return metadata_document
 
-def _build_bundle_metadata_document(replica: Replica, key: str) -> dict:
+def build_bundle_metadata_document(replica: Replica, key: str) -> dict:
     """
     This returns a JSON document with bundle manifest and metadata files suitable for JMESPath filters.
     """

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -57,7 +57,7 @@ class TestEventsUtils(unittest.TestCase, DSSAssertMixin):
                 self._test_record_event_for_bundle(replica, prefixes, metadata_document, key)
 
     def _test_record_event_for_bundle(self, replica, prefixes, metadata_document, key):
-        with mock.patch("dss.events._build_bundle_metadata_document", return_value=metadata_document):
+        with mock.patch("dss.events.build_bundle_metadata_document", return_value=metadata_document):
             with mock.patch("dss.events.FlashFlood") as ff:
                 ret = events.record_event_for_bundle(replica, key, prefixes)
                 used_prefixes = prefixes or replica.flashflood_prefix_write
@@ -120,7 +120,7 @@ class TestEvents(unittest.TestCase, DSSAssertMixin):
                    .add_query("version", version))
             with self.subTest("event found", replica=replica.name):
                 res = self.app.get(str(url))
-                md = events._build_bundle_metadata_document(replica, f"bundles/{uuid}.{version}")
+                md = events.build_bundle_metadata_document(replica, f"bundles/{uuid}.{version}")
                 self.assertEqual(md, res.json())
             with self.subTest("event not found returns 404", replica=replica.name):
                 url.set(path=f"/v1/events/{uuid4()}")
@@ -129,7 +129,7 @@ class TestEvents(unittest.TestCase, DSSAssertMixin):
 
     def test_list_events(self):
         for replica in Replica:
-            expected_docs = [events._build_bundle_metadata_document(replica, f"bundles/{uuid}.{version}")
+            expected_docs = [events.build_bundle_metadata_document(replica, f"bundles/{uuid}.{version}")
                              for uuid, version in self.bundles[replica.name]]
 
             from_date = to_date = None


### PR DESCRIPTION
This renames `_build_bundle_metadata_document` to `build_bundle_metadata_document`.