### PR TITLE
DSS Infra: Chalice IAM Policy

### DIFF
--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -69,7 +69,6 @@
         "Action": [
             "dynamodb:*"
         ],
-        "Resource": "arn:aws:dynamodb:*:$account_id:table/dss-async-state-$stage",
         "Resource": "arn:aws:dynamodb:*:$account_id:*"
     },
     {

--- a/iam/policy-templates/dss-lambda.json
+++ b/iam/policy-templates/dss-lambda.json
@@ -69,6 +69,7 @@
         "Action": [
             "dynamodb:*"
         ],
+        "Resource": "arn:aws:dynamodb:*:$account_id:table/dss-async-state-$stage",
         "Resource": "arn:aws:dynamodb:*:$account_id:*"
     },
     {


### PR DESCRIPTION
Removes different IAM policies depending on deployment source.
Only updates IAM policies from non-CI environments (operator machines).
Addresses malformed IAM policy for dss-{stage} lambda. 

Connected To #2681 , #1973 , #1955