### PR TITLE
[Fusillade Check 1/3] Add list-users, list-groups, list-roles endpoints to dss-ops iam script

### DIFF
--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -356,6 +356,10 @@ def extract_fus_policies(action: str, fus_client, do_headers: bool = True):
                         d = json.loads(iam_policy)
                     except TypeError:
                         d = iam_policy
+                    except json.decoder.JSONDecodeError:
+                        msg = f"Warning: malformed policy document for user {user} and {asset_type} {asset}: \n{iam_policy}"
+                        logger.warning(msg)
+                        d = {}  # Malformed JSON
                     if "Id" not in d:
                         d["Id"] = ANONYMOUS_POLICY_NAME
                     managed_policies.append(d)
@@ -550,8 +554,6 @@ def list_fus_user_policies(fus_client, do_headers: bool = True):
 
     result = []
     
-    import pdb; pdb.set_trace()
-
     # NOTE: This makes unnecessary duplicate API calls.
     # It would be better to get list of groups/roles then mark ones attached to users.
     for user in users:

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -682,7 +682,7 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
             contents = [IAMSEPARATOR.join(c) for c in contents]
 
     else:
-        raise RuntimeError(f"Error: IAM functionality not implemented for {args.cloud_provider}")
+        raise NotImplementedError(f"Error: IAM functionality not implemented for {args.cloud_provider}")
 
     # Print list to output
     if args.output:
@@ -729,6 +729,9 @@ def list_roles(argv: typing.List[str], args: argparse.Namespace):
         fus_stage = DSS2FUS[dss_stage]
         client = FusilladeClient(fus_stage)
         contents = list_fus_roles(client)
+
+    else:
+        raise NotImplementedError(f"Error: IAM functionality not implemented for {args.cloud_provider}")
 
     # Print list to output
     if args.output:

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -660,7 +660,7 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
             contents = [IAMSEPARATOR.join(c) for c in contents]
 
     elif args.cloud_provider == "gcp":
-        pass
+        raise NotImplementedError("Error: IAM functionality for GCP not implemented")
     elif args.cloud_provider == "fusillade":
 
         stage = DSS2FUS[os.environ["DSS_DEPLOYMENT_STAGE"]]
@@ -722,7 +722,7 @@ def list_roles(argv: typing.List[str], args: argparse.Namespace):
     if args.cloud_provider == "aws":
         contents = list_aws_roles(iam_client)
     elif args.cloud_provider == "gcp":
-        pass
+        raise NotImplementedError("Error: IAM functionality for GCP not implemented")
     elif args.cloud_provider == "fusillade":
 
         dss_stage = os.environ["DSS_DEPLOYMENT_STAGE"]

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -188,24 +188,22 @@ def _get_aws_api_labels_dict() -> typing.Dict[str, typing.Dict[str, str]]:
 
 def _make_aws_api_labels_dict_entry(*args) -> typing.Dict[str, str]:
     """
-    Convenience function to unpack 4 values into a dictionary of labels, useful for processing
-    API results.
+    Convenience function to unpack 4 values into a dictionary of labels, useful for processing API results.
+
+    Example:
+        >>> _make_aws_api_labels_dict_entry("Users", "UserName", "UserDetailList", "UserPolicyList")
+        {
+            "extracted_list_label": "Users",
+            "name_label": "UserName",
+            "detail_list_label": "UserDetailList",
+            "policy_list_label": "UserPolicyList"
+        }
 
     :params arg[0]: label of asset type
     :params arg[1]: label of asset name
     :params arg[2]: label of asset details
     :params arg[3]: label of asset policy details
     :returns: dictionary of organized labels
-
-    Example:
-
-        >>> _make_aws_api_labels_dict_entry("User", "UserName", "UserDetailList", "UserPolicyList")
-        {
-            "extracted_list_label": "User",
-            "name_label": "UserName",
-            "detail_list_label": "UserDetailList",
-            "policy_list_label": "UserPolicyList"
-        }
     """
     assert len(args) == 4, "Error: need 4 arguments!"
     return dict(
@@ -266,7 +264,6 @@ def list_aws_policies(client, managed: bool):
 def dump_aws_policies(client, managed: bool):
     """Return a list of dictionaries containing AWS policy documents"""
     return extract_aws_policies("dump", client, managed)
-
 
 
 def list_aws_assets(asset_type, client):
@@ -357,7 +354,8 @@ def extract_fus_policies(action: str, fus_client, do_headers: bool = True):
                     except TypeError:
                         d = iam_policy
                     except json.decoder.JSONDecodeError:
-                        msg = f"Warning: malformed policy document for user {user} and {asset_type} {asset}: \n{iam_policy}"
+                        msg = f"Warning: malformed policy document for user {user} and {asset_type} {asset}:\n"
+                        msg += f"{iam_policy}"
                         logger.warning(msg)
                         d = {}  # Malformed JSON
                     if "Id" not in d:
@@ -398,11 +396,11 @@ def dump_fus_policies(fus_client, do_headers):
 
 def list_fus_assets(asset_type, fus_client):
     """Return a list of names of Fusillade assets"""
-    if asset_type=="users":
+    if asset_type == "users":
         return list_fus_users(fus_client)
-    elif asset_type=="groups":
+    elif asset_type == "groups":
         return list_fus_groups(fus_client)
-    elif asset_type=="roles":
+    elif asset_type == "roles":
         return list_fus_roles(fus_client)
 
 
@@ -553,7 +551,7 @@ def list_fus_user_policies(fus_client, do_headers: bool = True):
     users = list(fus_client.paginate("/v1/users", "users"))
 
     result = []
-    
+
     # NOTE: This makes unnecessary duplicate API calls.
     # It would be better to get list of groups/roles then mark ones attached to users.
     for user in users:
@@ -763,13 +761,11 @@ list_asset_args = {
     )
 }
 
