### PR TITLE
Use stage in dss-events-scribe CloudWatch rule name

### DIFF
--- a/daemons/dss-events-scribe/app.py
+++ b/daemons/dss-events-scribe/app.py
@@ -24,6 +24,7 @@ from dss.events import journal_flashflood, update_flashflood
 configure_lambda_logging()
 logger = logging.getLogger(__name__)
 dss.Config.set_config(dss.BucketConfig.NORMAL)
+stage = os.environ['DSS_DEPLOYMENT_STAGE']
 
 app = domovoi.Domovoi()
 
@@ -37,10 +38,10 @@ class ReplicaStatus:
         self.prefix = prefix
 
 
-@app.scheduled_function("rate(10 minutes)")
-def dss_events_scribe_journal_and_update(event, context):
+@app.scheduled_function("rate(10 minutes)", rule_name=f"dss-events-scribe-journal-and-update-{stage}")
+def journal_and_update(event, context):
     # TODO: Make this configurable
-    minimum_number_of_events = 10 if "dev" == os.environ['DSS_DEPLOYMENT_STAGE'] else 1000
+    minimum_number_of_events = 10 if "dev" == stage else 1000
 
     def lambda_seconds_remaining() -> float:
         # lambda time to live is configured with `lambda_timeout` in `daemons/dss-events-scribe/.chalice/config.json`

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -234,7 +234,7 @@ class TestEvents(unittest.TestCase, DSSAssertMixin):
         return results
 
 class TestEventsDaemon(unittest.TestCase, DSSAssertMixin):
-    def test_dss_events_scribe_journal_and_update(self):
+    def test_journal_and_update(self):
         journal_flashflood_returns = {r.flashflood_prefix_read: [True, False] for r in Replica}
         update_flashflood_returns = {r.flashflood_prefix_read: [1, 0] for r in Replica}
 
@@ -253,13 +253,13 @@ class TestEventsDaemon(unittest.TestCase, DSSAssertMixin):
             def get_remaining_time_in_millis(self):
                 return 300 * 1000
 
-        daemon_app.dss_events_scribe_journal_and_update({}, Context())
+        daemon_app.journal_and_update({}, Context())
         for pfx in journal_flashflood_returns:
             self.assertEqual(0, len(journal_flashflood_returns[pfx]))
         for pfx in update_flashflood_returns:
             self.assertEqual(0, len(update_flashflood_returns[pfx]))
 
-    def test_dss_events_scribe_journal_and_update_timeout(self):
+    def test_journal_and_update_timeout(self):
         class Context:
             def get_remaining_time_in_millis(self):
                 return 0.0
@@ -267,7 +267,7 @@ class TestEventsDaemon(unittest.TestCase, DSSAssertMixin):
         with mock.patch("daemons.dss-events-scribe.app.journal_flashflood", side_effect=Exception()):
             with mock.patch("daemons.dss-events-scribe.app.update_flashflood", side_effect=Exception()):
                 # This should timeout and not call journal_flashflood or update_flashflood
-                daemon_app.dss_events_scribe_journal_and_update({}, Context())
+                daemon_app.journal_and_update({}, Context())
 
 def _upload_bundle(app, replica, uuid=None):
     files = list()


### PR DESCRIPTION
Unless the rule name is parameterized by stage, all stages will share the same rule.