### PR TITLE
[Fusillade Check 1/3] Refactor dss-ops iam script and tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,6 +91,7 @@ setup_fusillade:
     - else
     -   FUS_STAGE=$DSS_DEPLOYMENT_STAGE
     - fi
+    - python -m json.tool ./temp-roles.json > /dev/null || exit 1
     - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force $FUS_STAGE
     - scripts/check_fusillade.py $FUS_STAGE
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,6 +92,7 @@ setup_fusillade:
     -   FUS_STAGE=$DSS_DEPLOYMENT_STAGE
     - fi
     - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force $FUS_STAGE
+    - scripts/check_fusillade.py $FUS_STAGE
   except:
     - schedules
   only:

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -703,9 +703,6 @@ list_asset_args = {
     "--force": dict(
         action="store_true",
         help="If output file already exists, overwrite it (default is not to overwrite)",
-    ),
-    "--exclude-headers": dict(
-        action="store_true", help="Exclude headers on the list being output"
     )
 }
 

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -396,7 +396,7 @@ def dump_fus_policies(fus_client, do_headers: bool):
 
 def list_fus_assets(asset_type: str, fus_client) -> typing.List[str]:
     """Return a list of names of Fusillade assets"""
-    res = list(fus_client.paginate(f"/v1/{asset_type}", "{asset_type}"))
+    res = list(fus_client.paginate(f"/v1/{asset_type}", f"{asset_type}"))
     res = sorted(list(set(res)))
     return res
 

--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -166,6 +166,55 @@ def get_fus_role_attached_policies(fus_client, action, role):
 
 
 # ---
+# AWS utility functions/classes
+# ---
+def _get_aws_api_list_endpoints_dict() -> typing.Dict[str, str]:
+    """Store AWS API endpoints to list each asset type"""
+    return {
+        "users": "list_users",
+        "groups": "list_groups",
+        "roles": "list_roles"
+    }
+
+
+def _get_aws_api_labels_dict() -> typing.Dict[str, typing.Dict[str, str]]:
+    """Store the labels used to unwrap JSON results from the AWS API"""
+    return {
+        "users": _make_aws_api_labels_dict_entry("Users", "UserName", "UserDetailList", "UserPolicyList"),
+        "groups": _make_aws_api_labels_dict_entry("Groups", "GroupName", "GroupDetailList", "GroupPolicyList"),
+        "roles": _make_aws_api_labels_dict_entry("Roles", "RoleName", "RoleDetailList", "RolePolicyList"),
+    }
+
+
+def _make_aws_api_labels_dict_entry(*args) -> typing.Dict[str, str]:
+    """
+    Convenience function to unpack 4 values into a dictionary of labels, useful for processing API results.
+
+    Example:
+        >>> _make_aws_api_labels_dict_entry("Users", "UserName", "UserDetailList", "UserPolicyList")
+        {
+            "extracted_list_label": "Users",
+            "name_label": "UserName",
+            "detail_list_label": "UserDetailList",
+            "policy_list_label": "UserPolicyList"
+        }
+
+    :params arg[0]: label of asset type
+    :params arg[1]: label of asset name
+    :params arg[2]: label of asset details
+    :params arg[3]: label of asset policy details
+    :returns: dictionary of organized labels
+    """
+    assert len(args) == 4, "Error: need 4 arguments!"
+    return dict(
+        extracted_list_label=args[0],
+        name_label=args[1],
+        detail_list_label=args[2],
+        policy_list_label=args[3],
+    )
+
+
+# ---
 # Dump/list AWS policies
 # ---
 def extract_aws_policies(action: str, client, managed: bool):
@@ -276,7 +325,15 @@ def extract_fus_policies(action: str, fus_client, do_headers: bool = True):
                 except (KeyError, TypeError):
                     pass
                 else:
