### PR TITLE
[easy] Lowercase uuid prefixes for GET /bundles/all.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1486,7 +1486,10 @@ paths:
           enum: [aws, gcp]
         - name: prefix
           in: query
-          description: Is used to specify the beginning of a particular bundle UUID. Specifying a character(s) would provide all avaliable bundles starting with that character(s).
+          description: >
+          Used to specify the beginning of a particular bundle UUID.  Capitalized letters will be lower-cased as is
+          done when users submit a uuid (all uuids have lower-cased letters upon ingestion into the dss).
+          Specifying a character(s) would provide all avaliable bundles starting with that character(s).
           required: false
           type: string
         - name: token

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1487,9 +1487,9 @@ paths:
         - name: prefix
           in: query
           description: >
-          Used to specify the beginning of a particular bundle UUID.  Capitalized letters will be lower-cased as is
-          done when users submit a uuid (all uuids have lower-cased letters upon ingestion into the dss).
-          Specifying a character(s) would provide all avaliable bundles starting with that character(s).
+            Used to specify the beginning of a particular bundle UUID.  Capitalized letters will be lower-cased as is
+            done when users submit a uuid (all uuids have lower-cased letters upon ingestion into the dss).
+            Specifying a character(s) would provide all avaliable bundles starting with that character(s).
           required: false
           type: string
         - name: token

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -151,9 +151,8 @@ def enumerate(replica: str,
     :param per_page: max items per page to show, 10 <= per_page <= 500
     :param search_after: used to page searches, should not be set by the user.
     """
-
     if prefix:
-        search_prefix = f'{BUNDLE_PREFIX}/{prefix}'
+        search_prefix = f'{BUNDLE_PREFIX}/{prefix.lower()}'
     else:
         search_prefix = f'{BUNDLE_PREFIX}/'
     api_domain_name = f'https://{os.environ.get("API_DOMAIN_NAME")}'


### PR DESCRIPTION
When calling GET /bundles/all with the prefix `bundles/f` and `bundles/F`, the former gives search results and the latter does not.

Since we lowercase uuids for users when they submit them, we should also probably lowercase them when that user searches for that same uuid (or uuid prefix).

See https://github.com/HumanCellAtlas/data-store/issues/2643