### PR TITLE
[easy] Add check for terraform version.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -21,6 +21,7 @@ $(error Please run make commands from a Python 3.6 virtualenv)
 endif
 
 
-ifeq ($(findstring Terraform v0.12.16, $(shell terraform --version 2>&1)),)
+ifeq ($(findstring terraform, $(shell which terraform 2>&1)),)
+else ifeq ($(findstring Terraform v0.12.16, $(shell terraform --version 2>&1)),)
 $(error You must use Terraform v0.12.16, please check your terraform version.)
 endif

--- a/common.mk
+++ b/common.mk
@@ -19,3 +19,8 @@ endif
 ifeq ($(findstring Python 3.6, $(shell python --version 2>&1)),)
 $(error Please run make commands from a Python 3.6 virtualenv)
 endif
+
+
+ifeq ($(findstring Terraform v0.12.16, $(shell terraform --version 2>&1)),)
+$(error You must use Terraform v0.12.16, please check your terraform version.)
+endif


### PR DESCRIPTION
So that we don't accidentally upgrade our system.  Behavior now looks like:

```(v3nv) quokka@qcore:~/update-terraform-warnings/data-store$ make plan-infra
common.mk:25: *** You must use Terraform v0.12.16, please check your terraform version..  Stop.```