-                    d = json.loads(iam_policy)
+                    try:
+                        d = json.loads(iam_policy)
+                    except TypeError:
+                        d = iam_policy
+                    except json.decoder.JSONDecodeError:
+                        msg = f"Warning: malformed policy document for user {user} and {asset_type} {asset}:\n"
+                        msg += f"{iam_policy}"
+                        logger.warning(msg)
+                        d = {}  # Malformed JSON
                     if "Id" not in d:
                         d["Id"] = ANONYMOUS_POLICY_NAME
                     managed_policies.append(d)
@@ -303,12 +360,12 @@ def extract_fus_policies(action: str, fus_client, do_headers: bool = True):
     return master_list
 
 
-def list_fus_policies(fus_client, do_headers) -> typing.List[str]:
+def list_fus_policies(fus_client, do_headers: bool) -> typing.List[str]:
     """Return a list of names of Fusillade policies"""
     return extract_fus_policies("list", fus_client, do_headers)
 
 
-def dump_fus_policies(fus_client, do_headers):
+def dump_fus_policies(fus_client, do_headers: bool):
     """Return a list of dictionaries containing Fusillade policy documents"""
     return extract_fus_policies("dump", fus_client, do_headers)
 
@@ -327,41 +384,10 @@ def list_aws_policies_grouped(asset_type, client, managed: bool, do_headers: boo
     """
     extracted_list = []
 
-    # Prepare to extract labels for JSON returned by API
-    def _make_aws_api_labels_dict_entry(*args) -> typing.Dict[str, str]:
-        """
-        Convenience function to unpack 4 values into a dictionary of labels, useful for processing
-        API results.
-
-        :params arg[0]: label of asset type
-        :params arg[1]: label of asset name
-        :params arg[2]: label of asset details
-        :params arg[3]: label of asset policy details
-        :returns: dictionary of organized labels
-        """
-        assert len(args) == 4, "Error: need 4 arguments!"
-        return dict(
-            extracted_list_label=args[0],
-            name_label=args[1],
-            detail_list_label=args[2],
-            policy_list_label=args[3],
-        )
-
-    def _get_aws_api_labels_dict() -> typing.Dict[str, typing.Dict[str, str]]:
-        """Store the labels used to unwrap JSON results from the AWS API"""
-        labels = {
-            "user": _make_aws_api_labels_dict_entry("User", "UserName", "UserDetailList", "UserPolicyList"),
-            "group": _make_aws_api_labels_dict_entry(
-                "Group", "GroupName", "GroupDetailList", "GroupPolicyList"
-            ),
-            "role": _make_aws_api_labels_dict_entry("Role", "RoleName", "RoleDetailList", "RolePolicyList"),
-        }
-        return labels
-
     # Extract labels needed
     labels = _get_aws_api_labels_dict()
     if asset_type not in labels:
-        raise RuntimeError(f"Error: asset type {asset_type} is not valid, try one of: {labels}")
+        raise RuntimeError(f"Error: asset type \"{asset_type}\" is not valid, try one of: {labels.keys()}")
     extracted_list_label, filter_label, name_label, detail_list_label, policy_list_label = (
         labels[asset_type]["extracted_list_label"],
         labels[asset_type]["extracted_list_label"],
@@ -417,21 +443,6 @@ def list_aws_policies_grouped(asset_type, client, managed: bool, do_headers: boo
     return extracted_list
 
 
-def list_aws_user_policies(*args, **kwargs):
-    """Extract a list of policies that apply to each user"""
-    return list_aws_policies_grouped("user", *args, **kwargs)
-
-
-def list_aws_group_policies(*args, **kwargs):
-    """Extract a list of policies that apply to each group"""
-    return list_aws_policies_grouped("group", *args, **kwargs)
-
-
-def list_aws_role_policies(*args, **kwargs):
-    """Extract a list of policies that apply to each resource"""
-    return list_aws_policies_grouped("role", *args, **kwargs)
-
-
 # ---
 # List GCP policies grouped by asset type
 # ---
@@ -442,24 +453,17 @@ def list_gcp_policies_grouped(asset_type, client, managed: bool, do_headers: boo
     pass
 
 
-def list_gcp_user_policies(*args, **kwargs):
-    """Extract a list of policies that apply to each user"""
-    pass
-
-
-def list_gcp_group_policies(*args, **kwargs):
-    """Extract a list of policies that apply to each group"""
-    pass
-
-
-def list_gcp_role_policies(*args, **kwargs):
-    """Extract a list of policies that apply to each resource"""
-    pass
-
-
 # ---
 # List Fusillade policies grouped by asset type
 # ---
+def list_fus_policies_grouped(group_by, fus_client, do_headers: bool = True):
+    if group_by == "users":
+        return list_fus_user_policies(fus_client, do_headers)
+    elif group_by == "groups":
+        return list_fus_group_policies(fus_client, do_headers)
+    elif group_by == "roles":
+        return list_fus_role_policies(fus_client, do_headers)
+
 def list_fus_user_policies(fus_client, do_headers: bool = True):
     """
     Call the Fusillade API to retrieve policies grouped by user.
@@ -615,46 +619,38 @@ def list_policies(argv: typing.List[str], args: argparse.Namespace):
     do_headers = not args.exclude_headers
 
     if args.cloud_provider == "aws":
-
         if args.group_by is None:
             contents = list_aws_policies(iam_client, managed)
+        elif args.group_by in ['users', 'groups', 'roles']:
+            contents = list_aws_policies_grouped(args.group_by, iam_client, managed, do_headers)
         else:
-            if args.group_by == "users":
-                contents = list_aws_user_policies(iam_client, managed, do_headers)
-            elif args.group_by == "groups":
-                contents = list_aws_group_policies(iam_client, managed, do_headers)
-            elif args.group_by == "roles":
-                contents = list_aws_role_policies(iam_client, managed, do_headers)
-            else:
-                raise RuntimeError(f"Invalid --group-by argument passed: {args.group_by}")
+            raise RuntimeError(f"Invalid --group-by argument passed: {args.group_by}")
 
-            # Join the tuples
+        # Join the tuples
+        if args.group_by is not None:
             contents = [IAMSEPARATOR.join(c) for c in contents]
 
     elif args.cloud_provider == "gcp":
-        pass
-    elif args.cloud_provider == "fusillade":
+        raise NotImplementedError("Error: IAM functionality for GCP not implemented")
 
-        stage = DSS2FUS[os.environ["DSS_DEPLOYMENT_STAGE"]]
-        client = FusilladeClient(stage=stage)
+    elif args.cloud_provider == "fusillade":
+        fus_stage = DSS2FUS[os.environ["DSS_DEPLOYMENT_STAGE"]]
+        client = FusilladeClient(fus_stage)
 
         if args.group_by is None:
             # list policies
             contents = list_fus_policies(client, do_headers)
+        elif args.group_by in ['users', 'groups', 'roles']:
+            contents = list_fus_policies_grouped(args.group_by, client, do_headers)
         else:
-            # list policies grouped by asset
-            if args.group_by == "users":
-                contents = list_fus_user_policies(client, do_headers)
-            elif args.group_by == "groups":
-                contents = list_fus_group_policies(client, do_headers)
-            elif args.group_by == "roles":
-                contents = list_fus_role_policies(client, do_headers)
+            RuntimeError(f"Invalid --group-by argument passed: {args.group_by}")
 
-            # Join the tuples
+        # Join the tuples
+        if args.group_by is not None:
             contents = [IAMSEPARATOR.join(c) for c in contents]
 
     else:
-        raise RuntimeError(f"Error: IAM functionality not implemented for {args.cloud_provider}")
+        raise NotImplementedError(f"Error: IAM functionality not implemented for {args.cloud_provider}")
 
     # Print list to output
     if args.output:

--- a/scripts/check_fusillade.py
+++ b/scripts/check_fusillade.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+"""
+This script ensures Fusillade roles (defined in this repo at roles.json)
+are correctly applied to the right Fusillade stage, and that the current
+state of the Fusillade cloud directory contains the roles defined in roles.json.
+Operator should provide the Fusillade stage as the first arg or using the
+FUS_DEPLOYMENT_STAGE environment var.
+"""
+import subprocess
+import os
+import sys
+import json
+import copy
+
+
+FUS2DSS = {
+    "testing": "dev",
+    "dev": None,
+    "integration": "integration",
+    "staging": "staging",
+    "prod": "prod"
+}
+DSS_ENV_FILES = {
+    "dev": "environment",
+    "integration": "environment.integration",
+    "staging": "environment.staging",
+    "prod": "environment.prod"
+}
+IAMSEPARATOR = " : "
+
+
+class FusilladeChecker(object):
+    """
+    This class defines functionality to check that the data store roles
+    specified in roles.json have been deployed correctly to Fusillade.
+
+    Steps:
+    - collect info from roles.json in repo and extract list of roles
+    - check that each role from roles.json is present in roles listed in fusillade
+    """
+    STAGES = {
+        'dev': 'environment',
+        'testing': 'environment',
+        'integration': 'environment.integration',
+        'staging': 'environment.staging',
+        'prod': 'environment.prod'
+    }
+    def __init__(self, fus_stage):
+        """Set up stage info and check values"""
+        if fus_stage not in DSS2FUS:
+            print(f'Custom stage "{fus_stage}" provided. Skipping Fusillade check.')
+            return
+        else:
+            self.fus_stage = fus_stage
+            self.dss_stage = FUS2DSS[fus_stage]
+
+        this_dir = os.path.abspath(os.path.dirname(__file__))
+        self.scripts_dir = this_dir
+        self.dss_dir = os.path.join(this_dir, '..')
+
+        # Bootstrap: stage_env must be set before we can run get_stage_env
+        self.stage_env = copy.deepcopy(os.environ)
+
+        # Set up the environment vars for this stage
+        env_file = DSS_ENV_FILES[self.dss_stage]
+        self.stage_env = self.get_stage_env(os.path.join(self.dss_dir, env_file))
+
+    def get_stage_env(self, env_file):
+        """Return a serialized JSON of the environment variables for this stage"""
+        dump = 'python -c "import os, json; print(json.dumps(dict(os.environ)))"'
+        cmd = ['bash', '-c', f'source {env_file} && {dump}']
+        return json.loads(self.run_cmd(cmd, shell=False))
+
+    def run(self):
+        """Run the Fusillade check, raise an exception if the check fails"""
+        roles_json = self.get_roles_from_json()
+        roles_fus = self.get_roles_from_fus()
+        # Assert each role in json is in list roles output
+        errors = []
+        for r in roles_json:
+            if r not in roles_fus:
+                errors.append(f"Role {r} is in roles.json but is not in Fusillade cloud directory")
+        if len(errors) > 0:
+            err_msg = "Encountered errors:\n"
+            err_msg += "\n".join(errors)
+            raise RuntimeError(err_msg)
+
+    def get_roles_from_json(self) -> list:
+        """Extract a list of roles from roles.json in this repo"""
+        roles_dir = os.path.join(os.path.dirname(__file__), '..')
+        roles_json = os.path.join(roles_dir, 'roles.json')
+        with open(roles_json, 'r') as f:
+            roles_dict = json.load(f)
+        roles_list = [k for k in roles_dict['roles']]
+        return roles_list
+
+    def get_roles_from_fus(self) -> list:
+        """List all Fusillade roles using dss-ops and return the list of roles"""
+        # Call dss-ops script, iam list action
+        ops_script = os.path.join(self.scripts_dir, 'dss-ops.py')
+        ops_action = "iam list fusillade"
+        ops_args = f"--group-by roles --exclude-headers --quiet"
+        cmd = f"{ops_script} {ops_action} {ops_args}"
+        raw_resp = self.run_cmd(cmd)
+        resp_lines = [j for j in raw_resp.split("\n") if len(j)>0]
+        roles = [k.split(IAMSEPARATOR)[0] for k in resp_lines]
+        return roles
+
+    def run_cmd(self, cmd, cwd=os.getcwd(), shell=True):
+        """Wrapper to run a command and return stdout"""
+        p = subprocess.Popen(cmd,
+                             shell=shell,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             cwd=cwd,
+                             env=self.stage_env)
+        stdout, stderr = p.communicate()
+        if p.returncode != 0:
+            raise RuntimeError(f'While checking Fusillade, an error occured:\n'
+                               f'stdout: {stdout}\n\n'
+                               f'stderr: {stderr}\n')
+        return stdout.decode('utf-8')
+
+
+def main(stage = None):
+    if len(sys.argv) > 1:
+        stage = sys.argv[1]
+    elif 'FUS_DEPLOYMENT_STAGE' in os.environ:
+        stage = os.environ['FUS_DEPLOYMENT_STAGE']
+    else:
+        msg = "Error: FUS_DEPLOYMENT_STAGE environment variable not defined. Please define it "
+        msg += "or provide 'stage' as the first environment."
+        raise RuntimeError(msg)
+    s = FusilladeChecker(stage)
+    s.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -283,7 +283,22 @@ class TestOperations(unittest.TestCase):
         with io.BytesIO(data) as fh:
             gs_blob.upload_from_file(fh, content_type="application/octet-stream")
 
-    def test_iam_aws(self):
+    def test_iam_aws_list_policies(self):
+
+        def _get_aws_list_policies_kwargs(**kwargs):
+            # Set default kwarg values, then set any user-specified kwargs
+            custom_kwargs = dict(
+                cloud_provider="aws",
+                group_by=None,
+                output=None,
+                force=False,
+                include_managed=False,
+                exclude_headers=False,
+                quiet=True
+            )
+            for kw, val in kwargs.items():
+                custom_kwargs[kw] = val
+            return custom_kwargs
 
         def _get_fake_policy_document():
             """Utility function to get a fake policy document for mocking the AWS API"""
@@ -317,35 +332,16 @@ class TestOperations(unittest.TestCase):
                 # Plain call to list_policies
                 iam_client.get_paginator.return_value = MockPaginator()
                 with CaptureStdout() as output:
-                    iam.list_policies([], argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by=None,
-                        output=None,
-                        force=False,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ))
+                    kwargs = _get_aws_list_policies_kwargs()
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn("fake-policy", output)
 
                 # Check write to output file
                 temp_prefix = "dss-test-operations-iam-aws-list-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 iam_client.get_paginator.return_value = MockPaginator()
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by=None,
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_aws_list_policies_kwargs(output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn("fake-policy", output)
@@ -428,38 +424,16 @@ class TestOperations(unittest.TestCase):
 
                 # Plain call to list_policies
                 with CaptureStdout() as output:
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="aws",
-                            group_by="users",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_aws_list_policies_kwargs(group_by="users")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-user-1", "fake-policy-attached-to-fake-user-1"]), output)
 
                 # Check write to output file
                 temp_prefix = "dss-test-operations-iam-aws-list-users-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 iam_client.get_paginator.return_value = MockPaginator_UserPolicies()
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by="users",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_aws_list_policies_kwargs(group_by="users", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(
@@ -476,19 +450,8 @@ class TestOperations(unittest.TestCase):
 
                 # Plain call to list_policies
                 with CaptureStdout() as output:
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="aws",
-                            group_by="groups",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_aws_list_policies_kwargs(group_by="groups")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(
                     IAMSEPARATOR.join(["fake-group-1", "fake-policy-attached-to-fake-group-1"]), output
                 )
@@ -497,19 +460,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-aws-list-groups-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 iam_client.get_paginator.return_value = MockPaginator_GroupPolicies()
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by="groups",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_aws_list_policies_kwargs(group_by="groups", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(
@@ -526,19 +478,8 @@ class TestOperations(unittest.TestCase):
 
                 # Plain call to list_policies
                 with CaptureStdout() as output:
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="aws",
-                            group_by="roles",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_aws_list_policies_kwargs(group_by="roles")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(
                     IAMSEPARATOR.join(["fake-role-1", "fake-policy-attached-to-fake-role-1"]), output
                 )
@@ -547,19 +488,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-aws-list-roles-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 iam_client.get_paginator.return_value = MockPaginator_RolePolicies()
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by="roles",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_aws_list_policies_kwargs(group_by="roles", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(
@@ -568,48 +498,36 @@ class TestOperations(unittest.TestCase):
 
                 # Make sure we can't overwrite without --force
                 with self.assertRaises(RuntimeError):
-                    iam.list_policies([], argparse.Namespace(
-                        cloud_provider="aws",
-                        group_by="another-invalid-choice",
-                        output=fname,
-                        force=False,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ))
+                    kwargs = _get_aws_list_policies_kwargs(group_by="roles", output=fname, force=False)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
 
         # Test error-handling and exceptions last
         with self.subTest("Test exceptions and error-handling for AWS IAM functions in dss-ops"):
 
             with self.assertRaises(RuntimeError):
-                iam.list_policies([], argparse.Namespace(
-                    cloud_provider="invalid-cloud-provider",
-                    group_by=None,
-                    output=None,
-                    force=False,
-                    include_managed=False,
-                    exclude_headers=False,
-                    quiet=True,
-                    stage=None,
-                ))
+                kwargs = _get_aws_list_policies_kwargs(cloud_provider="invalid-cloud-provider")
+                iam.list_policies([], argparse.Namespace(**kwargs))
 
             with self.assertRaises(RuntimeError):
-                iam.list_policies([], argparse.Namespace(
-                    cloud_provider="aws",
-                    group_by="another-invalid-choice",
-                    output=None,
-                    force=False,
-                    include_managed=False,
-                    exclude_headers=False,
-                    quiet=True,
-                    stage=None,
-                ))
+                kwargs = _get_aws_list_policies_kwargs(group_by="another-invalid-choice")
+                iam.list_policies([], argparse.Namespace(**kwargs))
 
-    def test_iam_gcp(self):
-        pass
+    def test_iam_fus_list_policies(self):
 
-    def test_iam_fus(self):
+        def _get_fus_list_policies_kwargs(**kwargs):
+            # Set default kwargs values, then set user-specified kwargs
+            custom_kwargs = dict(
+                cloud_provider="fusillade",
+                group_by=None,
+                output=None,
+                force=False,
+                exclude_headers=False,
+                include_managed=False,
+                quiet=True
+            )
+            for kw, val in kwargs.items():
+                custom_kwargs[kw] = val
+            return custom_kwargs
 
         with self.subTest("Fusillade client"):
             with mock.patch("dss.operations.iam.DCPServiceAccountManager") as SAM, \
@@ -637,7 +555,7 @@ class TestOperations(unittest.TestCase):
 
                 # Test call_api()
                 req.get = mock.MagicMock(return_value=FakeResponse())
-                client = iam.FusilladeClient(stage="testing")
+                client = iam.FusilladeClient("testing")
                 result = client.call_api("/foobar", "key")
                 self.assertEqual(result, "value")
 
@@ -675,35 +593,21 @@ class TestOperations(unittest.TestCase):
             # When we call list_policies(), which calls list_fus_user_policies(),
             # it calls the paginate() method to get a list of all users,
             # then the paginate() method twice for each user (once for groups, once for roles),
-            users_response = ["fake-user@foo.bar", "another-fake-user@baz.wuz"]
-            groups_response = ["fake-group"]
-            roles_response = ["fake-role"]
-            groups_response = ["fake-group-2"]
-            roles_response = ["fake-role-2"]
-            fus_client().paginate = mock.MagicMock(
-                side_effect=[
-                    users_response,
-                    groups_response,
-                    roles_response,
-                    groups_response,
-                    roles_response,
-                ]
-            )
+            side_effects = [
+                ["fake-user@foo.bar", "another-fake-user@baz.wuz"],
+                ["fake-group"], ["fake-role"], ["fake-group-2"], ["fake-role-2"]
+            ]
+            fus_client().paginate = mock.MagicMock(side_effect=side_effects)
 
             # Once we have called the paginate() methods,
             # we call the call_api() method to get IAM policies attached to roles and groups
-            policy_doc_g1 = '{"Id": "fake-group-policy"}'
-            policy_doc_r1 = '{"Id": "fake-role-policy"}'
-            policy_doc_g2 = '{"Id": "fake-group-2-policy"}'
-            policy_doc_r2 = '{"Id": "fake-role-2-policy"}'
-            fus_client().call_api = mock.MagicMock(
-                side_effect=[
-                    _wrap_policy(policy_doc_g1),
-                    _wrap_policy(policy_doc_r1),
-                    _wrap_policy(policy_doc_g2),
-                    _wrap_policy(policy_doc_r2),
-                ]
-            )
+            policy_docs = [
+                '{"Id": "fake-group-policy"}',
+                '{"Id": "fake-role-policy"}',
+                '{"Id": "fake-group-2-policy"}',
+                '{"Id": "fake-role-2-policy"}',
+            ]
+            fus_client().call_api = mock.MagicMock(side_effect=[_wrap_policy(doc) for doc in policy_docs])
 
         with self.subTest("List Fusillade policies"):
 
@@ -713,19 +617,8 @@ class TestOperations(unittest.TestCase):
                 # Plain call to list_fus_policies
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by=None,
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=False,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs()
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn("fake-group-policy", output)
                 self.assertIn("fake-role-policy", output)
                 self.assertIn("fake-group-2-policy", output)
@@ -734,19 +627,8 @@ class TestOperations(unittest.TestCase):
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by=None,
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(exclude_headers=True)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn("fake-group-policy", output)
                 self.assertIn("fake-role-policy", output)
                 self.assertIn("fake-group-2-policy", output)
@@ -756,19 +638,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-fus-list-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client(fus_client)
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="fusillade",
-                        group_by=None,
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_fus_list_policies_kwargs(output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn("fake-group-policy", output)
@@ -783,19 +654,8 @@ class TestOperations(unittest.TestCase):
                 # List fusillade policies grouped by user
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="users",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=False,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="users")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
@@ -804,19 +664,8 @@ class TestOperations(unittest.TestCase):
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="users",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="users", exclude_headers=True)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
@@ -826,19 +675,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-fus-list-users-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client(fus_client)
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="fusillade",
-                        group_by="users",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_fus_list_policies_kwargs(group_by="users", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
@@ -855,66 +693,30 @@ class TestOperations(unittest.TestCase):
                 # When we call list_policies(), which calls list_fus_group_policies(),
                 # it calls paginate() to get all groups,
                 # then calls paginate() to get roles for each group
-                groups_response = ["fake-group", "fake-group-2"]
-                roles_response1 = ["fake-role"]
-                roles_response2 = ["fake-role-2"]
-                fus_client().paginate = mock.MagicMock(
-                    side_effect=[
-                        groups_response,
-                        roles_response1,
-                        roles_response2
-                    ]
-                )
+                responses = [["fake-group", "fake-group-2"], ["fake-role"], ["fake-role-2"]]
+                fus_client().paginate = mock.MagicMock(side_effect=responses)
 
                 # For each role, list_fus_group_policies() calls get_fus_role_attached_policies(),
                 # which calls call_api() on each role and returns a corresponding policy document
                 # @chmreid TODO: should this be calling get policy on each group, too? (inline policies)
-                policy_doc_r1 = '{"Id": "fake-role-policy"}'
-                policy_doc_r2 = '{"Id": "fake-role-2-policy"}'
-                fus_client().call_api = mock.MagicMock(
-                    side_effect=[
-                        _wrap_policy(policy_doc_r1),
-                        _wrap_policy(policy_doc_r2),
-                    ]
-                )
+                policy_docs = ['{"Id": "fake-role-policy"}', '{"Id": "fake-role-2-policy"}']
+                fus_client().call_api = mock.MagicMock(side_effect=[_wrap_policy(doc) for doc in policy_docs])
 
             with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
 
                 # List fusillade policies grouped by groups
                 with CaptureStdout() as output:
                     _repatch_fus_client_groups(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="groups",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=False,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="groups")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-group-2", "fake-role-2-policy"]), output)
 
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client_groups(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="groups",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="groups", exclude_headers=True)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-group-2", "fake-role-2-policy"]), output)
 
@@ -922,19 +724,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-fus-list-groups-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client_groups(fus_client)
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="fusillade",
-                        group_by="groups",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_fus_list_policies_kwargs(group_by="groups", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(IAMSEPARATOR.join(["fake-group", "fake-role-policy"]), output)
@@ -947,58 +738,30 @@ class TestOperations(unittest.TestCase):
                 """Re-patch a mock Fusillade client with the proper responses for using the --group-by roles flag"""
                 # When we call list_policies, which calls list_fus_role_policies(),
                 # it calls paginate() to get the list of all roles,
-                roles_response = ["fake-role", "fake-role-2"]
-                fus_client().paginate = mock.MagicMock(side_effect=[roles_response])
+                side_effects = [["fake-role", "fake-role-2"]]
+                fus_client().paginate = mock.MagicMock(side_effect=side_effects)
 
                 # list_fus_role_policies then calls get_fus_role_attached_policies()
                 # to get a list of policies attached to the role,
                 # which calls call_api() for each role returned by the paginate command
-                policy_doc_r1 = '{"Id": "fake-role-policy"}'
-                policy_doc_r2 = '{"Id": "fake-role-2-policy"}'
-                fus_client().call_api = mock.MagicMock(
-                    side_effect=[
-                        _wrap_policy(policy_doc_r1),
-                        _wrap_policy(policy_doc_r2),
-                    ]
-                )
+                policy_docs = ['{"Id": "fake-role-policy"}', '{"Id": "fake-role-2-policy"}']
+                fus_client().call_api = mock.MagicMock(side_effect=[_wrap_policy(doc) for doc in policy_docs])
 
             with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
 
                 # List fusillade policies grouped by roles
                 with CaptureStdout() as output:
                     _repatch_fus_client_roles(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="roles",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=False,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="roles")
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-role-2", "fake-role-2-policy"]), output)
 
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client_roles(fus_client)
-                    iam.list_policies(
-                        [],
-                        argparse.Namespace(
-                            cloud_provider="fusillade",
-                            group_by="roles",
-                            output=None,
-                            force=False,
-                            include_managed=False,
-                            exclude_headers=True,
-                            quiet=True,
-                            stage=None,
-                        ),
-                    )
+                    kwargs = _get_fus_list_policies_kwargs(group_by="roles", exclude_headers=True)
+                    iam.list_policies([], argparse.Namespace(**kwargs))
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)
                 self.assertIn(IAMSEPARATOR.join(["fake-role-2", "fake-role-2-policy"]), output)
 
@@ -1006,19 +769,8 @@ class TestOperations(unittest.TestCase):
                 temp_prefix = "dss-test-operations-iam-list-roles-temp-output"
                 f, fname = tempfile.mkstemp(prefix=temp_prefix)
                 _repatch_fus_client_roles(fus_client)
-                iam.list_policies(
-                    [],
-                    argparse.Namespace(
-                        cloud_provider="fusillade",
-                        group_by="roles",
-                        output=fname,
-                        force=True,
-                        include_managed=False,
-                        exclude_headers=False,
-                        quiet=True,
-                        stage=None,
-                    ),
-                )
+                kwargs = _get_fus_list_policies_kwargs(group_by="roles", output=fname, force=True)
+                iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
                 self.assertIn(IAMSEPARATOR.join(["fake-role", "fake-role-policy"]), output)


### PR DESCRIPTION
This PR refactors the dss-ops IAM action and associated tests.

- rearrange functions in dss ops iam to be used across more of the code
- reduce copypasta and multiple functions related to users/groups/roles into single function calls for "assets" with keyword indicating "asset type"
- pack up and parameterize redundant keyword arguments passed to tests

This is a refactor only