### PR TITLE
[easy] Add tests for GET /bundles/all prefixes and syntax checking.

### DIFF
--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1488,9 +1488,12 @@ paths:
           in: query
           description: >
             Used to specify the beginning of a particular bundle UUID.  Capitalized letters will be lower-cased as is
-            done when users submit a uuid (all uuids have lower-cased letters upon ingestion into the dss).
-            Specifying a character(s) would provide all avaliable bundles starting with that character(s).
+            done when users submit a uuid (all uuids have lower-cased letters upon ingestion into the dss).  Characters
+            other than letters, numbers, and dashes are not allowed and will error.
+
+            The specified character(s) will return all available bundle uuids starting with that character(s).
           required: false
+          pattern: '^[a-zA-Z0-9-]+$'
           type: string
         - name: token
           in: query

--- a/dss-api.yml
+++ b/dss-api.yml
@@ -1493,7 +1493,7 @@ paths:
 
             The specified character(s) will return all available bundle uuids starting with that character(s).
           required: false
-          pattern: '^[a-zA-Z0-9-]+$'
+          pattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*$'
           type: string
         - name: token
           in: query

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -152,9 +152,6 @@ def enumerate(replica: str,
     :param search_after: used to page searches, should not be set by the user.
     """
     if prefix:
-        if any(c.isupper() for c in prefix):
-            sys.stderr.write('Note: prefix contains capital letters!  All data-store UUIDs are lower-cased (even if '
-                             'submitted as upper-case).  Supplied prefix will be lower-cased,')
         search_prefix = f'{BUNDLE_PREFIX}/{prefix.lower()}'
     else:
         search_prefix = f'{BUNDLE_PREFIX}/'

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import json
 import time

--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -1,4 +1,4 @@
-import io
+import sys
 import os
 import json
 import time
@@ -152,6 +152,9 @@ def enumerate(replica: str,
     :param search_after: used to page searches, should not be set by the user.
     """
     if prefix:
+        if any(c.isupper() for c in prefix):
+            sys.stderr.write('Note: prefix contains capital letters!  All data-store UUIDs are lower-cased (even if '
+                             'submitted as upper-case).  Supplied prefix will be lower-cased,')
         search_prefix = f'{BUNDLE_PREFIX}/{prefix.lower()}'
     else:
         search_prefix = f'{BUNDLE_PREFIX}/'

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1020,6 +1020,12 @@ class TestBundleApi(unittest.TestCase, TestAuthMixin, DSSAssertMixin, DSSUploadM
             self.assertIn(res.json()['bundles'][0]['uuid'], res.json()['search_prefix'])
             self.assertEquals(res.status_code, requests.codes.okay)
 
+        with self.subTest('Test successful case finds full uuid prefix when upper-cased.'):
+            res = self.app.get(f"/v1/bundles/all", params=dict(replica="aws", per_page=10, prefix=bundle_uuid.upper()))
+            self.assertEquals(res.json()['bundles'][0]['uuid'], bundle_uuid)
+            self.assertIn(res.json()['bundles'][0]['uuid'], res.json()['search_prefix'])
+            self.assertEquals(res.status_code, requests.codes.okay)
+
         with self.subTest('Test successful case finds partial uuid prefix.'):
             partial_uuid = bundle_uuid[:8]
             res = self.app.get(f"/v1/bundles/all", params=dict(replica="aws", per_page=10, prefix=partial_uuid))


### PR DESCRIPTION
After speaking with @jessebrennan , this further checks syntax and adds tests for prefixes supplied to `GET /bundles/all`.