-def list_asset_action(asset_type, argv: typing.List[str], args: argparse.Namespace): 
+def list_asset_action(asset_type, argv: typing.List[str], args: argparse.Namespace):
     """Print a simple, flat list of IAM assets available"""
     if args.output:
         if os.path.exists(args.output) and not args.force:
             raise RuntimeError(f"Error: cannot overwrite {args.output} without --force flag")
-
-    do_headers = not args.exclude_headers
 
     if args.cloud_provider == "aws":
         contents = list_aws_assets(asset_type, iam_client)
@@ -804,7 +800,7 @@ def list_users(argv: typing.List[str], args: argparse.Namespace):
 @iam.action("list-groups", arguments=list_asset_args)
 def list_groups(argv: typing.List[str], args: argparse.Namespace):
     """Print a simple, flat list of IAM groups available"""
-    list_asset_action("groups", argv=argv, args=args) 
+    list_asset_action("groups", argv=argv, args=args)
 
 @iam.action("list-roles", arguments=list_asset_args)
 def list_roles(argv: typing.List[str], args: argparse.Namespace):

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -166,6 +166,57 @@ def get_fus_role_attached_policies(fus_client, action, role):
 
 
 # ---
+# AWS utility functions/classes
+# ---
+def _get_aws_api_list_endpoints_dict() -> typing.Dict[str, str]:
+    """Store AWS API endpoints to list each asset type"""
+    return {
+        "users": "list_users",
+        "groups": "list_groups",
+        "roles": "list_roles"
+    }
+
+
+def _get_aws_api_labels_dict() -> typing.Dict[str, typing.Dict[str, str]]:
+    """Store the labels used to unwrap JSON results from the AWS API"""
+    return {
+        "users": _make_aws_api_labels_dict_entry("Users", "UserName", "UserDetailList", "UserPolicyList"),
+        "groups": _make_aws_api_labels_dict_entry("Groups", "GroupName", "GroupDetailList", "GroupPolicyList"),
+        "roles": _make_aws_api_labels_dict_entry("Roles", "RoleName", "RoleDetailList", "RolePolicyList"),
+    }
+
+
+def _make_aws_api_labels_dict_entry(*args) -> typing.Dict[str, str]:
+    """
+    Convenience function to unpack 4 values into a dictionary of labels, useful for processing
+    API results.
+
+    :params arg[0]: label of asset type
+    :params arg[1]: label of asset name
+    :params arg[2]: label of asset details
+    :params arg[3]: label of asset policy details
+    :returns: dictionary of organized labels
+
+    Example:
+
+        >>> _make_aws_api_labels_dict_entry("User", "UserName", "UserDetailList", "UserPolicyList")
+        {
+            "extracted_list_label": "User",
+            "name_label": "UserName",
+            "detail_list_label": "UserDetailList",
+            "policy_list_label": "UserPolicyList"
+        }
+    """
+    assert len(args) == 4, "Error: need 4 arguments!"
+    return dict(
+        extracted_list_label=args[0],
+        name_label=args[1],
+        detail_list_label=args[2],
+        policy_list_label=args[3],
+    )
+
+
+# ---
 # Dump/list AWS policies
 # ---
 def extract_aws_policies(action: str, client, managed: bool):
@@ -217,24 +268,28 @@ def dump_aws_policies(client, managed: bool):
     return extract_aws_policies("dump", client, managed)
 
 
-def list_aws_roles(client):
-    """
-    Call the AWS IAM API to retrieve a list of roles.
 
-    :param client: the boto client to use
-    """
+def list_aws_assets(asset_type, client):
+    """Use the AWS API to compile a flat list of asset names"""
     master_list = []  # holds main results
 
-    paginator = client.get_paginator("list_roles")
+    # Prepare labels for extracting asset info
+    aws_labels = _get_aws_api_labels_dict()
+    if asset_type not in aws_labels:
+        raise RuntimeError(f"Error: unrecognized AWS asset type: {asset_type}")
+    asset_labels = aws_labels[asset_type]
+
+    # Map asset types to AWS API endpoints
+    endpoints = _get_aws_api_list_endpoints_dict()
+
+    paginator = client.get_paginator(endpoints[asset_type])
     for page in paginator.paginate():
-        for policy in page["Roles"]:
-            role_name = policy["RoleName"]
-            master_list.append(policy_name)
+        for policy in page[asset_labels['extracted_list_label']]:
+            role_name = policy[asset_labels['name_label']]
+            master_list.append(role_name)
 
     # Sort names, remove duplicates
     master_list = sorted(list(set(master_list)))
-
-    # also need to get all inline policies
     return master_list
 
 
@@ -337,6 +392,30 @@ def dump_fus_policies(fus_client, do_headers):
     return extract_fus_policies("dump", fus_client, do_headers)
 
 
+def list_fus_assets(asset_type, fus_client):
+    """Return a list of names of Fusillade assets"""
+    if asset_type=="users":
+        return list_fus_users(fus_client)
+    elif asset_type=="groups":
+        return list_fus_groups(fus_client)
+    elif asset_type=="roles":
+        return list_fus_roles(fus_client)
+
+
+def list_fus_users(fus_client):
+    """Return a list of names of Fusillade users"""
+    users = list(fus_client.paginate("/v1/users", "users"))
+    users = sorted(list(set(users)))
+    return users
+
+
+def list_fus_groups(fus_client):
+    """Return a list of names of Fusillade roles"""
+    groups = list(fus_client.paginate("/v1/groups", "groups"))
+    groups = sorted(list(set(groups)))
+    return groups
+
+
 def list_fus_roles(fus_client):
     """Return a list of names of Fusillade roles"""
     roles = list(fus_client.paginate("/v1/roles", "roles"))
