### PR TITLE
Refactor notify v2 event handler

### DIFF
--- a/daemons/dss-notify-v2/app.py
+++ b/daemons/dss-notify-v2/app.py
@@ -134,7 +134,7 @@ def _deliver_notifications(replica: Replica, metadata_document: dict, key: str):
                                 replica=replica.name,
                                 key=key,
                                 event_type=metadata_document['event_type']), indent=4))
-    with ThreadPoolExecutor(max_workers=6) as e:
+    with ThreadPoolExecutor(max_workers=20) as e:
         e.map(_func, get_subscriptions_for_replica(replica))
 
 class DSSFailedNotificationDelivery(Exception):

--- a/tests/test_notify_v2.py
+++ b/tests/test_notify_v2.py
@@ -21,6 +21,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from dss.util import UrlBuilder
 from dss.events.handlers import notify_v2
+from dss.storage.identifiers import TOMBSTONE_SUFFIX
 from tests.infra import DSSAssertMixin, DSSUploadMixin, get_env, testmode
 from dss.config import Replica
 from tests.infra.server import ThreadedLocalServer, SilentHandler
@@ -125,6 +126,51 @@ class TestNotifyV2(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
         self.assertEquals(notification['subscription_id'], subscription['uuid'])
         self.assertEquals(notification['match']['bundle_uuid'], bundle_uuid)
         self.assertEquals(notification['match']['bundle_version'], f"{bundle_version}")
+
+    def test_handle_bucket_event(self):
+        for replica in Replica:
+            for is_delete_event in [False, True]:
+                for key_exists in [False, True]:
+                    for key_is_tombstone in [False, True]:
+                        kwargs = dict(replica=replica,
+                                      is_delete_event=is_delete_event,
+                                      key_exists=key_exists,
+                                      key_is_tombstone=key_is_tombstone)
+                        with self.subTest(** kwargs):
+                            self._test_handle_bucket_event(** kwargs)
+
+    @mock.patch("daemons.dss-notify-v2.app.get_deleted_bundle_metadata_document")
+    @mock.patch("daemons.dss-notify-v2.app.exists")
+    @mock.patch("daemons.dss-notify-v2.app.get_tombstoned_bundles")
+    @mock.patch("daemons.dss-notify-v2.app.delete_event_for_bundle")
+    @mock.patch("daemons.dss-notify-v2.app.build_bundle_metadata_document")
+    @mock.patch("daemons.dss-notify-v2.app.record_event_for_bundle")
+    @mock.patch("daemons.dss-notify-v2.app._deliver_notifications")
+    def _test_handle_bucket_event(self,
+                                  *mocked_methods,
+                                  replica: Replica,
+                                  is_delete_event: bool,
+                                  key_exists: bool,
+                                  key_is_tombstone: bool):
+        mocks = {m._mock_name: m for m in mocked_methods}
+        mocks['exists'].return_value = key_exists
+        mocks['get_deleted_bundle_metadata_document'].return_value = f"{uuid4()}"
+        mocks['build_bundle_metadata_document'].return_value = f"{uuid4()}"
+        mocks['record_event_for_bundle'].return_value = f"{uuid4()}"
+        key = f"{uuid4()}.{TOMBSTONE_SUFFIX}" if key_is_tombstone else f"{uuid4()}"
+        daemon_app._handle_bucket_event(replica, key, is_delete_event)  # type: ignore
+        if is_delete_event:
+            metadata_doc = mocks['get_deleted_bundle_metadata_document'].return_value
+            mocks['_deliver_notifications'].assert_called_with(replica, metadata_doc, key)
+        else:
+            if key_exists:
+                if key_is_tombstone:
+                    metadata_doc = mocks['build_bundle_metadata_document'].return_value
+                else:
+                    metadata_doc = mocks['record_event_for_bundle'].return_value
+                mocks['_deliver_notifications'].assert_called_with(replica, metadata_doc, key)
+            else:
+                mocks['_deliver_notifications'].assert_not_called()
 
     @testmode.standalone
     def test_notify_or_queue(self):


### PR DESCRIPTION
This:
- verifies the existence of normal bundle keys and tombstoned bundle keys before attempting to build or retrieve the bundle metadata document.
- tests the refactored handler method