### PR TITLE
Eventually see dynamodb result for subscription owner.

### DIFF
--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -100,7 +100,7 @@ class TestSubscriptionsBase(ElasticsearchTestCase, TestAuthMixin, DSSAssertMixin
 
     @eventually(timeout=5, interval=1, errors={AssertionError})
     def assert_owner_subscription_count(self, owner, replica, subscription_count):
-        assert count_subscriptions_for_owner(Replica[replica], owner) == subscription_count
+        self.assertEquals(count_subscriptions_for_owner(Replica[replica], owner), subscription_count)
 
     def test_db_count_subscriptions_for_owner(self):
         """Test dynamoDB helper functions used to store and retrieve subscription information."""


### PR DESCRIPTION
These pass locally for me so I'd like to see if this fixes our recent test failures:
https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/data-store/-/jobs/58183
https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/data-store/-/jobs/58162
