### PR TITLE
Use polite_print in secrets and lambda_params

### DIFF
--- a/dss/operations/iam.py
+++ b/dss/operations/iam.py
@@ -636,8 +636,7 @@ iam = dispatch.target("iam", arguments={}, help=__doc__)
         ),
         "--exclude-headers": dict(
             action="store_true", help="Exclude headers on the list being output"
-        ),
-        "--quiet": dict(action="store_true", help="Suppress warning messages")
+        )
     },
 )
 def list_policies(argv: typing.List[str], args: argparse.Namespace):

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -103,7 +103,7 @@ def unset_ssm_parameter(env_var: str, quiet: bool = False) -> None:
         del environment[env_var]
         set_ssm_environment(environment)
         polite_print(
-            args.quiet,
+            quiet,
             f"Success! Unset variable in SSM store under $DSS_DEPLOYMENT_STAGE/environment:\n"
             f"    Name: {env_var}\n"
             f"    Previous value: {prev_value}\n"

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -78,7 +78,6 @@ def set_ssm_parameter(env_var: str, value, quiet: bool = False) -> None:
     :param bool quiet: suppress all output if true
     """
     environment = get_ssm_environment()
-    prev_value = environment.get(env_var)
     environment[env_var] = value
     set_ssm_environment(environment)
     polite_print(
@@ -107,9 +106,12 @@ def unset_ssm_parameter(env_var: str, quiet: bool = False) -> None:
             f"Success! Unset variable in SSM store under $DSS_DEPLOYMENT_STAGE/environment:\n"
             f"    Name: {env_var}\n"
             f"    Previous value: {prev_value}\n"
-        ) 
+        )
     except KeyError:
-        polite_print(quiet, f"Nothing to unset for variable {env_var} in SSM store under $DSS_DEPLOYMENT_STAGE/environment")
+        polite_print(
+            quiet,
+            f"Nothing to unset for variable {env_var} in SSM store under $DSS_DEPLOYMENT_STAGE/environment"
+        )
 
 
 # ---
@@ -454,7 +456,7 @@ def lambda_update(argv: typing.List[str], args: argparse.Namespace):
             lambda_env.update(local_env)
             if args.dry_run:
                 polite_print(
-                    args.quiet, 
+                    args.quiet,
                     f"Dry-run redeploying lambda function environment from SSM store for {lambda_name}"
                 )
             else:

--- a/dss/operations/lambda_params.py
+++ b/dss/operations/lambda_params.py
@@ -13,6 +13,7 @@ import typing
 from botocore.exceptions import ClientError
 
 from dss.operations import dispatch
+from dss.operations.util import polite_print
 from dss.operations.secrets import fix_secret_variable_prefix, fetch_secret_safely
 
 from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore
@@ -80,12 +81,12 @@ def set_ssm_parameter(env_var: str, value, quiet: bool = False) -> None:
     prev_value = environment.get(env_var)
     environment[env_var] = value
     set_ssm_environment(environment)
-    if not quiet:
-        print("Success! Set variable in SSM parameter store environment:")
-        print(f"    Name: {env_var}")
-        print(f"    Value: {value}")
-        if prev_value:
-            print(f"Previous value: {prev_value}")
+    polite_print(
+        quiet,
+        f"Success! Set variable in SSM parameter store environment:\n"
+        f"    Name: {env_var}\n"
+        f"    Value: {value}\n"
+    )
 
 
 def unset_ssm_parameter(env_var: str, quiet: bool = False) -> None:
@@ -101,13 +102,14 @@ def unset_ssm_parameter(env_var: str, quiet: bool = False) -> None:
         prev_value = environment[env_var]
         del environment[env_var]
         set_ssm_environment(environment)
-        if not quiet:
-            print("Success! Unset variable in SSM store under $DSS_DEPLOYMENT_STAGE/environment:")
-            print(f"    Name: {env_var} ")
-            print(f"    Previous value: {prev_value}")
+        polite_print(
+            args.quiet,
+            f"Success! Unset variable in SSM store under $DSS_DEPLOYMENT_STAGE/environment:\n"
+            f"    Name: {env_var}\n"
+            f"    Previous value: {prev_value}\n"
+        ) 
     except KeyError:
-        if not quiet:
-            print(f"Nothing to unset for variable {env_var} in SSM store under $DSS_DEPLOYMENT_STAGE/environment")
+        polite_print(quiet, f"Nothing to unset for variable {env_var} in SSM store under $DSS_DEPLOYMENT_STAGE/environment")
 
 
 # ---
@@ -156,8 +158,7 @@ def get_deployed_lambdas(quiet: bool = True):
             lambda_client.get_function(FunctionName=name)
             yield name
         except lambda_client.exceptions.ResourceNotFoundException:
-            if not quiet:
-                print(f"{name} not deployed, or does not deploy a lambda function")
+            polite_print(quiet, f"{name} not deployed, or does not deploy a lambda function")
 
 
 def get_deployed_lambda_environment(lambda_name: str, quiet: bool = True) -> dict:
@@ -166,8 +167,7 @@ def get_deployed_lambda_environment(lambda_name: str, quiet: bool = True) -> dic
         lambda_client.get_function(FunctionName=lambda_name)
         c = lambda_client.get_function_configuration(FunctionName=lambda_name)
     except lambda_client.exceptions.ResourceNotFoundException:
-        if not quiet:
-            print(f"{lambda_name} is not a deployed lambda function")
+        polite_print(quiet, f"{lambda_name} is not a deployed lambda function")
         return {}
     else:
         # get_function_configuration() above returns a dict, no need to convert
@@ -194,12 +194,12 @@ def get_local_lambda_environment(quiet: bool = True) -> dict:
         try:
             env[name] = os.environ[name]
         except KeyError:
-            if not quiet:
-                print(
-                    f"Warning: environment variable {name} is in the list of environment variables "
-                    "to export to lambda functions, EXPORT_ENV_VARS_TO_LAMBDA, but variable is not "
-                    "defined in the local environment, so there is no value to set."
-                )
+            polite_print(
+                quiet,
+                f"Warning: environment variable {name} is in the list of environment variables "
+                "to export to lambda functions, EXPORT_ENV_VARS_TO_LAMBDA, but variable is not "
+                "defined in the local environment, so there is no value to set."
+            )
     return env
 
 
@@ -208,8 +208,7 @@ def set_lambda_var(env_var: str, value, lambda_name: str, quiet: bool = False) -
     environment = get_deployed_lambda_environment(lambda_name, quiet=False)
     environment[env_var] = value
     set_deployed_lambda_environment(lambda_name, environment)
-    if not quiet:
-        print(f"Success! Set variable {env_var} in deployed lambda function {lambda_name}")
+    polite_print(quiet, f"Success! Set variable {env_var} in deployed lambda function {lambda_name}")
 
 
 def unset_lambda_var(env_var: str, lambda_name: str, quiet: bool = False) -> None:
@@ -218,11 +217,9 @@ def unset_lambda_var(env_var: str, lambda_name: str, quiet: bool = False) -> Non
     try:
         del environment[env_var]
         set_deployed_lambda_environment(lambda_name, environment)
-        if not quiet:
-            print(f"Success! Unset variable {env_var} in deployed lambda function {lambda_name}")
+        polite_print(quiet, f"Success! Unset variable {env_var} in deployed lambda function {lambda_name}")
     except KeyError:
-        if not quiet:
-            print(f"Nothing to unset for variable {env_var} in deployed lambda function {lambda_name}")
+        polite_print(quiet, f"Nothing to unset for variable {env_var} in deployed lambda function {lambda_name}")
 
 
 def print_lambda_env(lambda_name, lambda_env):
@@ -338,15 +335,15 @@ def lambda_set(argv: typing.List[str], args: argparse.Namespace):
     val = sys.stdin.read()
 
     if args.dry_run:
-        if not args.quiet:
-            print(
-                f"Dry-run setting variable {name} in lambda environment in SSM store under "
-                "$DSS_DEPLOYMENT_STAGE/environment"
-            )
-            print(f"    Name: {name}")
-            print(f"    Value: {val}")
-            for lambda_name in get_deployed_lambdas():
-                print(f"Dry-run setting variable {name} in lambda {lambda_name}")
+        polite_print(
+            args.quiet,
+            f"Dry-run setting variable {name} in lambda environment in SSM store under "
+            "$DSS_DEPLOYMENT_STAGE/environment"
+        )
+        polite_print(args.quiet, f"    Name: {name}")
+        polite_print(args.quiet, f"    Value: {val}")
+        for lambda_name in get_deployed_lambdas():
+            polite_print(args.quiet, f"Dry-run setting variable {name} in lambda {lambda_name}")
 
     else:
         # Set the variable in the SSM store first, then in each deployed lambda
@@ -372,10 +369,9 @@ def lambda_unset(argv: typing.List[str], args: argparse.Namespace):
 
     # Unset the variable from the SSM store first, then from each deployed lambda
     if args.dry_run:
-        if not args.quiet:
-            print(f'Dry-run deleting variable {name} from SSM store')
-            for lambda_name in get_deployed_lambdas():
-                print(f'Dry-run deleting variable {name} from lambda function "{lambda_name}"')
+        polite_print(args.quiet, f"Dry-run deleting variable {name} from SSM store")
+        for lambda_name in get_deployed_lambdas():
+            polite_print(args.quiet, f'Dry-run deleting variable {name} from lambda function "{lambda_name}"')
 
     else:
         unset_ssm_parameter(name, quiet=args.quiet)
@@ -437,18 +433,18 @@ def lambda_update(argv: typing.List[str], args: argparse.Namespace):
     local_env["ADMIN_USER_EMAILS"] = get_admin_emails()
 
     if args.dry_run:
-        if not args.quiet:
-            print(
-                f"Dry-run redeploying local environment to lambda function environment "
-                "stored in SSM store under $DSS_DEPLOYMENT_STAGE/environment"
-            )
+        polite_print(
+            args.quiet,
+            f"Dry-run redeploying local environment to lambda function environment "
+            "stored in SSM store under $DSS_DEPLOYMENT_STAGE/environment"
+        )
     else:
         set_ssm_environment(local_env)
-        if not args.quiet:
-            print(
-                f"Finished redeploying local environment to lambda function environment "
-                "stored in SSM store under $DSS_DEPLOY_STAGE/environment"
-            )
+        polite_print(
+            args.quiet,
+            f"Finished redeploying local environment to lambda function environment "
+            "stored in SSM store under $DSS_DEPLOY_STAGE/environment"
+        )
 
     # Optionally, update environment of each deployed lambda
     if args.update_deployed:
@@ -457,9 +453,13 @@ def lambda_update(argv: typing.List[str], args: argparse.Namespace):
             lambda_env = get_deployed_lambda_environment(lambda_name)
             lambda_env.update(local_env)
             if args.dry_run:
-                if not args.quiet:
-                    print(f"Dry-run redeploying lambda function environment from SSM store for {lambda_name}")
+                polite_print(
+                    args.quiet, 
+                    f"Dry-run redeploying lambda function environment from SSM store for {lambda_name}"
+                )
             else:
                 set_deployed_lambda_environment(lambda_name, lambda_env)
-                if not args.quiet:
-                    print(f"Finished redeploying lambda function environment from SSM store for {lambda_name}")
+                polite_print(
+                    args.quiet,
+                    f"Finished redeploying lambda function environment from SSM store for {lambda_name}"
+                )

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -12,6 +12,7 @@ import logging
 from botocore.exceptions import ClientError
 
 from dss.operations import dispatch
+from dss.operations.util import polite_print
 from dss.util.aws.clients import secretsmanager as sm_client  # type: ignore
 
 logger = logging.getLogger(__name__)
@@ -187,14 +188,21 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
     except ClientError:
         # A secret variable with that name does not exist, so create it
         if args.dry_run:
-            if not args.quiet:
-                print(f"Secret variable {secret_name} not found in secrets manager, dry-run creating it")
+            polite_print(
+                args.quiet,
+                f"Secret variable {secret_name} not found in secrets manager, dry-run creating it"
+            )
         else:
-            if not args.quiet:
-                if args.infile:
-                    print(f"Secret variable {secret_name} not found in secrets manager, creating from input file")
-                else:
-                    print(f"Secret variable {secret_name} not found in secrets manager, creating from stdin")
+            if args.infile:
+                polite_print(
+                    args.quiet,
+                    f"Secret variable {secret_name} not found in secrets manager, creating from input file"
+                )
+            else:
+                polite_print(
+                    args.quiet,
+                    f"Secret variable {secret_name} not found in secrets manager, creating from stdin"
+                )
             sm_client.create_secret(Name=secret_name, SecretString=secret_val)
 
     else:
@@ -222,14 +230,21 @@ def set_secret(argv: typing.List[str], args: argparse.Namespace):
                 sys.exit(0)
 
         if args.dry_run:
-            if not args.quiet:
-                print(f"Secret variable {secret_name} found in secrets manager, dry-run updating it")
+            polite_print(
+                args.quiet,
+                f"Secret variable {secret_name} found in secrets manager, dry-run updating it"
+            )
         else:
-            if not args.quiet:
-                if args.infile:
-                    print(f"Secret variable {secret_name} found in secrets manager, updating from input file")
-                else:
-                    print(f"Secret variable {secret_name} found in secrets manager, updating from stdin")
+            if args.infile:
+                polite_print(
+                    args.quiet,
+                    f"Secret variable {secret_name} found in secrets manager, updating from input file"
+                )
+            else:
+                polite_print(
+                    args.quiet,
+                    f"Secret variable {secret_name} found in secrets manager, updating from stdin"
+                )
             sm_client.update_secret(SecretId=secret_name, SecretString=secret_val)
 
 
@@ -259,13 +274,17 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
 
     except ClientError:
         # No secret var found
-        if not args.quiet:
-            print(f"Secret variable {secret_name} not found in secrets manager!")
+        polite_print(
+            args.quiet,
+            f"Secret variable {secret_name} not found in secrets manager!"
+        )
 
     except sm_client.exceptions.InvalidRequestException:
         # Already deleted secret var
-        if not args.quiet:
-            print(f"Secret variable {secret_name} already marked for deletion in secrets manager!")
+        polite_print(
+            args.quiet,
+            f"Secret variable {secret_name} already marked for deletion in secrets manager!"
+        )
 
     else:
         # Get operation was successful, secret variable exists
@@ -284,10 +303,14 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
 
         if args.dry_run:
             # Delete it for fakes
-            if not args.quiet:
-                print(f"Secret variable {secret_name} found in secrets manager, dry-run deleting it")
+            polite_print(
+                args.quiet, 
+                f"Secret variable {secret_name} found in secrets manager, dry-run deleting it"
+            )
         else:
             # Delete it for real
-            if not args.quiet:
-                print(f"Secret variable {secret_name} found in secrets manager, deleting it")
+            polite_print(
+                args.quiet,
+                f"Secret variable {secret_name} found in secrets manager, deleting it"
+            )
             sm_client.delete_secret(SecretId=secret_name)

--- a/dss/operations/secrets.py
+++ b/dss/operations/secrets.py
@@ -304,7 +304,7 @@ def del_secret(argv: typing.List[str], args: argparse.Namespace):
         if args.dry_run:
             # Delete it for fakes
             polite_print(
-                args.quiet, 
+                args.quiet,
                 f"Secret variable {secret_name} found in secrets manager, dry-run deleting it"
             )
         else:

--- a/dss/operations/util.py
+++ b/dss/operations/util.py
@@ -27,6 +27,13 @@ command_queue_url = "https://sqs.{}.amazonaws.com/{}/dss-operations-{}".format(
 )
 
 
+LOG_MONITOR_SLEEP_DURATION = 10
+
+
+def polite_print(quiet, msg):
+    if not quiet:
+        print(msg)
+
 def map_bucket_results(func: typing.Callable, handle: BlobStore, bucket: str, base_pfx: str, parallelization=10):
     """
     Call `func` on an iterable of keys
@@ -47,7 +54,6 @@ def map_bucket(*args, **kwargs):
     for _ in map_bucket_results(*args, **kwargs):
         pass
 
-LOG_MONITOR_SLEEP_DURATION = 10
 
 def monitor_logs(logs_client, job_id: str, start_time: datetime):
     start = new_start = int(1000 * (datetime.timestamp(datetime.utcnow())))


### PR DESCRIPTION
For the secrets and lambda actions of dss-ops, there are some options that take a `--quiet` flag to suppress output to stdout to make it easier to pipe output to a JSON file or use as input for a subsequent step.

This PR refactors how these print statements happen by defining a `polite_print()` function that checks if the `--quiet` flag is present and only prints the message if it is not present.