@@ -358,41 +437,10 @@ def list_aws_policies_grouped(asset_type, client, managed: bool, do_headers: boo
     """
     extracted_list = []
 
-    # Prepare to extract labels for JSON returned by API
-    def _make_aws_api_labels_dict_entry(*args) -> typing.Dict[str, str]:
-        """
-        Convenience function to unpack 4 values into a dictionary of labels, useful for processing
-        API results.
-
-        :params arg[0]: label of asset type
-        :params arg[1]: label of asset name
-        :params arg[2]: label of asset details
-        :params arg[3]: label of asset policy details
-        :returns: dictionary of organized labels
-        """
-        assert len(args) == 4, "Error: need 4 arguments!"
-        return dict(
-            extracted_list_label=args[0],
-            name_label=args[1],
-            detail_list_label=args[2],
-            policy_list_label=args[3],
-        )
-
-    def _get_aws_api_labels_dict() -> typing.Dict[str, typing.Dict[str, str]]:
-        """Store the labels used to unwrap JSON results from the AWS API"""
-        labels = {
-            "user": _make_aws_api_labels_dict_entry("User", "UserName", "UserDetailList", "UserPolicyList"),
-            "group": _make_aws_api_labels_dict_entry(
-                "Group", "GroupName", "GroupDetailList", "GroupPolicyList"
-            ),
-            "role": _make_aws_api_labels_dict_entry("Role", "RoleName", "RoleDetailList", "RolePolicyList"),
-        }
-        return labels
-
     # Extract labels needed
     labels = _get_aws_api_labels_dict()
     if asset_type not in labels:
-        raise RuntimeError(f"Error: asset type {asset_type} is not valid, try one of: {labels}")
+        raise RuntimeError(f"Error: asset type \"{asset_type}\" is not valid, try one of: {labels.keys()}")
     extracted_list_label, filter_label, name_label, detail_list_label, policy_list_label = (
         labels[asset_type]["extracted_list_label"],
         labels[asset_type]["extracted_list_label"],
@@ -450,17 +498,17 @@ def list_aws_policies_grouped(asset_type, client, managed: bool, do_headers: boo
 
 def list_aws_user_policies(*args, **kwargs):
     """Extract a list of policies that apply to each user"""
-    return list_aws_policies_grouped("user", *args, **kwargs)
+    return list_aws_policies_grouped("users", *args, **kwargs)
 
 
 def list_aws_group_policies(*args, **kwargs):
     """Extract a list of policies that apply to each group"""
-    return list_aws_policies_grouped("group", *args, **kwargs)
+    return list_aws_policies_grouped("groups", *args, **kwargs)
 
 
 def list_aws_role_policies(*args, **kwargs):
     """Extract a list of policies that apply to each resource"""
-    return list_aws_policies_grouped("role", *args, **kwargs)
+    return list_aws_policies_grouped("roles", *args, **kwargs)
 
 
 # ---
@@ -501,6 +549,8 @@ def list_fus_user_policies(fus_client, do_headers: bool = True):
     users = list(fus_client.paginate("/v1/users", "users"))
 
     result = []
+    
+    import pdb; pdb.set_trace()
 
     # NOTE: This makes unnecessary duplicate API calls.
     # It would be better to get list of groups/roles then mark ones attached to users.
@@ -646,42 +696,40 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
     do_headers = not args.exclude_headers
 
     if args.cloud_provider == "aws":
-
         if args.group_by is None:
             contents = list_aws_policies(iam_client, managed)
+        elif args.group_by == "users":
+            contents = list_aws_user_policies(iam_client, managed, do_headers)
+        elif args.group_by == "groups":
+            contents = list_aws_group_policies(iam_client, managed, do_headers)
+        elif args.group_by == "roles":
+            contents = list_aws_role_policies(iam_client, managed, do_headers)
         else:
-            if args.group_by == "users":
-                contents = list_aws_user_policies(iam_client, managed, do_headers)
-            elif args.group_by == "groups":
-                contents = list_aws_group_policies(iam_client, managed, do_headers)
-            elif args.group_by == "roles":
-                contents = list_aws_role_policies(iam_client, managed, do_headers)
-            else:
-                raise RuntimeError(f"Invalid --group-by argument passed: {args.group_by}")
+            raise RuntimeError(f"Invalid --group-by argument passed: {args.group_by}")
 
-            # Join the tuples
+        # Join the tuples
+        if args.group_by is not None:
             contents = [IAMSEPARATOR.join(c) for c in contents]
 
     elif args.cloud_provider == "gcp":
         raise NotImplementedError("Error: IAM functionality for GCP not implemented")
-    elif args.cloud_provider == "fusillade":
 
-        stage = DSS2FUS[os.environ["DSS_DEPLOYMENT_STAGE"]]
-        client = FusilladeClient(stage=stage)
+    elif args.cloud_provider == "fusillade":
+        fus_stage = DSS2FUS[os.environ["DSS_DEPLOYMENT_STAGE"]]
+        client = FusilladeClient(fus_stage)
 
         if args.group_by is None:
             # list policies
             contents = list_fus_policies(client, do_headers)
-        else:
-            # list policies grouped by asset
-            if args.group_by == "users":
-                contents = list_fus_user_policies(client, do_headers)
-            elif args.group_by == "groups":
-                contents = list_fus_group_policies(client, do_headers)
-            elif args.group_by == "roles":
-                contents = list_fus_role_policies(client, do_headers)
+        elif args.group_by == "users":
+            contents = list_fus_user_policies(client, do_headers)
+        elif args.group_by == "groups":
+            contents = list_fus_group_policies(client, do_headers)
+        elif args.group_by == "roles":
+            contents = list_fus_role_policies(client, do_headers)
 
-            # Join the tuples
+        # Join the tuples
+        if args.group_by is not None:
             contents = [IAMSEPARATOR.join(c) for c in contents]
 
     else:
@@ -697,41 +745,41 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
         sys.stdout = stdout_
 
 
-@iam.action(
-    "list-roles",
-    arguments={
-        "cloud_provider": dict(
-            choices=["aws", "gcp", "fusillade"], help="The cloud provider whose policies are being listed"
-        ),
-        "--output": dict(
-            type=str, required=False, help="Specify an output file name (output sent to stdout by default)"
-        ),
-        "--force": dict(
-            action="store_true",
-            help="If output file already exists, overwrite it (default is not to overwrite)",
-        ),
-        "--exclude-headers": dict(
-            action="store_true", help="Exclude headers on the list being output"
-        )
-    }
-)
-def list_roles(argv: typing.List[str], args: argparse.Namespace):
-    """Print a simple, flat list of IAM roles available"""
+list_asset_args = {
+    "cloud_provider": dict(
+        choices=["aws", "gcp", "fusillade"], help="The cloud provider whose policies are being listed"
+    ),
+    "--output": dict(
+        type=str, required=False, help="Specify an output file name (output sent to stdout by default)"
+    ),
+    "--force": dict(
+        action="store_true",
+        help="If output file already exists, overwrite it (default is not to overwrite)",
+    ),
+    "--exclude-headers": dict(
+        action="store_true", help="Exclude headers on the list being output"
+    )
+}
+
+def list_asset_action(asset_type, argv: typing.List[str], args: argparse.Namespace): 
+    """Print a simple, flat list of IAM assets available"""
     if args.output:
         if os.path.exists(args.output) and not args.force:
             raise RuntimeError(f"Error: cannot overwrite {args.output} without --force flag")
 
     do_headers = not args.exclude_headers
+
     if args.cloud_provider == "aws":
-        contents = list_aws_roles(iam_client)
+        contents = list_aws_assets(asset_type, iam_client)
+
     elif args.cloud_provider == "gcp":
         raise NotImplementedError("Error: IAM functionality for GCP not implemented")
-    elif args.cloud_provider == "fusillade":
 
+    elif args.cloud_provider == "fusillade":
         dss_stage = os.environ["DSS_DEPLOYMENT_STAGE"]
         fus_stage = DSS2FUS[dss_stage]
-        client = FusilladeClient(fus_stage)
-        contents = list_fus_roles(client)
+        fus_client = FusilladeClient(fus_stage)
+        contents = list_fus_assets(asset_type, fus_client)
 
     else:
         raise NotImplementedError(f"Error: IAM functionality not implemented for {args.cloud_provider}")
@@ -744,3 +792,19 @@ def list_roles(argv: typing.List[str], args: argparse.Namespace):
         print(c)
     if args.output:
         sys.stdout = stdout_
+
+
+@iam.action("list-users", arguments=list_asset_args)
+def list_users(argv: typing.List[str], args: argparse.Namespace):
+    """Print a simple, flat list of IAM users available"""
+    list_asset_action("users", argv=argv, args=args)
+
+@iam.action("list-groups", arguments=list_asset_args)
+def list_groups(argv: typing.List[str], args: argparse.Namespace):
+    """Print a simple, flat list of IAM groups available"""
+    list_asset_action("groups", argv=argv, args=args) 
+
+@iam.action("list-roles", arguments=list_asset_args)
+def list_roles(argv: typing.List[str], args: argparse.Namespace):
+    """Print a simple, flat list of IAM roles available"""
+    list_asset_action("roles", argv=argv, args=args)

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -698,7 +698,7 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
             # list policies
             contents = list_fus_policies(client, do_headers)
         elif args.group_by in ['users', 'groups', 'roles']:
-            contents = list_fus_policies_grouped(args.grouped_by, client, do_headers)
+            contents = list_fus_policies_grouped(args.group_by, client, do_headers)
         else:
             RuntimeError(f"Invalid --group-by argument passed: {args.group_by}")
 

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -402,6 +402,8 @@ def list_fus_assets(asset_type: str, fus_client) -> typing.List[str]:
         return list_fus_groups(fus_client)
     elif asset_type == "roles":
         return list_fus_roles(fus_client)
+    else:
+        raise RuntimeError(f"Error: invalid asset type {asset_type}")
 
 
 def list_fus_users(fus_client) -> typing.List[str]:

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -297,7 +297,10 @@ def extract_fus_policies(action: str, fus_client, do_headers: bool = True):
                 except (KeyError, TypeError):
                     pass
                 else:
-                    d = json.loads(iam_policy)
+                    try:
+                        d = json.loads(iam_policy)
+                    except TypeError:
+                        d = iam_policy
                     if "Id" not in d:
                         d["Id"] = ANONYMOUS_POLICY_NAME
                     managed_policies.append(d)

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -396,35 +396,9 @@ def dump_fus_policies(fus_client, do_headers: bool):
 
 def list_fus_assets(asset_type: str, fus_client) -> typing.List[str]:
     """Return a list of names of Fusillade assets"""
-    if asset_type == "users":
-        return list_fus_users(fus_client)
-    elif asset_type == "groups":
-        return list_fus_groups(fus_client)
-    elif asset_type == "roles":
-        return list_fus_roles(fus_client)
-    else:
-        raise RuntimeError(f"Error: invalid asset type {asset_type}")
-
-
-def list_fus_users(fus_client) -> typing.List[str]:
-    """Return a list of names of Fusillade users"""
-    users = list(fus_client.paginate("/v1/users", "users"))
-    users = sorted(list(set(users)))
-    return users
-
-
-def list_fus_groups(fus_client) -> typing.List[str]:
-    """Return a list of names of Fusillade roles"""
-    groups = list(fus_client.paginate("/v1/groups", "groups"))
-    groups = sorted(list(set(groups)))
-    return groups
-
-
-def list_fus_roles(fus_client) -> typing.List[str]:
-    """Return a list of names of Fusillade roles"""
-    roles = list(fus_client.paginate("/v1/roles", "roles"))
-    roles = sorted(list(set(roles)))
-    return roles
+    res = list(fus_client.paginate(f"/v1/{asset_type}", "{asset_type}"))
+    res = sorted(list(set(res)))
+    return res
 
 
 # ---

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -776,6 +776,50 @@ class TestOperations(unittest.TestCase):
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-role-2", "fake-role-2-policy"]), output)
 
+    def test_iam_fus_list_assets(self):
+
+        def _get_fus_list_assets_kwargs(**kwargs):
+            # Set default kwargs values, then set user-specified kwargs
+            custom_kwargs = dict(
+                cloud_provider="fusillade",
+                output=None,
+                force=False,
+                exclude_headers=False,
+            )
+            for kw, val in kwargs.items():
+                custom_kwargs[kw] = val
+            return custom_kwargs
+
+        with self.subTest("Fusillade list users"):
+            with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
+                side_effects = [["fake-user-1@foo.bar", "fake-user-2@baz.wuz"]]
+                fus_client().paginate = mock.MagicMock(side_effect=side_effects)
+                kwargs = _get_fus_list_assets_kwargs()
+                with CaptureStdout() as output:
+                    iam.list_users([], argparse.Namespace(**kwargs))
+                self.assertIn("fake-user-1@foo.bar", output)
+                self.assertIn("fake-user-2@baz.wuz", output)
+
+        with self.subTest("Fusillade list groups"):
+            with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
+                side_effects = [["fake-group-1", "fake-group-2"]]
+                fus_client().paginate = mock.MagicMock(side_effect=side_effects)
+                kwargs = _get_fus_list_assets_kwargs()
+                with CaptureStdout() as output:
+                    iam.list_groups([], argparse.Namespace(**kwargs))
+                self.assertIn("fake-group-1", output)
+                self.assertIn("fake-group-2", output)
+
+        with self.subTest("Fusillade list roles"):
+            with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
+                side_effects = [["fake-role-1", "fake-role-2"]]
+                fus_client().paginate = mock.MagicMock(side_effect=side_effects)
+                kwargs = _get_fus_list_assets_kwargs()
+                with CaptureStdout() as output:
+                    iam.list_roles([], argparse.Namespace(**kwargs))
+                self.assertIn("fake-role-1", output)
+                self.assertIn("fake-role-2", output)
+
     def test_secrets_crud(self):
         # CRUD (create read update delete) test procedure:
         # - create new secret

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -776,6 +776,56 @@ class TestOperations(unittest.TestCase):
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-role-2", "fake-role-2-policy"]), output)
 
+    def test_iam_aws_list_assets(self):
+
+        def _get_aws_list_assets_kwargs(**kwargs):
+            # Set default kwargs values, then set user-specified kwargs
+            custom_kwargs = dict(
+                cloud_provider="aws",
+                output=None,
+                force=False,
+                exclude_headers=False,
+            )
+            for kw, val in kwargs.items():
+                custom_kwargs[kw] = val
+            return custom_kwargs
+
+        with self.subTest("AWS list users"):
+            with mock.patch("dss.operations.iam.iam_client") as iam_client:
+                class MockPaginator_Users(object):
+                    def paginate(self, *args, **kwargs):
+                        return [{"Users": [{"UserName": "fake-user-1@foo.bar"}, {"UserName": "fake-user-2@baz.wuz"}]}]
+                iam_client.get_paginator.return_value = MockPaginator_Users()
+                with CaptureStdout() as output:
+                    kwargs = _get_aws_list_assets_kwargs()
+                    iam.list_users([], argparse.Namespace(**kwargs))
+                self.assertIn("fake-user-1@foo.bar", output)
+                self.assertIn("fake-user-2@baz.wuz", output)
+
+        with self.subTest("AWS list groups"):
+            with mock.patch("dss.operations.iam.iam_client") as iam_client:
+                class MockPaginator_Groups(object):
+                    def paginate(self, *args, **kwargs):
+                        return [{"Groups": [{"GroupName": "fake-group-1"}, {"GroupName": "fake-group-2"}]}]
+                iam_client.get_paginator.return_value = MockPaginator_Groups()
+                with CaptureStdout() as output:
+                    kwargs = _get_aws_list_assets_kwargs()
+                    iam.list_groups([], argparse.Namespace(**kwargs))
+                self.assertIn("fake-group-1", output)
+                self.assertIn("fake-group-2", output)
+
+        with self.subTest("AWS list roles"):
+            with mock.patch("dss.operations.iam.iam_client") as iam_client:
+                class MockPaginator_Roles(object):
+                    def paginate(self, *args, **kwargs):
+                        return [{"Roles": [{"RoleName": "fake-role-1"}, {"RoleName": "fake-role-2"}]}]
+                iam_client.get_paginator.return_value = MockPaginator_Roles()
+                with CaptureStdout() as output:
+                    kwargs = _get_aws_list_assets_kwargs()
+                    iam.list_roles([], argparse.Namespace(**kwargs))
+                self.assertIn("fake-role-1", output)
+                self.assertIn("fake-role-2", output)
+
     def test_iam_fus_list_assets(self):
 
         def _get_fus_list_assets_kwargs(**kwargs):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -602,10 +602,10 @@ class TestOperations(unittest.TestCase):
             # Once we have called the paginate() methods,
             # we call the call_api() method to get IAM policies attached to roles and groups
             policy_docs = [
-                '{"Id": "fake-group-policy"}'
-                '{"Id": "fake-role-policy"}'
-                '{"Id": "fake-group-2-policy"}'
-                '{"Id": "fake-role-2-policy"}'
+                '{"Id": "fake-group-policy"}',
+                '{"Id": "fake-role-policy"}',
+                '{"Id": "fake-group-2-policy"}',
+                '{"Id": "fake-role-2-policy"}',
             ]
             fus_client().call_api = mock.MagicMock(side_effect=[_wrap_policy(doc) for doc in policy_docs])
 
@@ -613,12 +613,6 @@ class TestOperations(unittest.TestCase):
 
             with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
                 # Note: Need to call _repatch_fus_client() before each test
-
-                # ---
-                _repatch_fus_client(fus_client)
-                kwargs = _get_fus_list_policies_kwargs()
-                iam.list_policies([], argparse.Namespace(**kwargs))
-                # ---
 
                 # Plain call to list_fus_policies
                 with CaptureStdout() as output:
@@ -731,6 +725,7 @@ class TestOperations(unittest.TestCase):
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client_groups(fus_client)
                 kwargs = _get_fus_list_policies_kwargs(group_by="groups", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
@@ -775,6 +770,7 @@ class TestOperations(unittest.TestCase):
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client_roles(fus_client)
                 kwargs = _get_fus_list_policies_kwargs(group_by="roles", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -325,7 +325,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ))
                 self.assertIn("fake-policy", output)
 
@@ -343,7 +342,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ),
                 )
                 with open(fname, "r") as f:
@@ -438,7 +436,6 @@ class TestOperations(unittest.TestCase):
                             include_managed=False,
                             exclude_headers=True,
                             quiet=True,
-                            stage=None,
                         ),
                     )
                 self.assertIn(IAMSEPARATOR.join(["fake-user-1", "fake-policy-attached-to-fake-user-1"]), output)
@@ -457,7 +454,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ),
                 )
                 with open(fname, "r") as f:
@@ -486,7 +482,6 @@ class TestOperations(unittest.TestCase):
                             include_managed=False,
                             exclude_headers=True,
                             quiet=True,
-                            stage=None,
                         ),
                     )
                 self.assertIn(
@@ -507,7 +502,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ),
                 )
                 with open(fname, "r") as f:
@@ -536,7 +530,6 @@ class TestOperations(unittest.TestCase):
                             include_managed=False,
                             exclude_headers=True,
                             quiet=True,
-                            stage=None,
                         ),
                     )
                 self.assertIn(
@@ -557,7 +550,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ),
                 )
                 with open(fname, "r") as f:
@@ -576,7 +568,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ))
 
         # Test error-handling and exceptions last
@@ -591,7 +582,6 @@ class TestOperations(unittest.TestCase):
                     include_managed=False,
                     exclude_headers=False,
                     quiet=True,
-                    stage=None,
                 ))
 
             with self.assertRaises(RuntimeError):
@@ -603,7 +593,6 @@ class TestOperations(unittest.TestCase):
                     include_managed=False,
                     exclude_headers=False,
                     quiet=True,
-                    stage=None,
                 ))
 
     def test_iam_gcp(self):
@@ -637,7 +626,7 @@ class TestOperations(unittest.TestCase):
 
                 # Test call_api()
                 req.get = mock.MagicMock(return_value=FakeResponse())
-                client = iam.FusilladeClient(stage="testing")
+                client = iam.FusilladeClient("testing")
                 result = client.call_api("/foobar", "key")
                 self.assertEqual(result, "value")
 
@@ -814,7 +803,6 @@ class TestOperations(unittest.TestCase):
                             include_managed=False,
                             exclude_headers=True,
                             quiet=True,
-                            stage=None,
                         ),
                     )
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
@@ -836,7 +824,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ),
                 )
                 with open(fname, "r") as f:
@@ -893,7 +880,6 @@ class TestOperations(unittest.TestCase):
                             include_managed=False,
                             exclude_headers=False,
                             quiet=True,
-                            stage=None,
                         ),
                     )
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
@@ -912,7 +898,6 @@ class TestOperations(unittest.TestCase):
                             include_managed=False,
                             exclude_headers=True,
                             quiet=True,
-                            stage=None,
                         ),
                     )
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
@@ -932,7 +917,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ),
                 )
                 with open(fname, "r") as f:
@@ -977,7 +961,6 @@ class TestOperations(unittest.TestCase):
                             include_managed=False,
                             exclude_headers=False,
                             quiet=True,
-                            stage=None,
                         ),
                     )
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)
@@ -996,7 +979,6 @@ class TestOperations(unittest.TestCase):
                             include_managed=False,
                             exclude_headers=True,
                             quiet=True,
-                            stage=None,
                         ),
                     )
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)
@@ -1016,7 +998,6 @@ class TestOperations(unittest.TestCase):
                         include_managed=False,
                         exclude_headers=False,
                         quiet=True,
-                        stage=None,
                     ),
                 )
                 with open(fname, "r") as f:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -283,7 +283,22 @@ class TestOperations(unittest.TestCase):
         with io.BytesIO(data) as fh:
             gs_blob.upload_from_file(fh, content_type="application/octet-stream")
 
-    def test_iam_aws(self):
+    def test_iam_aws_list_policies(self):
+
+        def _get_aws_list_policies_kwargs(**kwargs):
+            # Set default kwarg values, then set any user-specified kwargs
+            custom_kwargs = dict(
+                cloud_provider="aws",
+                group_by=None,
+                output=None,
+                force=False,
+                include_managed=False,
+                exclude_headers=False,
+                quiet=True
+            )
+            for kw, val in kwargs.items():
+                custom_kwargs[kw] = val
+            return custom_kwargs
 
         def _get_fake_policy_document():
             """Utility function to get a fake policy document for mocking the AWS API"""
@@ -317,33 +332,16 @@ class TestOperations(unittest.TestCase):
                 # Plain call to list_policies
                 iam_client.get_paginator.return_value = MockPaginator()
                 with CaptureStdout() as output:
-                    iam.list_policies([], argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by=None,
-                        output=None,
-                        force=False,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ))
+                    kwargs = _get_aws_list_policies_kwargs()
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn("fake-policy", output)
 
                 # Check write to output file
                 temp_prefix = "dss-test-operations-iam-aws-list-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 iam_client.get_paginator.return_value = MockPaginator()
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by=None,
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ),
-                )
+                kwargs = _get_aws_list_policies_kwargs(output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn("fake-policy", output)
@@ -426,36 +424,16 @@ class TestOperations(unittest.TestCase):
 
                 # Plain call to list_policies
                 with CaptureStdout() as output:
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="aws",
-                            group_by="users",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                        ),
-                    )
+                    kwargs = _get_aws_list_policies_kwargs(group_by="users")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-user-1", "fake-policy-attached-to-fake-user-1"]), output)
 
                 # Check write to output file
                 temp_prefix = "dss-test-operations-iam-aws-list-users-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 iam_client.get_paginator.return_value = MockPaginator_UserPolicies()
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by="users",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ),
-                )
+                kwargs = _get_aws_list_policies_kwargs(group_by="users", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(
@@ -472,18 +450,8 @@ class TestOperations(unittest.TestCase):
 
                 # Plain call to list_policies
                 with CaptureStdout() as output:
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="aws",
-                            group_by="groups",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                        ),
-                    )
+                    kwargs = _get_aws_list_policies_kwargs(group_by="groups")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(
                     IAMSEPARATOR.join(["fake-group-1", "fake-policy-attached-to-fake-group-1"]), output
                 )
@@ -492,18 +460,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-aws-list-groups-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 iam_client.get_paginator.return_value = MockPaginator_GroupPolicies()
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by="groups",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ),
-                )
+                kwargs = _get_aws_list_policies_kwargs(group_by="groups", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(
@@ -520,18 +478,8 @@ class TestOperations(unittest.TestCase):
 
                 # Plain call to list_policies
                 with CaptureStdout() as output:
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="aws",
-                            group_by="roles",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                        ),
-                    )
+                    kwargs = _get_aws_list_policies_kwargs(group_by="roles")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(
                     IAMSEPARATOR.join(["fake-role-1", "fake-policy-attached-to-fake-role-1"]), output
                 )
@@ -540,18 +488,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-aws-list-roles-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 iam_client.get_paginator.return_value = MockPaginator_RolePolicies()
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by="roles",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ),
-                )
+                kwargs = _get_aws_list_policies_kwargs(group_by="roles", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(
@@ -560,45 +498,36 @@ class TestOperations(unittest.TestCase):
 
                 # Make sure we can't overwrite without --force
                 with self.assertRaises(RuntimeError):
-                    iam.list_policies([], argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by="another-invalid-choice",
-                        output=fname,
-                        force=False,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ))
+                    kwargs = _get_aws_list_policies_kwargs(group_by="roles", output=fname, force=False)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
 
         # Test error-handling and exceptions last
         with self.subTest("Test exceptions and error-handling for AWS IAM functions in dss-ops"):
 
             with self.assertRaises(RuntimeError):
-                iam.list_policies([], argparse.Namespace(
-                    cloud_provider="invalid-cloud-provider",
-                    group_by=None,
-                    output=None,
-                    force=False,
-                    include_managed=False,
-                    exclude_headers=False,
-                    quiet=True,
-                ))
+                kwargs = _get_aws_list_policies_kwargs(cloud_provider="invalid-cloud-provider")
+                iam.list_policies([], argparse.Namespace(**kwargs))
 
             with self.assertRaises(RuntimeError):
-                iam.list_policies([], argparse.Namespace(
-                    cloud_provider="aws",
-                    group_by="another-invalid-choice",
-                    output=None,
-                    force=False,
-                    include_managed=False,
-                    exclude_headers=False,
-                    quiet=True,
-                ))
+                kwargs = _get_aws_list_policies_kwargs(group_by="another-invalid-choice")
+                iam.list_policies([], argparse.Namespace(**kwargs))
 
-    def test_iam_gcp(self):
-        pass
+    def test_iam_fus_list_policies(self):
 
-    def test_iam_fus(self):
+        def _get_fus_list_policies_kwargs(**kwargs):
+            # Set default kwargs values, then set user-specified kwargs
+            custom_kwargs = dict(
+                cloud_provider="fusillade",
+                group_by=None,
+                output=None,
+                force=False,
+                exclude_headers=False,
+                include_managed=False,
+                quiet=True
+            )
+            for kw, val in kwargs.items():
+                custom_kwargs[kw] = val
+            return custom_kwargs
 
         with self.subTest("Fusillade client"):
             with mock.patch("dss.operations.iam.DCPServiceAccountManager") as SAM, \
@@ -664,57 +593,38 @@ class TestOperations(unittest.TestCase):
             # When we call list_policies(), which calls list_fus_user_policies(),
             # it calls the paginate() method to get a list of all users,
             # then the paginate() method twice for each user (once for groups, once for roles),
-            users_response = ["fake-user@foo.bar", "another-fake-user@baz.wuz"]
-            groups_response = ["fake-group"]
-            roles_response = ["fake-role"]
-            groups_response = ["fake-group-2"]
-            roles_response = ["fake-role-2"]
-            fus_client().paginate = mock.MagicMock(
-                side_effect=[
-                    users_response,
-                    groups_response,
-                    roles_response,
-                    groups_response,
-                    roles_response,
-                ]
-            )
+            side_effects = [
+                ["fake-user@foo.bar", "another-fake-user@baz.wuz"],
+                ["fake-group"], ["fake-role"], ["fake-group-2"], ["fake-role-2"]
+            ]
+            fus_client().paginate = mock.MagicMock(side_effect=side_effects)
 
             # Once we have called the paginate() methods,
             # we call the call_api() method to get IAM policies attached to roles and groups
-            policy_doc_g1 = '{"Id": "fake-group-policy"}'
-            policy_doc_r1 = '{"Id": "fake-role-policy"}'
-            policy_doc_g2 = '{"Id": "fake-group-2-policy"}'
-            policy_doc_r2 = '{"Id": "fake-role-2-policy"}'
-            fus_client().call_api = mock.MagicMock(
-                side_effect=[
-                    _wrap_policy(policy_doc_g1),
-                    _wrap_policy(policy_doc_r1),
-                    _wrap_policy(policy_doc_g2),
-                    _wrap_policy(policy_doc_r2),
-                ]
-            )
+            policy_docs = [
+                '{"Id": "fake-group-policy"}'
+                '{"Id": "fake-role-policy"}'
+                '{"Id": "fake-group-2-policy"}'
+                '{"Id": "fake-role-2-policy"}'
+            ]
+            fus_client().call_api = mock.MagicMock(side_effect=[_wrap_policy(doc) for doc in policy_docs])
 
         with self.subTest("List Fusillade policies"):
 
             with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
                 # Note: Need to call _repatch_fus_client() before each test
 
+                # ---
+                _repatch_fus_client(fus_client)
+                kwargs = _get_fus_list_policies_kwargs()
+                iam.list_policies([], argparse.Namespace(**kwargs))
+                # ---
+
                 # Plain call to list_fus_policies
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by=None,
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=False,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs()
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn("fake-group-policy", output)
                 self.assertIn("fake-role-policy", output)
                 self.assertIn("fake-group-2-policy", output)
@@ -723,19 +633,8 @@ class TestOperations(unittest.TestCase):
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by=None,
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(exclude_headers=True)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn("fake-group-policy", output)
                 self.assertIn("fake-role-policy", output)
                 self.assertIn("fake-group-2-policy", output)
@@ -745,19 +644,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-fus-list-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client(fus_client)
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="fusillade",
-                        group_by=None,
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_fus_list_policies_kwargs(output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn("fake-group-policy", output)
@@ -772,19 +660,8 @@ class TestOperations(unittest.TestCase):
                 # List fusillade policies grouped by user
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="users",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=False,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="users")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
@@ -793,18 +670,8 @@ class TestOperations(unittest.TestCase):
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="users",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="users", exclude_headers=True)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
@@ -814,18 +681,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-fus-list-users-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client(fus_client)
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="fusillade",
-                        group_by="users",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ),
-                )
+                kwargs = _get_fus_list_policies_kwargs(group_by="users", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
@@ -842,64 +699,30 @@ class TestOperations(unittest.TestCase):
                 # When we call list_policies(), which calls list_fus_group_policies(),
                 # it calls paginate() to get all groups,
                 # then calls paginate() to get roles for each group
-                groups_response = ["fake-group", "fake-group-2"]
-                roles_response1 = ["fake-role"]
-                roles_response2 = ["fake-role-2"]
-                fus_client().paginate = mock.MagicMock(
-                    side_effect=[
-                        groups_response,
-                        roles_response1,
-                        roles_response2
-                    ]
-                )
+                responses = [["fake-group", "fake-group-2"], ["fake-role"], ["fake-role-2"]]
+                fus_client().paginate = mock.MagicMock(side_effect=responses)
 
                 # For each role, list_fus_group_policies() calls get_fus_role_attached_policies(),
                 # which calls call_api() on each role and returns a corresponding policy document
                 # @chmreid TODO: should this be calling get policy on each group, too? (inline policies)
-                policy_doc_r1 = '{"Id": "fake-role-policy"}'
-                policy_doc_r2 = '{"Id": "fake-role-2-policy"}'
-                fus_client().call_api = mock.MagicMock(
-                    side_effect=[
-                        _wrap_policy(policy_doc_r1),
-                        _wrap_policy(policy_doc_r2),
-                    ]
-                )
+                policy_docs = ['{"Id": "fake-role-policy"}', '{"Id": "fake-role-2-policy"}']
+                fus_client().call_api = mock.MagicMock(side_effect=[_wrap_policy(doc) for doc in policy_docs])
 
             with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
 
                 # List fusillade policies grouped by groups
                 with CaptureStdout() as output:
                     _repatch_fus_client_groups(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="groups",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=False,
-                            quiet=True,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="groups")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-group-2", "fake-role-2-policy"]), output)
 
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client_groups(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="groups",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="groups", exclude_headers=True)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-group-2", "fake-role-2-policy"]), output)
 
@@ -907,18 +730,7 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-fus-list-groups-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client_groups(fus_client)
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="fusillade",
-                        group_by="groups",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ),
-                )
+                kwargs = _get_fus_list_policies_kwargs(group_by="groups", output=fname, force=True)
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
@@ -931,56 +743,30 @@ class TestOperations(unittest.TestCase):
                 """Re-patch a mock Fusillade client with the proper responses for using the --group-by roles flag"""
                 # When we call list_policies, which calls list_fus_role_policies(),
                 # it calls paginate() to get the list of all roles,
-                roles_response = ["fake-role", "fake-role-2"]
-                fus_client().paginate = mock.MagicMock(side_effect=[roles_response])
+                side_effects = [["fake-role", "fake-role-2"]]
+                fus_client().paginate = mock.MagicMock(side_effect=side_effects)
 
                 # list_fus_role_policies then calls get_fus_role_attached_policies()
                 # to get a list of policies attached to the role,
                 # which calls call_api() for each role returned by the paginate command
-                policy_doc_r1 = '{"Id": "fake-role-policy"}'
-                policy_doc_r2 = '{"Id": "fake-role-2-policy"}'
-                fus_client().call_api = mock.MagicMock(
-                    side_effect=[
-                        _wrap_policy(policy_doc_r1),
-                        _wrap_policy(policy_doc_r2),
-                    ]
-                )
+                policy_docs = ['{"Id": "fake-role-policy"}', '{"Id": "fake-role-2-policy"}']
+                fus_client().call_api = mock.MagicMock(side_effect=[_wrap_policy(doc) for doc in policy_docs])
 
             with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
 
                 # List fusillade policies grouped by roles
                 with CaptureStdout() as output:
                     _repatch_fus_client_roles(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="roles",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=False,
-                            quiet=True,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="roles")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-role-2", "fake-role-2-policy"]), output)
 
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client_roles(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="roles",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="roles", exclude_headers=True)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-role-2", "fake-role-2-policy"]), output)
 
@@ -988,18 +774,7 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-list-roles-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client_roles(fus_client)
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="fusillade",
-                        group_by="roles",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                    ),
-                )
+                kwargs = _get_fus_list_policies_kwargs(group_by="roles", output=fname, force=True)
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)


### PR DESCRIPTION
This PR makes the following changes:

* adds a `list-users`, `list-groups`, and `list-roles` endpoint to dss-ops iam action
* adds tests for the new endpoints
* refactors dss-ops iam tests to be shorter/less verbose
* refactors dss-ops iam function calls to simplify logic
* adds better error-handling to dss-ops iam functionality

Most of the code changes are either reducing copypasta or adding new functions for the new `list-X` functionality.

Closes #2592 