### PR TITLE
Add setup/check fusillade steps to prod CI/CD

### DIFF
--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -33,19 +33,15 @@ setup_fusillade:
   script:
     - git clone -b master https://github.com/HumanCellAtlas/dcp-fusillade.git
     - cd dcp-fusillade
-# currently, there is no environment.production in the dcp-fusillade repo
-    - source environment # && source environment.production
+# currently, there is no environment.prod in the dcp-fusillade repo
+    - source environment # && source environment.prod
     - cd ..
     - source environment
     - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then
     -   source environment.$CI_COMMIT_REF_NAME
     - fi
     - cat ./roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
-    - if [ "$DSS_DEPLOYMENT_STAGE" == "prod" ]; then
-    -   FUS_STAGE='production'
-    - else
-    -   FUS_STAGE=$DSS_DEPLOYMENT_STAGE
-    - fi
+    - FUS_STAGE=$DSS_DEPLOYMENT_STAGE
     - python -m json.tool ./temp-roles.json > /dev/null || exit 1
     - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force $FUS_STAGE
     - scripts/check_fusillade.py $FUS_STAGE

--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -33,8 +33,8 @@ setup_fusillade:
   script:
     - git clone -b master https://github.com/HumanCellAtlas/dcp-fusillade.git
     - cd dcp-fusillade
-# currently, there is no environment.prod in the dcp-fusillade repo
-    - source environment # && source environment.prod
+# currently, there is no environment.production in the dcp-fusillade repo
+    - source environment # && source environment.production
     - cd ..
     - source environment
     - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then

--- a/.gitlab-ci-prod.yml
+++ b/.gitlab-ci-prod.yml
@@ -11,6 +11,7 @@ variables:
 
 stages:
   - deploy
+  - fusillade
   - test
 
 before_script:
@@ -26,6 +27,32 @@ before_script:
   - scripts/dss-ops.py secrets get application_secrets.json > application_secrets.json
   - scripts/dss-ops.py secrets get gcp-credentials.json > gcp-credentials.json
   - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
+
+setup_fusillade:
+  stage: fusillade
+  script:
+    - git clone -b master https://github.com/HumanCellAtlas/dcp-fusillade.git
+    - cd dcp-fusillade
+# currently, there is no environment.prod in the dcp-fusillade repo
+    - source environment # && source environment.prod
+    - cd ..
+    - source environment
+    - if [[ -f "environment.$CI_COMMIT_REF_NAME" ]]; then
+    -   source environment.$CI_COMMIT_REF_NAME
+    - fi
+    - cat ./roles.json | sed "s/\${stage}/${DSS_DEPLOYMENT_STAGE}/g" > temp-roles.json
+    - if [ "$DSS_DEPLOYMENT_STAGE" == "prod" ]; then
+    -   FUS_STAGE='production'
+    - else
+    -   FUS_STAGE=$DSS_DEPLOYMENT_STAGE
+    - fi
+    - python -m json.tool ./temp-roles.json > /dev/null || exit 1
+    - dcp-fusillade/scripts/setup_fusillade.py --file temp-roles.json --force $FUS_STAGE
+    - scripts/check_fusillade.py $FUS_STAGE
+  except:
+    - schedules
+  only:
+    - prod
 
 deploy:
   stage: deploy


### PR DESCRIPTION
This adds calls to the setup fusillade and check fusillade script from `.gitlab-ci-prod.yml`.

Currently this maps the `prod` stage of DSS to the `production` stage of Fusillade. (I hope one day soon everyone in the DCP will use `prod`.)

Closes #2677 