### PR TITLE
Improve jmespath/dss-notify-v2 documentation

### DIFF
--- a/daemons/dss-notify-v2/Readme.md
+++ b/daemons/dss-notify-v2/Readme.md
@@ -66,12 +66,8 @@ owner, and the sort key is the subscription uuid. There is one table per replica
 Subscriptions are accessed via owner for API actions. When notifications are triggered during an object storage
 event, subscriptions are fetched from the backend via `scan`.
 
-If notification delivery fails, a notification record is made in the queue. Delivery will be attempted immediately
-after failure and at time intervals of one minute, ten minutes, one hour, six hours, and 16 hours after the first
-failure. Delivery would then continue for the next 6 days at 24 hour intervals. After day 7, no further
-notification will be delivered and the subscription will be removed from the delivery service. The old subscription
-will remain and the user would need to delete it and create a new subscription in order to receive new
-notifications.
+If notification delivery fails, a notification record is made in the queue. Delivery will be attempted 15 minutes 
+after failure, and then every 6 hours over the course of 7 days.
 
 ### Bundle Metadata Document
 

--- a/daemons/dss-notify-v2/Readme.md
+++ b/daemons/dss-notify-v2/Readme.md
@@ -30,20 +30,20 @@ Bundle creation notifications have the format
 
 ```
 {
-  'dss_api': {dss_api_url},
-  'bundle_url': "{dss_api_url}/v1/bundles/{uuid}?version={version}",
-  'transaction_id': {uuid},
-  'subscription_id': {uuid},
-  'event_type': "CREATE"|"TOMBSTONE"|"DELETE",
-  'event_timestamp': "timestamp"
-  'match': {
-    'bundle_uuid': {uuid},
-    'bundle_version': {version},
+  "dss_api": $DSS_API_URL,
+  "bundle_url": "$DSS_API_URL/v1/bundles/$UUID?version=$VERSION",
+  "transaction_id": $UUID,
+  "subscription_id": $UUID,
+  "event_type": "CREATE"|"TOMBSTONE"|"DELETE",
+  "event_timestamp": "timestamp"
+  "match": {
+    "bundle_uuid": $UUID,
+    "bundle_version": $VERSION,
   }
-  'jmespath_query': {jmespath_query},
-  'attachments': {
-    "attachment_name_1": {value},
-    "attachment_name_1": {value},
+  "jmespath_query": $JMESPATH_QUERY,
+  "attachments": {
+    "attachment_name_1": $ATTACHMENT_VALUE_1,
+    "attachment_name_2": $ATTACHMENT_VALUE_2,
     ...
     "_errors": [...]
   }
@@ -51,7 +51,7 @@ Bundle creation notifications have the format
 ```
 
 The `jmespath_query` and `attachment` fields are subscription dependent and may not be present. Attachment
-usage and format description can be found in the /subscription endpoint of the [DSS OpenAPI specifications](../../dss-api.yml).
+usage and format description can be found in the `/subscriptions` endpoint of the [DSS OpenAPI specifications](../../dss-api.yml).
 
 The `event_timestamp` field is the event creation date in the `DSS_VERSION` format.
 
@@ -60,36 +60,52 @@ The `event_timestamp` field is the event creation date in the `DSS_VERSION` form
 Event subscriptions are managed via the `/subscriptions` API endpoint, described in detail by the
 [DSS OpenAPI specification](../../dss-api.yml).
 
-The subscription backend is AWS DynamoDB, used as a key-value store. The hash key is the email
-of the subscription owner, and the sort key is the subscription uuid. There is one table per replica.
+The subscription backend is AWS DynamoDB, used as a key-value store. The hash key is the email of the subscription
+owner, and the sort key is the subscription uuid. There is one table per replica.
 
-Subscriptions are accessed via owner for API actions. When notifications are triggered during an object storage event,
-subscriptions are fetched from the backend via `scan`.
+Subscriptions are accessed via owner for API actions. When notifications are triggered during an object storage
+event, subscriptions are fetched from the backend via `scan`.
 
-If notification delivery fails, a notification record is made in the queue.Delivery will be attempted immediately
-after failure and at time intervals of one minute, ten minutes, one hour, six hours, and 16 hours
-after the first failure. Delivery would then continue for the next 6 days at 24 hour intervals. After day 7, no further notification will be delivered and the subscription will be
-removed from the delivery service. The old subscription will remain and the user would need to delete it and create a new subscription in order to receive new notifications.
+If notification delivery fails, a notification record is made in the queue. Delivery will be attempted immediately
+after failure and at time intervals of one minute, ten minutes, one hour, six hours, and 16 hours after the first
+failure. Delivery would then continue for the next 6 days at 24 hour intervals. After day 7, no further
+notification will be delivered and the subscription will be removed from the delivery service. The old subscription
+will remain and the user would need to delete it and create a new subscription in order to receive new
+notifications.
 
 ### Bundle Metadata Document
 
-The bundle metadata document is constructed from json files present in the bundle manifest, and
-includes the bundle manifest describe in the [DSS OpenAPI specifications](../../dss-api.yml). The structure
-accommodates the possibility of multiple files sharing a name.
+The bundle metadata document is constructed from JSON files present in the bundle manifest, and includes the bundle
+manifest described in the [DSS OpenAPI specifications](../../dss-api.yml). The structure accommodates the
+possibility of multiple files sharing a name.
 
