### PR TITLE
Include `bundle_info` in bundle metadata document

### DIFF
--- a/daemons/dss-notify-v2/Readme.md
+++ b/daemons/dss-notify-v2/Readme.md
@@ -80,6 +80,10 @@ The bundle metadata document format for a new bundle or version is
 ```
 {
   "event_type": "CREATE",
+  "bundle_info": {
+    "uuid": "48b7bdf2-410a-4d56-969c-e42e91d1f1fe",
+    "version": "2019-02-12T224603.042173Z"
+  },
   "manifest": {
     "version": ...,
     "files": [

--- a/daemons/dss-notify-v2/Readme.md
+++ b/daemons/dss-notify-v2/Readme.md
@@ -123,6 +123,10 @@ For a tombstone it is
 ```
 {
   "event_type": "TOMBSTONE",
+  "bundle_info": {
+    "uuid": $uuid,
+    "version": $version,
+  },
   "admin_deleted": "true",
   "email": $admin_email,
   "reason": "the reason",
@@ -135,8 +139,10 @@ For a deleted bundle it is
 ```
 {
   "event_type": "DELETE",
-  "uuid": $uuid
-  "version": $version,
+  "bundle_info": {
+    "uuid": $uuid,
+    "version": $version,
+  },
 }
 ```
 

--- a/dss/events/__init__.py
+++ b/dss/events/__init__.py
@@ -46,13 +46,8 @@ def get_deleted_bundle_metadata_document(replica: Replica, key: str) -> dict:
     """
     Build the bundle metadata document assocated with a non-existent key.
     """
-    _, fqid = key.split("/")
-    uuid, version = fqid.split(".", 1)
-    return {
-        'event_type': "DELETE",
-        "uuid": uuid,
-        "version": version,
-    }
+    fqid = BundleFQID.from_key(key)
+    return dict(event_type="DELETE", bundle_info=dict(uuid=fqid.uuid, version=fqid.version))
 
 @lru_cache(maxsize=2)
 def record_event_for_bundle(replica: Replica,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -74,6 +74,14 @@ class TestEventsUtils(unittest.TestCase, DSSAssertMixin):
                 self.assertEqual(md['bundle_info']['uuid'], uuid)
                 self.assertEqual(md['bundle_info']['version'], version)
 
+    def test_get_deleted_bundle_metadata_document(self):
+        uuid = "f3cafb77-84ea-4050-98c9-2e3935f90f16"
+        version = "2019-11-15T183956.169809Z"
+        md = events.get_deleted_bundle_metadata_document("", f"bundles/{uuid}.{version}")
+        self.assertEqual(md['event_type'], "DELETE")
+        self.assertEqual(md['bundle_info']['uuid'], uuid)
+        self.assertEqual(md['bundle_info']['version'], version)
+
     def test_record_event_for_bundle(self):
         metadata_document = dict(foo=f"{uuid4()}")
         key = f"bundles/{uuid4()}.{datetime_to_version_format(datetime.utcnow())}"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -22,6 +22,7 @@ pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noq
 sys.path.insert(0, pkg_root)  # noqa
 
 import dss
+from dss.storage.identifiers import TOMBSTONE_SUFFIX
 from dss.util.aws import resources
 from dss import events
 from dss.config import BucketConfig, override_bucket_config, Config, Replica
@@ -48,6 +49,31 @@ def tearDownModule():
 
 
 class TestEventsUtils(unittest.TestCase, DSSAssertMixin):
+    def test_build_bundle_metadata_document(self):
+        dss.Config.set_config(dss.BucketConfig.TEST)
+        app = ThreadedLocalServer()
+        app.start()
+        self.addCleanup(app.shutdown)
+        for replica in Replica:
+            uuid, version = _upload_bundle(app, replica)
+            key = f"bundles/{uuid}.{version}"
+            with self.subTest("Build normal bundle metadata document", replica=replica):
+                md = events.build_bundle_metadata_document(replica, key)
+                self.assertIn("manifest", md)
+                self.assertIn("files", md)
+                self.assertIn("version", md['manifest'])
+                self.assertIn("files", md['manifest'])
+                self.assertEqual(md['event_type'], "CREATE")
+                self.assertEqual(md['bundle_info']['uuid'], uuid)
+                self.assertEqual(md['bundle_info']['version'], version)
+            _tombstone_bundle(app, replica, uuid, version)
+            with self.subTest("Build tombstoned bundle metadata document", replica=replica):
+                md = events.build_bundle_metadata_document(replica, f"{key}.{TOMBSTONE_SUFFIX}")
+                self.assertNotIn("manifest", md)
+                self.assertEqual(md['event_type'], "TOMBSTONE")
+                self.assertEqual(md['bundle_info']['uuid'], uuid)
+                self.assertEqual(md['bundle_info']['version'], version)
+
     def test_record_event_for_bundle(self):
         metadata_document = dict(foo=f"{uuid4()}")
         key = f"bundles/{uuid4()}.{datetime_to_version_format(datetime.utcnow())}"
@@ -258,6 +284,14 @@ def _upload_bundle(app, replica, uuid=None):
     resp = app.get(f"/v1/bundles/{bundle_uuid}?replica={replica.name}&version={bundle_version}")
     return bundle_uuid, bundle_version
 
+def _tombstone_bundle(app, replica, uuid, version=None):
+    url = f"/v1/bundles/{uuid}?replica={replica.name}"
+    if version is not None:
+        url += f"&version={version}"
+    resp = app.delete(url,
+                      headers={** get_auth_header(), ** {'Content-Type': "application/json"}},
+                      json=dict(reason="testing"))
+    resp.raise_for_status()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds `bundle_info` to the bundle metadata document, making it possible to filter JMESPath subscriptions on both bundle uuid and version.
```
{
  "event_type: ...
  "bundle_info" = {
    'uuid': ...,
    'version': ...
  },
  ...
}
```

closes #2513 