### PR TITLE
Confirm flashflood writes during journaling/update

### DIFF
--- a/dss/api/events.py
+++ b/dss/api/events.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 import requests
 from flask import request, make_response, jsonify
-from flashflood import FlashFlood, FlashFloodEventNotFound
 
 from dss.util.aws import resources
 from dss import Config, Replica
@@ -26,7 +25,7 @@ def list_events(replica: str, from_date: str=None, to_date: str=None, per_page: 
     tdate = datetime_from_timestamp(to_date) if to_date else datetime.max
     if fdate > tdate:
         raise DSSException(400, "bad_request", "to_date must be greater than from_date")
-    ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), Replica[replica].flashflood_prefix_read)
+    ff = Config.get_flashflood_handle(Replica[replica].flashflood_prefix_read)
     event_streams = list()
     for i, event_stream in enumerate(ff.list_event_streams(fdate, tdate)):
         if datetime_from_timestamp(event_stream['from_date']) < tdate:

--- a/dss/events/__init__.py
+++ b/dss/events/__init__.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 
+import flashflood
 from flashflood import FlashFlood, FlashFloodEventNotFound, JournalID
 
 from dss.util.aws import resources
@@ -152,6 +153,7 @@ def journal_flashflood(prefix: str,
     """
     Compile new events into journals.
     """
+    flashflood.config.object_exists_waiter_config['Delay'] = 1
     ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), prefix)
     journals = list()
     for journal_id in list_new_flashflood_journals(prefix, start_from_journal_id):
@@ -166,6 +168,7 @@ def list_new_flashflood_journals(prefix: str, start_from_journal_id: JournalID=N
     List new journals.
     Listing can optionally begin with `start_from_journal_id`
     """
+    flashflood.config.object_exists_waiter_config['Delay'] = 1
     ff = FlashFlood(resources.s3, Config.get_flashflood_bucket(), prefix)
     # TODO: Add interface method to flash-flood to avoid private attribute access
     journals = ff._Journal.list(list_from=start_from_journal_id)


### PR DESCRIPTION
This configures flashflood to wait for s3 consistency during event journaling and updates, avoiding the possibility that the previous batch of journals/updates are unavailable for read before the next batch is
processed.