### PR TITLE
DSS Operations: Bundle Reference List

### DIFF
--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -225,7 +225,7 @@ class build_reference_list(StorageOperationHandler):
             storage_object_references.append(f"files/{files['uuid']}.{files['version']}")
             storage_object_references.append(compose_blob_key(files))
         pprint.pprint(storage_object_references)
-        return storage_object_references # returned for testing
+        return storage_object_references  # returned for testing
 
 
 # TODO: Move to cloud_blobstore

--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -6,7 +6,6 @@ import typing
 import logging
 import argparse
 import math
-import pprint
 from uuid import uuid4
 from traceback import format_exc
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -6,6 +6,7 @@ import typing
 import logging
 import argparse
 import math
+import pprint
 from uuid import uuid4
 from traceback import format_exc
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -209,8 +210,11 @@ class verify_referential_integrity(StorageOperationHandler):
 @storage.action("build-reference-list",
                 mutually_exclusive=["--keys"])
 class build_reference_list(StorageOperationHandler):
-    """This uses bundle data to build out a reference list of objects that are relevant to the bundle"""
+    """This uses bundle key to build out a reference list of objects that are relevant to the bundle"""
     def process_key(self, key):
+        if not key.startswith(BUNDLE_PREFIX):
+            logger.error(f"only bundle keys supported, unable to process: {key}")
+            return
         storage_object_references = list()
         storage_object_references.append(key)
         try:
@@ -220,7 +224,8 @@ class build_reference_list(StorageOperationHandler):
         for files in bundle_metadata['files']:
             storage_object_references.append(f"files/{files['uuid']}.{files['version']}")
             storage_object_references.append(compose_blob_key(files))
-        return storage_object_references
+        pprint.pprint(storage_object_references)
+        return storage_object_references # returned for testing
 
 
 # TODO: Move to cloud_blobstore

--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -218,7 +218,7 @@ class build_reference_list(StorageOperationHandler):
         except BlobNotFoundError as e:
             logger.error(f"bundle {key} not found {e}")
         for files in bundle_metadata['files']:
-            storage_object_references.append(f"files/{files['name']}.{files['uuid']}")
+            storage_object_references.append(f"files/{files['uuid']}.{files['version']}")
             storage_object_references.append(compose_blob_key(files))
         return storage_object_references
 

--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -214,8 +214,7 @@ class build_reference_list(StorageOperationHandler):
         if not key.startswith(BUNDLE_PREFIX):
             logger.error(f"only bundle keys supported, unable to process: {key}")
             return
-        storage_object_references = list()
-        storage_object_references.append(key)
+        storage_object_references = [key]
         try:
             bundle_metadata = json.loads(self.handle.get(self.replica.bucket, key))
         except BlobNotFoundError as e:

--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -224,7 +224,8 @@ class build_reference_list(StorageOperationHandler):
         for files in bundle_metadata['files']:
             storage_object_references.append(f"files/{files['uuid']}.{files['version']}")
             storage_object_references.append(compose_blob_key(files))
-        pprint.pprint(storage_object_references)
+        for key in storage_object_references:
+            print(key)
         return storage_object_references  # returned for testing
 
 

--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -206,6 +206,24 @@ class verify_referential_integrity(StorageOperationHandler):
             self.log_warning("EntityMissingDependencies", dict(key=key, replica=self.replica.name))
 
 
+@storage.action("build-reference-list",
+                mutually_exclusive=["--keys"])
+class build_reference_list(StorageOperationHandler):
+    """This uses bundle data to build out a reference list of objects that are relevant to the bundle"""
+    def process_key(self, key):
+        storage_object_references = list()
+        storage_object_references.append(key)
+        bucket = self.replica.bucket
+        try:
+            bundle_metadata = json.loads(self.handle.get(bucket,key))
+        except BlobNotFoundError as e:
+            logger.error(f"bundle {key} not found {e}")
+        for files in bundle_metadata['files']:
+            storage_object_references.append(f"files/{files['name']}.{files['uuid']}")
+            storage_object_references.append(compose_blob_key(files))
+        print(storage_object_references)
+        return storage_object_references
+
 # TODO: Move to cloud_blobstore
 def update_aws_content_type(s3_client, bucket, key, content_type):
     blob = resources.s3.Bucket(bucket).Object(key)

