### PR TITLE
[easy] Change production to prod.

### DIFF
--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -63,7 +63,7 @@ class FusilladeClient(object):
         "integration": "https://auth.integration.data.humancellatlas.org",
         "staging": "https://auth.staging.data.humancellatlas.org",
         "testing": "https://auth.testing.data.humancellatlas.org",
-        "production": "https://auth.data.humancellatlas.org",
+        "prod": "https://auth.data.humancellatlas.org",
     }
 
     def __init__(self, stage):


### PR DESCRIPTION
This updates the Fusillade stage names in the `FusilladeClient` class in `dss/operations/iam.py`. `s/production/prod`.

See https://github.com/HumanCellAtlas/fusillade/pull/366 for the PR that swapped out `prod` in place of `production` in fusillade.