-The bundle metadata document format for a new bundle or version is is
+The bundle metadata document format for a new bundle or version is
 
 ```
 {
-  'event_type': "CREATE",
-  'manifest': {bundle_manifest}
-  'files': {
-    {file_name_1}: [
-      {json_contents},
+  "event_type": "CREATE",
+  "manifest": {
+    "version": ...,
+    "files": [
+      "name": "cell_suspension.json",
+      "uuid": "48b7bdf2-410a-4d56-969c-e42e91d1f1fe",
+      "version": "2019-02-12T224603.042173Z",
+      "content-type": "application/json",
+      "size": 22,
+      "indexed": True,
+      "crc32c": "e978e85d",
+      "s3-etag": "89f6f8bec37ec1fc4560f3f99d47721d",
+      "sha1": "58f03f7c6c0887baa54da85db5c820cfbe25d367",
+      "sha256": "9b4c0dde8683f924975d0867903dc7a967f46bee5c0a025c451b9ba73e43f120"
+    ],
+  },
+  "files": {
+    $file_name_A: [
+      $json_contents,
       ...
     ],
-    {file_name_1}: [
-      {json_contents},
+    $file_name_B: [
+      $json_contents,
       ...
     ],
     ...
@@ -97,15 +113,20 @@ The bundle metadata document format for a new bundle or version is is
 }
 ```
 
+(Note: when the bundle metadata document is being assembled, file names are passed through a function
+[`_dot_to_underscore_and_strip_numeric_suffix()`](https://github.com/HumanCellAtlas/data-store/blob/573e7ac028b119fcdb25dda488ffbb6d0e33ba0e/dss/events/__init__.py#L118-L129)
+that transforms the filename by replacing dots `.` with underscores `_` and by stripping any numerical suffix
+(e.g., the filename `library_preparation_protocol_0.json` becomes `library_preparation_protocol_json`).
+
 For a tombstone it is
 
 ```
 {
-  'event_type': "TOMBSTONE",
-  'admin_deleted': "true",
-  'email': {admin_email},
-  'reason': "the reason",
-  'version': "the version",
+  "event_type": "TOMBSTONE",
+  "admin_deleted": "true",
+  "email": $admin_email,
+  "reason": "the reason",
+  "version": "the version",
 }
 ```
 
@@ -113,9 +134,9 @@ For a deleted bundle it is
 
 ```
 {
-  'event_type': "DELETE",
-  'uuid': {uuid}
-  'version': {version},
+  "event_type": "DELETE",
+  "uuid": $uuid
+  "version": $version,
 }
 ```
 
@@ -144,11 +165,11 @@ To receive notifications for everything EXCEPT tombstones, use
 jmespath_query = "event_type==`CREATE`"
 ```
 
-For the bundle metadata document
+As another example, for the following bundle metadata document
 
 ```
 {
-  'manifest': [
+  "manifest": [
     {
       "name": "cell_suspension.json",
       "uuid": "48b7bdf2-410a-4d56-969c-e42e91d1f1fe",
@@ -162,15 +183,15 @@ For the bundle metadata document
       "sha256": "9b4c0dde8683f924975d0867903dc7a967f46bee5c0a025c451b9ba73e43f120"
     }
   ],
-  'files': {
-    'cell_suspension': [
+  "files": {
+    "cell_suspension_json": [
       {
         "biomaterial_core": {
           "biomaterial_id": "Q4_DEMO-cellsus_SAMN02797092",
           "ncbi_taxon_id": [
             9606
           ]
-        },
+        }
       },
       {
         "biomaterial_core": {
@@ -181,12 +202,13 @@ For the bundle metadata document
           ]
         },
       },
+      ...
     ]
   }
 }
 ```
 
-These filters will receive a notifications
+The following filters would receive notifications:
 
 ```
 jmespath_query = "manifest[?name==`cell_suspension.json`].sha"
@@ -195,9 +217,9 @@ jmespath_query = "files.cell_suspension[].biomaterial_core.ncbi_taxon_id[] | con
 jmespath_query = "files.cell_suspension[].biomaterial_core.ncbi_taxon_id[] | contains(@, `9609`)"
 ```
 
-These filters will NOT receive a notification
+and the following filters would NOT receive notifications:
 
 ```
-jmespath_query = "manifest[?name==`dissociation_protocol_0.json.json`]"
+jmespath_query = "manifest[?name==`dissociation_protocol_0.json`]"
 jmespath_query = "files.cell_suspension[].biomaterial_core.ncbi_taxon_id[] | contains(@, `9608`)"
 ```


### PR DESCRIPTION
Taking a shot at #2563 to improve JMESpath documentation, improving changes suggested in #2510.

This addresses the following issues:

- documents what the bundle manifest looks like (individual fields)
- replaces `file_name_1` with `file_name_A` and mentions the transformation of `_dot_to_underscore_and_strip_numerical_suffix`
- replaces `{variable_name}` interpolation with `$variable_name` interpolation (good way of denoting variable JSON contents independent of JSON syntax, and also useful if using something like `envsubst`)

### Test plan

None required, this only changes documentation

### Deployment instructions & migrations

N/A

### Release notes

Improving JMESpath documentation for v2 notifications