--- a/dss/operations/storage.py
+++ b/dss/operations/storage.py
@@ -213,16 +213,15 @@ class build_reference_list(StorageOperationHandler):
     def process_key(self, key):
         storage_object_references = list()
         storage_object_references.append(key)
-        bucket = self.replica.bucket
         try:
-            bundle_metadata = json.loads(self.handle.get(bucket,key))
+            bundle_metadata = json.loads(self.handle.get(self.replica.bucket, key))
         except BlobNotFoundError as e:
             logger.error(f"bundle {key} not found {e}")
         for files in bundle_metadata['files']:
             storage_object_references.append(f"files/{files['name']}.{files['uuid']}")
             storage_object_references.append(compose_blob_key(files))
-        print(storage_object_references)
         return storage_object_references
+
 
 # TODO: Move to cloud_blobstore
 def update_aws_content_type(s3_client, bucket, key, content_type):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -158,7 +158,7 @@ class TestOperations(unittest.TestCase):
 
     def test_bundle_reference_list(self):
         class MockHandler:
-            mock_file_data = {"uuid" : "987",
+            mock_file_data = {"uuid": "987",
                               "version": "987",
                               "sha256": "256k",
                               "sha1": "1thing",
@@ -168,25 +168,24 @@ class TestOperations(unittest.TestCase):
             mock_bundle_key = 'bundles/123.456'
             handle = mock.Mock()
 
-            def get(self,bucket,key):
+            def get(self, bucket, key):
                 return json.dumps(self.mock_bundle_metadata)
 
         for replica in Replica:
             with self.subTest("Test Bundle Reference"):
                 with override_bucket_config(BucketConfig.TEST):
                     with mock.patch("dss.operations.storage.Config") as mock_handle:
-                        mock_handle.get_blobstore_handle = mock.MagicMock(return_value = MockHandler())
+                        mock_handle.get_blobstore_handle = mock.MagicMock(return_value=MockHandler())
                         args = argparse.Namespace(keys=[MockHandler.mock_bundle_key],
                                                   replica=replica.name,
                                                   entity_type='bundles',
                                                   job_id="")
-                        res = storage.build_reference_list([],args).process_key(MockHandler.mock_bundle_key)
-                        self.assertIn(MockHandler.mock_bundle_key,res)
+                        res = storage.build_reference_list([], args).process_key(MockHandler.mock_bundle_key)
+                        self.assertIn(MockHandler.mock_bundle_key, res)
                         self.assertIn(f'files/{MockHandler.mock_file_data["uuid"]}.'
                                       f'{MockHandler.mock_file_data["version"]}',
                                       res)
-                        self.assertIn(compose_blob_key(MockHandler.mock_file_data),res)
-
+                        self.assertIn(compose_blob_key(MockHandler.mock_file_data), res)
 
     def test_update_content_type(self):
         TestCase = namedtuple("TestCase", "replica upload size update initial_content_type expected_content_type")

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -156,6 +156,15 @@ class TestOperations(unittest.TestCase):
                         storage.repair_file_blob_metadata([], args).process_key(key)
                         self.assertEqual(log_warning.call_args[0][0], "JSONDecodeError")
 
+    def test_bundle_reference_list(self):
+        mock_file_data = {"uuid" : uuid.uuid4(),
+                          "version": datetime_to_version_format(datetime.datetime()),"sha256": "",
+                          "sha1": "",
+                          "s3-etag": "",
+                          "crc32c": ""}
+        mock_bundle_metadata = {"files": [mock_file_data]}
+        
+
     def test_update_content_type(self):
         TestCase = namedtuple("TestCase", "replica upload size update initial_content_type expected_content_type")
         with override_bucket_config(BucketConfig.TEST):


### PR DESCRIPTION
Allows reference lists to be built for bundle key

Enables us to build object references for tombstoned bundles

Connected to #2528 