### PR TITLE
Update terraform files to address deprecation warnings.

### DIFF
--- a/infra/async_state_db/main.tf
+++ b/infra/async_state_db/main.tf
@@ -4,10 +4,10 @@ locals {
   common_tags = "${map(
     "managedBy" , "terraform",
     "Name"      , "${var.DSS_INFRA_TAG_SERVICE}-asyncdynamodb",
-    "project"   , "${var.DSS_INFRA_TAG_PROJECT}",
-    "env"       , "${var.DSS_DEPLOYMENT_STAGE}",
-    "service"   , "${var.DSS_INFRA_TAG_SERVICE}",
-    "owner"     , "${var.DSS_INFRA_TAG_OWNER}"
+    "project"   , var.DSS_INFRA_TAG_PROJECT,
+    "env"       , var.DSS_DEPLOYMENT_STAGE,
+    "service"   , var.DSS_INFRA_TAG_SERVICE,
+    "owner"     , var.DSS_INFRA_TAG_OWNER
   )}"
 }
 
@@ -26,5 +26,5 @@ resource "aws_dynamodb_table" "sfn_state" {
     type = "S"
   }
 
-  tags = "${local.common_tags}"
+  tags = local.common_tags
 }

--- a/infra/buckets/gs.tf
+++ b/infra/buckets/gs.tf
@@ -1,50 +1,50 @@
 resource google_storage_bucket dss_gs_bucket {
-  name          = "${var.DSS_GS_BUCKET}"
-  provider      = "google"
+  name          = var.DSS_GS_BUCKET
+  provider      = google
   location      = "US"
   storage_class = "MULTI_REGIONAL"
-  labels = "${merge(local.common_tags, local.gcp_tags)}"
+  labels = merge(local.common_tags, local.gcp_tags)
 }
 
 resource google_storage_bucket dss_gs_bucket_test {
-  count         = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  name          = "${var.DSS_GS_BUCKET_TEST}"
-  provider      = "google"
+  count         = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  name          = var.DSS_GS_BUCKET_TEST
+  provider      = google
   location      = "US"
   storage_class = "MULTI_REGIONAL"
-  labels = "${merge(local.common_tags, local.gcp_tags)}"
+  labels = merge(local.common_tags, local.gcp_tags)
   lifecycle_rule {
     action {
       type = "Delete"
     }
     condition {
-      age = "${var.DSS_BLOB_TTL_DAYS}"
+      age = var.DSS_BLOB_TTL_DAYS
       with_state = "LIVE"
     }
   }
 }
 
 resource google_storage_bucket dss_gs_bucket_test_fixtures {
-  count         = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  name          = "${var.DSS_GS_BUCKET_TEST_FIXTURES}"
-  provider      = "google"
+  count         = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  name          = var.DSS_GS_BUCKET_TEST_FIXTURES
+  provider      = google
   location      = "US"
   storage_class = "MULTI_REGIONAL"
-  labels = "${merge(local.common_tags, local.gcp_tags)}"
+  labels = merge(local.common_tags, local.gcp_tags)
 }
 
 resource google_storage_bucket dss_gs_checkout_bucket {
-  name          = "${var.DSS_GS_CHECKOUT_BUCKET}"
-  provider      = "google"
+  name          = var.DSS_GS_CHECKOUT_BUCKET
+  provider      = google
   location      = "US"
   storage_class = "MULTI_REGIONAL"
-  labels = "${merge(local.common_tags, local.gcp_tags)}"
+  labels = merge(local.common_tags, local.gcp_tags)
   lifecycle_rule {
     action {
       type = "Delete"
     }
     condition {
-      age = "${var.DSS_BLOB_TTL_DAYS}"
+      age = var.DSS_BLOB_TTL_DAYS
       matches_storage_class = ["STANDARD"]
       with_state = "LIVE"
     }
@@ -52,7 +52,7 @@ resource google_storage_bucket dss_gs_checkout_bucket {
 }
 
 locals {
-  checkout_bucket_viewers = "${compact(split(",", var.DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS))}"
+  checkout_bucket_viewers = compact(split(",", var.DSS_CHECKOUT_BUCKET_OBJECT_VIEWERS))
   gcp_tags = "${map(
     "name"      , "${var.DSS_INFRA_TAG_SERVICE}-gs-storage",
     "owner"     , "${element(split("@", var.DSS_INFRA_TAG_OWNER),0)}",
@@ -61,43 +61,43 @@ locals {
 }
 
 resource "google_storage_bucket_iam_member" "checkout_viewer" {
-  count  = "${length(local.checkout_bucket_viewers)}"
-  bucket = "${google_storage_bucket.dss_gs_checkout_bucket.name}"
+  count  = length(local.checkout_bucket_viewers)
+  bucket = google_storage_bucket.dss_gs_checkout_bucket.name
   role   = "roles/storage.objectViewer"
-  member = "${local.checkout_bucket_viewers[count.index]}"
+  member = local.checkout_bucket_viewers[count.index]
 }
 
 resource google_storage_bucket dss_gs_checkout_bucket_test {
-  count         = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  name          = "${var.DSS_GS_CHECKOUT_BUCKET_TEST}"
-  provider      = "google"
+  count         = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  name          = var.DSS_GS_CHECKOUT_BUCKET_TEST
+  provider      = google
   location      = "US"
   storage_class = "MULTI_REGIONAL"
-  labels = "${merge(local.common_tags, local.gcp_tags)}"
+  labels = merge(local.common_tags, local.gcp_tags)
   lifecycle_rule {
     action {
       type = "Delete"
     }
     condition {
-      age = "${var.DSS_BLOB_TTL_DAYS}"
+      age = var.DSS_BLOB_TTL_DAYS
       with_state = "LIVE"
     }
   }
 }
 
 resource google_storage_bucket dss_gs_checkout_bucket_test_user {
-  count         = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  name          = "${var.DSS_GS_CHECKOUT_BUCKET_TEST_USER}"
-  provider      = "google"
+  count         = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  name          = var.DSS_GS_CHECKOUT_BUCKET_TEST_USER
+  provider      = google
   location      = "US"
   storage_class = "MULTI_REGIONAL"
-  labels = "${merge(local.common_tags, local.gcp_tags)}"
+  labels = merge(local.common_tags, local.gcp_tags)
   lifecycle_rule {
     action {
       type = "Delete"
     }
     condition {
-      age = "${var.DSS_BLOB_TTL_DAYS}"
+      age = var.DSS_BLOB_TTL_DAYS
       with_state = "LIVE"
     }
   }

--- a/infra/buckets/s3.tf
+++ b/infra/buckets/s3.tf
@@ -14,8 +14,8 @@ locals {
 }
 
 resource aws_s3_bucket dss_s3_bucket {
-  count = "${length(var.DSS_S3_BUCKET) > 0 ? 1 : 0}"
-  bucket = "${var.DSS_S3_BUCKET}"
+  count = length(var.DSS_S3_BUCKET) > 0 ? 1 : 0
+  bucket = var.DSS_S3_BUCKET
   server_side_encryption_configuration {
     rule {
 	  apply_server_side_encryption_by_default {
@@ -23,32 +23,32 @@ resource aws_s3_bucket dss_s3_bucket {
       }
     }
   }
-  tags = "${merge(local.common_tags, local.aws_tags)}"
+  tags = merge(local.common_tags, local.aws_tags)
 }
 
 resource aws_s3_bucket dss_s3_bucket_test {
-  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  bucket = "${var.DSS_S3_BUCKET_TEST}"
+  count = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  bucket = var.DSS_S3_BUCKET_TEST
   lifecycle_rule {
     id = "prune old things"
     enabled = true
-    abort_incomplete_multipart_upload_days = "${var.DSS_BLOB_TTL_DAYS}"
+    abort_incomplete_multipart_upload_days = var.DSS_BLOB_TTL_DAYS
     expiration {
-      days = "${var.DSS_BLOB_TTL_DAYS}"
+      days = var.DSS_BLOB_TTL_DAYS
     }
   }
-  tags = "${merge(local.common_tags, local.aws_tags)}"
+  tags = merge(local.common_tags, local.aws_tags)
 }
 
 resource aws_s3_bucket dss_s3_bucket_test_fixtures {
-  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  bucket = "${var.DSS_S3_BUCKET_TEST_FIXTURES}"
-  tags = "${merge(local.common_tags, local.aws_tags)}"
+  count = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  bucket = var.DSS_S3_BUCKET_TEST_FIXTURES
+  tags = merge(local.common_tags, local.aws_tags)
 }
 
 resource aws_s3_bucket dss_s3_checkout_bucket {
-  count = "${length(var.DSS_S3_CHECKOUT_BUCKET) > 0 ? 1 : 0}"
-  bucket = "${var.DSS_S3_CHECKOUT_BUCKET}"
+  count = length(var.DSS_S3_CHECKOUT_BUCKET) > 0 ? 1 : 0
+  bucket = var.DSS_S3_CHECKOUT_BUCKET
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -63,15 +63,15 @@ resource aws_s3_bucket dss_s3_checkout_bucket {
       "uncached" = "true"
     }
     expiration {
-      days = "${var.DSS_BLOB_TTL_DAYS}"
+      days = var.DSS_BLOB_TTL_DAYS
     }
   }
   lifecycle_rule {
     id = "failed multipart cleanup"
     enabled = true
-    abort_incomplete_multipart_upload_days = "${var.DSS_BLOB_TTL_DAYS}"
+    abort_incomplete_multipart_upload_days = var.DSS_BLOB_TTL_DAYS
   }
-  tags = "${merge(local.common_tags, local.aws_tags)}"
+  tags = merge(local.common_tags, local.aws_tags)
   cors_rule {
     allowed_methods = [
       "HEAD",
@@ -88,37 +88,37 @@ resource aws_s3_bucket dss_s3_checkout_bucket {
 }
 
 resource aws_s3_bucket dss_s3_checkout_bucket_test {
-  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  bucket = "${var.DSS_S3_CHECKOUT_BUCKET_TEST}"
+  count = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  bucket = var.DSS_S3_CHECKOUT_BUCKET_TEST
   lifecycle_rule {
     id = "dss_checkout_expiration"
     enabled = true
-    abort_incomplete_multipart_upload_days = "${var.DSS_BLOB_TTL_DAYS}"
+    abort_incomplete_multipart_upload_days = var.DSS_BLOB_TTL_DAYS
     expiration {
-      days = "${var.DSS_BLOB_TTL_DAYS}"
+      days = var.DSS_BLOB_TTL_DAYS
     }
   }
-  tags = "${merge(local.common_tags, local.aws_tags)}"
+  tags = merge(local.common_tags, local.aws_tags)
 }
 
 resource aws_s3_bucket dss_s3_checkout_bucket_test_user {
-  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  bucket = "${var.DSS_S3_CHECKOUT_BUCKET_TEST_USER}"
+  count = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  bucket = var.DSS_S3_CHECKOUT_BUCKET_TEST_USER
   lifecycle_rule {
     id = "dss_checkout_expiration"
     enabled = true
-    abort_incomplete_multipart_upload_days = "${var.DSS_BLOB_TTL_DAYS}"
+    abort_incomplete_multipart_upload_days = var.DSS_BLOB_TTL_DAYS
     expiration {
-      days = "${var.DSS_BLOB_TTL_DAYS}"
+      days = var.DSS_BLOB_TTL_DAYS
     }
   }
-  tags = "${merge(local.common_tags, local.aws_tags)}"
+  tags = merge(local.common_tags, local.aws_tags)
 }
 
 resource aws_s3_bucket dss_s3_checkout_bucket_unwritable {
-  count = "${var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0}"
-  bucket = "${var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE}"
-  tags = "${merge(local.common_tags, local.aws_tags)}"
+  count = var.DSS_DEPLOYMENT_STAGE == "dev" ? 1 : 0
+  bucket = var.DSS_S3_CHECKOUT_BUCKET_UNWRITABLE
+  tags = merge(local.common_tags, local.aws_tags)
   policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -152,8 +152,8 @@ POLICY
 }
 
 resource aws_s3_bucket dss_s3_events_bucket {
-  count = "${length(var.DSS_FLASHFLOOD_BUCKET) > 0 ? 1 : 0}"
-  bucket = "${var.DSS_FLASHFLOOD_BUCKET}"
+  count = length(var.DSS_FLASHFLOOD_BUCKET) > 0 ? 1 : 0
+  bucket = var.DSS_FLASHFLOOD_BUCKET
   server_side_encryption_configuration {
     rule {
 	  apply_server_side_encryption_by_default {
@@ -171,5 +171,5 @@ resource aws_s3_bucket dss_s3_events_bucket {
       days = "1"
     }
   }
-  tags = "${merge(local.common_tags, local.aws_tags)}"
+  tags = merge(local.common_tags, local.aws_tags)
 }

--- a/infra/collections_db/main.tf
+++ b/infra/collections_db/main.tf
@@ -31,5 +31,5 @@ resource "aws_dynamodb_table" "collections-db-aws" {
     type = "S"
   }
 
-  tags = "${local.common_tags}"
+  tags = local.common_tags
 }

--- a/infra/domain/main.tf
+++ b/infra/domain/main.tf
@@ -1,12 +1,12 @@
 data aws_caller_identity current {}
-locals {account_id = "${data.aws_caller_identity.current.account_id}"}
+locals {account_id = data.aws_caller_identity.current.account_id}
 
 data aws_route53_zone selected {
-  name = "${var.DSS_ZONE_NAME}"
+  name = var.DSS_ZONE_NAME
 }
 
 resource "aws_api_gateway_domain_name" "dss" {
-  domain_name               = "${var.API_DOMAIN_NAME}"
+  domain_name               = var.API_DOMAIN_NAME
   regional_certificate_arn  = "arn:aws:acm:${var.AWS_DEFAULT_REGION}:${local.account_id}:certificate/${var.ACM_CERTIFICATE_IDENTIFIER}"
 
   endpoint_configuration {
@@ -15,9 +15,9 @@ resource "aws_api_gateway_domain_name" "dss" {
 }
 
 resource "aws_route53_record" "dss" {
-  zone_id = "${data.aws_route53_zone.selected.zone_id}"
-  name    = "${var.API_DOMAIN_NAME}"
+  zone_id = data.aws_route53_zone.selected.zone_id
+  name    = var.API_DOMAIN_NAME
   type    = "CNAME"
   ttl     = "300"
-  records = ["${aws_api_gateway_domain_name.dss.regional_domain_name}"]
+  records = [aws_api_gateway_domain_name.dss.regional_domain_name]
 }

--- a/infra/dss-events-scribe/main.tf
+++ b/infra/dss-events-scribe/main.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "sqs" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values = ["${aws_cloudwatch_event_rule.events-scribe.arn}"]
+      values = [aws_cloudwatch_event_rule.events-scribe.arn]
     }
   }
   statement {
@@ -51,23 +51,23 @@ data "aws_iam_policy_document" "sqs" {
 
 resource "aws_sqs_queue" "dss-events-scribe-queue" {
   name   					 = "dss-events-scribe-${var.DSS_DEPLOYMENT_STAGE}"
-  tags   					 = "${local.common_tags}"
+  tags   					 = local.common_tags
   message_retention_seconds  = "3600"
   visibility_timeout_seconds = "600"
-  policy 					 = "${data.aws_iam_policy_document.sqs.json}"
+  policy 					 = data.aws_iam_policy_document.sqs.json
 }
 
 resource "aws_cloudwatch_event_rule" "events-scribe" {
   name 		  		  = "dss-events-scribe-${var.DSS_DEPLOYMENT_STAGE}"
   description 		  = "Queue event journal/update"
   schedule_expression = "rate(10 minutes)"
-  tags 				  = "${local.common_tags}"
+  tags 				  = local.common_tags
 }
 
 resource "aws_cloudwatch_event_target" "send-journal-and-update-message" {
-  count = "${length(local.replicas)}"
-  rule  = "${aws_cloudwatch_event_rule.events-scribe.name}"
-  arn   = "${aws_sqs_queue.dss-events-scribe-queue.arn}"
+  count = length(local.replicas)
+  rule  = aws_cloudwatch_event_rule.events-scribe.name
+  arn   = aws_sqs_queue.dss-events-scribe-queue.arn
   input = <<-DOC
   {
     "replica":"${local.replicas[count.index]}"

--- a/infra/elasticsearch/access_ips.tf
+++ b/infra/elasticsearch/access_ips.tf
@@ -3,6 +3,6 @@ data "aws_secretsmanager_secret_version" "source_ips" {
 }
 
 locals {
-  ips_str = "${data.aws_secretsmanager_secret_version.source_ips.secret_string}"
-  access_ips = "${compact(split(",", local.ips_str))}"
+  ips_str = data.aws_secretsmanager_secret_version.source_ips.secret_string
+  access_ips = compact(split(",", local.ips_str))
 }

--- a/infra/elasticsearch/main.tf
+++ b/infra/elasticsearch/main.tf
@@ -16,19 +16,19 @@ locals {
 resource "aws_cloudwatch_log_group" "es_index_log" {
   name = "/aws/aes/domains/${var.DSS_ES_DOMAIN}/es-index-${var.DSS_DEPLOYMENT_STAGE}-logs"
   retention_in_days = 1827
-  tags = "${local.common_tags}"
+  tags = local.common_tags
 }
 
 resource "aws_cloudwatch_log_group" "es_search_log" {
   name = "/aws/aes/domains/${var.DSS_ES_DOMAIN}/es-search-${var.DSS_DEPLOYMENT_STAGE}-logs"
   retention_in_days = 1827
-  tags = "${local.common_tags}"
+  tags = local.common_tags
 }
 
 resource "aws_cloudwatch_log_group" "es_application_log" {
   name = "/aws/aes/domains/${var.DSS_ES_DOMAIN}/es-application-${var.DSS_DEPLOYMENT_STAGE}-logs"
   retention_in_days = 1827
-  tags = "${local.common_tags}"
+  tags = local.common_tags
 }
 
 data "aws_iam_policy_document" "dss_es_cloudwatch_policy_document" {
@@ -42,17 +42,17 @@ data "aws_iam_policy_document" "dss_es_cloudwatch_policy_document" {
       "logs:CreateLogStream"
     ]
     resources = [
-      "${aws_cloudwatch_log_group.es_index_log.arn}",
-      "${aws_cloudwatch_log_group.es_search_log.arn}",
-      "${aws_cloudwatch_log_group.es_application_log.arn}"
+      aws_cloudwatch_log_group.es_index_log.arn,
+      aws_cloudwatch_log_group.es_search_log.arn,
+      aws_cloudwatch_log_group.es_application_log.arn
     ]
   }
 }
 
 resource "aws_cloudwatch_log_resource_policy" "dss_es_cloudwatch_policy" {
-  count = "${var.DSS_ES_DOMAIN_INDEX_LOGS_ENABLED == true ? 1 : 0}"
-  policy_name = "${var.DSS_ES_DOMAIN}"
-  policy_document = "${data.aws_iam_policy_document.dss_es_cloudwatch_policy_document.json}"
+  count = var.DSS_ES_DOMAIN_INDEX_LOGS_ENABLED == true ? 1 : 0
+  policy_name = var.DSS_ES_DOMAIN
+  policy_document = data.aws_iam_policy_document.dss_es_cloudwatch_policy_document.json
 }
 
 data "aws_iam_policy_document" "dss_es_access_policy_documennt" {
@@ -75,19 +75,19 @@ data "aws_iam_policy_document" "dss_es_access_policy_documennt" {
     condition {
       test = "IpAddress"
       variable = "aws:SourceIp"
-      values = "${local.access_ips}"
+      values = local.access_ips
     }
   }
 }
 
 resource aws_elasticsearch_domain elasticsearch {
-  count = "${length(var.DSS_ES_DOMAIN) > 0 ? 1 : 0}"
-  domain_name = "${var.DSS_ES_DOMAIN}"
+  count = length(var.DSS_ES_DOMAIN) > 0 ? 1 : 0
+  domain_name = var.DSS_ES_DOMAIN
   elasticsearch_version = "5.5"
 
   cluster_config {
-    instance_type = "${var.DSS_ES_INSTANCE_TYPE}"
-	instance_count = "${var.DSS_ES_INSTANCE_COUNT}"
+    instance_type = var.DSS_ES_INSTANCE_TYPE
+	instance_count = var.DSS_ES_INSTANCE_COUNT
   }
 
   advanced_options = {
@@ -97,37 +97,37 @@ resource aws_elasticsearch_domain elasticsearch {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp2"
-    volume_size = "${var.DSS_ES_VOLUME_SIZE}"
+    volume_size = var.DSS_ES_VOLUME_SIZE
   }
 
   log_publishing_options {
-    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.es_index_log.arn}"
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.es_index_log.arn
     log_type = "INDEX_SLOW_LOGS"
-    enabled = "${var.DSS_ES_DOMAIN_INDEX_LOGS_ENABLED}"
+    enabled = var.DSS_ES_DOMAIN_INDEX_LOGS_ENABLED
   }
 
   log_publishing_options {
-    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.es_search_log.arn}"
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.es_search_log.arn
     log_type = "SEARCH_SLOW_LOGS"
-    enabled = "${var.DSS_ES_DOMAIN_INDEX_LOGS_ENABLED}"
+    enabled = var.DSS_ES_DOMAIN_INDEX_LOGS_ENABLED
   }
 
   log_publishing_options {
-    cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.es_application_log.arn}"
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.es_application_log.arn
     log_type = "ES_APPLICATION_LOGS"
-    enabled = "${var.DSS_ES_DOMAIN_INDEX_LOGS_ENABLED}"
+    enabled = var.DSS_ES_DOMAIN_INDEX_LOGS_ENABLED
   }
 
   snapshot_options {
     automated_snapshot_start_hour = 23
   }
 
-    tags = "${merge(
+    tags = merge(
         local.common_tags,
         map(
            "Domain", "${var.DSS_ES_DOMAIN}"
         )
-    )}"
+    )
 
-  access_policies = "${data.aws_iam_policy_document.dss_es_access_policy_documennt.json}"
+  access_policies = data.aws_iam_policy_document.dss_es_access_policy_documennt.json
 }

--- a/infra/gcp_service_account/main.tf
+++ b/infra/gcp_service_account/main.tf
@@ -1,49 +1,49 @@
 data "google_project" "project" {}
 
 resource "google_service_account" "dss" {
-  display_name = "${var.DSS_GCP_SERVICE_ACCOUNT_NAME}"
-  account_id = "${var.DSS_GCP_SERVICE_ACCOUNT_NAME}"
+  display_name = var.DSS_GCP_SERVICE_ACCOUNT_NAME
+  account_id = var.DSS_GCP_SERVICE_ACCOUNT_NAME
 }
 
 # Useful command to discover role names (Guessing based on console titles is difficult):
 # `gcloud iam list-grantable-roles //cloudresourcemanager.googleapis.com/projects/{project-id}`
 
 resource "google_project_iam_member" "serviceaccountactor" {
-  project = "${data.google_project.project.project_id}"
+  project = data.google_project.project.project_id
   role    = "roles/iam.serviceAccountActor"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 resource "google_project_iam_member" "cloudruntimeconfiguratoradmin" {
-  project = "${data.google_project.project.project_id}"
+  project = data.google_project.project.project_id
   role    = "roles/runtimeconfig.admin"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 resource "google_project_iam_member" "storageadmin" {
-  project = "${data.google_project.project.project_id}"
+  project = data.google_project.project.project_id
   role    = "roles/storage.admin"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 resource "google_project_iam_member" "storageobjectcreator" {
-  project = "${data.google_project.project.project_id}"
+  project = data.google_project.project.project_id
   role    = "roles/storage.objectCreator"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 resource "google_project_iam_member" "cloudfunctionsdeveloper" {
-  project = "${data.google_project.project.project_id}"
+  project = data.google_project.project.project_id
   role    = "roles/cloudfunctions.developer"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 resource "google_project_iam_member" "viewer" {
-  project = "${data.google_project.project.project_id}"
+  project = data.google_project.project.project_id
   role    = "roles/viewer"
   member  = "serviceAccount:${google_service_account.dss.email}"
 }
 
 output "service_account" {
-  value = "${var.DSS_GCP_SERVICE_ACCOUNT_NAME}"
+  value = var.DSS_GCP_SERVICE_ACCOUNT_NAME
 }

--- a/infra/subscription_v2_db/main.tf
+++ b/infra/subscription_v2_db/main.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 resource "aws_dynamodb_table" "subscriptions-aws" {
-  count        = "${length(local.replicas)}"
+  count        = length(local.replicas)
   name         = "dss-subscriptions-v2-${local.replicas[count.index]}-${var.DSS_DEPLOYMENT_STAGE}"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "hash_key"
@@ -35,5 +35,5 @@ resource "aws_dynamodb_table" "subscriptions-aws" {
     type = "S"
   }
 
-  tags = "${local.common_tags}"
+  tags = local.common_tags
 }


### PR DESCRIPTION
Terraform generates 100 billion warnings since we updated to `0.12.16`.  This should address them and bring our scripts up to date.

Issue: #2671