### PR TITLE
Use test-specific placeholder emails (closes #2665)

### DIFF
--- a/tests/fixtures/datafiles/example_bundle/project_0.json
+++ b/tests/fixtures/datafiles/example_bundle/project_0.json
@@ -9,7 +9,7 @@
   "contributors": [
     {
       "contact_name": "Q4_DEMO-MintTeam",
-      "email": "dummy@email.com"
+      "email":"project_0@fixtures.data.humancellatlas.org"
     }
   ],
   "provenance": {

--- a/tests/sample_doc_tombstone.json
+++ b/tests/sample_doc_tombstone.json
@@ -1,5 +1,5 @@
 {
-  "email": "test@test.com",
+  "email": "sample_doc_tombstone@fixtures.data.humancellatlas.org",
   "reason": "disappeared", 
   "admin_deleted": true
 }

--- a/tests/sample_v0_index_doc_tombstone.json
+++ b/tests/sample_v0_index_doc_tombstone.json
@@ -1,5 +1,5 @@
 {
-  "email": "test@test.com",
+  "email": "sample_v0_index_doc_tombstone@fixtures.data.humancellatlas.org",
   "reason": "disappeared", 
   "admin_deleted": true,
   "uuid": "2712e1e7-d276-4c56-b33f-ead49e50b19e",

--- a/tests/sample_vx_index_doc.json
+++ b/tests/sample_vx_index_doc.json
@@ -379,7 +379,7 @@
         "contributors": [
           {
             "contact_name": "Q4_DEMO-MintTeam",
-            "email": "dummy@email.com"
+            "email": "sample_vx_index_doc_json@fixtures.data.humancellatlas.org"
           }
         ]
       }

--- a/tests/sample_vx_index_doc_tombstone.json
+++ b/tests/sample_vx_index_doc_tombstone.json
@@ -1,5 +1,5 @@
 {
-  "email": "test@test.com",
+  "email": "sample_vx_index_doc_tombstone@fixtures.data.humancellatlas.org",
   "reason": "disappeared", 
   "admin_deleted": true,
   "uuid": "2712e1e7-d276-4c56-b33f-ead49e50b19e",

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -298,7 +298,7 @@ class TestCheckoutApi(unittest.TestCase, DSSAssertMixin, DSSUploadMixin):
                         '/{0}/my_path'.format(nonexistent_bundle_uuid), '{0}/my_path'.format(nonexistent_bundle_uuid)]
         for replica in Replica:
             for format_dest in wrong_format:
-                json_request_body = dict(destination=format_dest, email='test@example.edu')
+                json_request_body = dict(destination=format_dest, email='test@test-checkout.data.humancellatlas.org')
                 with self.subTest(format_dest=format_dest):
                     self.assertResponse(method='post', path=f'/v1/bundles/{self.bundle_uuid}/checkout',
                                         expected_code=400, json_request_body=json_request_body,

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -627,8 +627,12 @@ class TestOperations(unittest.TestCase):
             # it calls the paginate() method to get a list of all users,
             # then the paginate() method twice for each user (once for groups, once for roles),
             side_effects = [
-                ["fake-user@foo.bar", "another-fake-user@baz.wuz"],
-                ["fake-group"], ["fake-role"], ["fake-group-2"], ["fake-role-2"]
+                [
+                    "fake-user@test-operations.data.humancellatlas.org",
+                    "another-fake-user@test-operations.data.humancellatlas.org"
+                ],
+                ["fake-group"], ["fake-role"],
+                ["fake-group-2"], ["fake-role-2"]
             ]
             fus_client().paginate = mock.MagicMock(side_effect=side_effects)
 
@@ -689,20 +693,36 @@ class TestOperations(unittest.TestCase):
                     _repatch_fus_client(fus_client)
                     kwargs = _get_fus_list_policies_kwargs(group_by="users")
                     iam.list_policies([], argparse.Namespace(**kwargs))
-                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-role-2-policy"]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "fake-user@test-operations.data.humancellatlas.org", "fake-group-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "fake-user@test-operations.data.humancellatlas.org", "fake-role-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "another-fake-user@test-operations.data.humancellatlas.org", "fake-group-2-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "another-fake-user@test-operations.data.humancellatlas.org", "fake-role-2-policy"
+                ]), output)
 
                 # Check exclude headers
                 with CaptureStdout() as output:
                     _repatch_fus_client(fus_client)
                     kwargs = _get_fus_list_policies_kwargs(group_by="users", exclude_headers=True)
                     iam.list_policies([], argparse.Namespace(**kwargs))
-                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-role-2-policy"]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "fake-user@test-operations.data.humancellatlas.org", "fake-group-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "fake-user@test-operations.data.humancellatlas.org", "fake-role-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "another-fake-user@test-operations.data.humancellatlas.org", "fake-group-2-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "another-fake-user@test-operations.data.humancellatlas.org", "fake-role-2-policy"
+                ]), output)
 
                 # Check write to output file
                 temp_prefix = "dss-test-operations-iam-fus-list-users-temp-output"
@@ -712,10 +732,18 @@ class TestOperations(unittest.TestCase):
                 iam.list_policies([], argparse.Namespace(**kwargs))
                 with open(fname, "r") as f:
                     output = f.read()
-                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
-                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-role-2-policy"]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "fake-user@test-operations.data.humancellatlas.org", "fake-group-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "fake-user@test-operations.data.humancellatlas.org", "fake-role-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "another-fake-user@test-operations.data.humancellatlas.org", "fake-group-2-policy"
+                ]), output)
+                self.assertIn(IAMSEPARATOR.join([
+                    "another-fake-user@test-operations.data.humancellatlas.org", "fake-role-2-policy"
+                ]), output)
 
         with self.subTest("List Fusillade policies grouped by groups"):
 
@@ -827,13 +855,16 @@ class TestOperations(unittest.TestCase):
             with mock.patch("dss.operations.iam.iam_client") as iam_client:
                 class MockPaginator_Users(object):
                     def paginate(self, *args, **kwargs):
-                        return [{"Users": [{"UserName": "fake-user-1@foo.bar"}, {"UserName": "fake-user-2@baz.wuz"}]}]
+                        return [{"Users": [
+                            {"UserName": "fake-user-1@test-operations.data.humancellatlas.org"},
+                            {"UserName": "fake-user-2@test-operations.data.humancellatlas.org"}
+                        ]}]
                 iam_client.get_paginator.return_value = MockPaginator_Users()
                 with CaptureStdout() as output:
                     kwargs = _get_aws_list_assets_kwargs()
                     iam.list_users([], argparse.Namespace(**kwargs))
-                self.assertIn("fake-user-1@foo.bar", output)
-                self.assertIn("fake-user-2@baz.wuz", output)
+                self.assertIn("fake-user-1@test-operations.data.humancellatlas.org", output)
+                self.assertIn("fake-user-2@test-operations.data.humancellatlas.org", output)
 
         with self.subTest("AWS list groups"):
             with mock.patch("dss.operations.iam.iam_client") as iam_client:
@@ -875,13 +906,16 @@ class TestOperations(unittest.TestCase):
 
         with self.subTest("Fusillade list users"):
             with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:
-                side_effects = [["fake-user-1@foo.bar", "fake-user-2@baz.wuz"]]
+                side_effects = [[
+                    "fake-user-1@test-operations.data.humancellatlas.org",
+                    "fake-user-2@test-operations.data.humancellatlas.org"
+                ]]
                 fus_client().paginate = mock.MagicMock(side_effect=side_effects)
                 kwargs = _get_fus_list_assets_kwargs()
                 with CaptureStdout() as output:
                     iam.list_users([], argparse.Namespace(**kwargs))
-                self.assertIn("fake-user-1@foo.bar", output)
-                self.assertIn("fake-user-2@baz.wuz", output)
+                self.assertIn("fake-user-1@test-operations.data.humancellatlas.org", output)
+                self.assertIn("fake-user-2@test-operations.data.humancellatlas.org", output)
 
         with self.subTest("Fusillade list groups"):
             with mock.patch("dss.operations.iam.FusilladeClient") as fus_client:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,7 +33,7 @@ class TestMockFusilladeServer(unittest.TestCase):
             security.assert_authorized(principal, actions, resources)
 
         # Ensure non-whitelisted principals are denied access
-        for principal in ['invalid@email.com']:
+        for principal in ['invalid-email@test-server.data.humancellatlas.org']:
             with self.assertRaises(dss.error.DSSForbiddenException):
                 security.assert_authorized(principal, actions, resources)
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -104,7 +104,7 @@ class TestSubscriptionsBase(ElasticsearchTestCase, TestAuthMixin, DSSAssertMixin
 
     def test_db_count_subscriptions_for_owner(self):
         """Test dynamoDB helper functions used to store and retrieve subscription information."""
-        owner = 'email@email.com'
+        owner = 'test_db_count_subscriptions_for_owner@test-subscriptions.data.humancellatlas.org'
         subscription_uuid = str(uuid.uuid4())
 
         for r in Replica:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,11 +191,11 @@ class TestSecurity(unittest.TestCase):
 
     def test_custom_email_claims(self):
         self.addCleanup(self.restore_email_claims, os.environ.pop('OIDC_EMAIL_CLAIM', 'EMPTY'))
-        email = 'email@email.com'
-        email_claim = 'email@claim.com'
+        email = 'test_custom_email_claims@test-utils.data.humancellatlas.org'
+        email_claim = 'test_custom_email_claims+claim@test-utils.data.humancellatlas.org'
         tests = [
             ({'email': email, Config.get_OIDC_email_claim(): email_claim}, email_claim),
-            ({Config.get_OIDC_email_claim(): 'email@claim.com'}, email_claim),
+            ({Config.get_OIDC_email_claim(): email_claim}, email_claim),
             ({'email': email}, email)
         ]
 


### PR DESCRIPTION
Replaces generic emails in tests (e.g. `test@test.com`) with
test-specific placeholder emails to aid in the debugging process.
In general, I used a convention like:

    {{ test_case_name }}@{{ test_suite_name }}.data.humancellatlas.org

I didn't touch tests/test_operations.py. It seemed to be fine. For propriety, here's the `ack`:

```
tests/test_operations.py
630:                ["fake-user@foo.bar", "another-fake-user@baz.wuz"],
692:                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
693:                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
694:                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
695:                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-role-2-policy"]), output)
702:                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
703:                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
704:                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
705:                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-role-2-policy"]), output)
715:                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-group-policy"]), output)
716:                self.assertIn(IAMSEPARATOR.join(["fake-user@foo.bar", "fake-role-policy"]), output)
717:                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-group-2-policy"]), output)
718:                self.assertIn(IAMSEPARATOR.join(["another-fake-user@baz.wuz", "fake-role-2-policy"]), output)
830:                        return [{"Users": [{"UserName": "fake-user-1@foo.bar"}, {"UserName": "fake-user-2@baz.wuz"}]}]
835:                self.assertIn("fake-user-1@foo.bar", output)
836:                self.assertIn("fake-user-2@baz.wuz", output)
878:                side_effects = [["fake-user-1@foo.bar", "fake-user-2@baz.wuz"]]
883:                self.assertIn("fake-user-1@foo.bar", output)
884:                self.assertIn("fake-user-2@baz.wuz", output)
```

I also didn't touch emails like `project-viewer@cool-project-188401.iam.gserviceaccount.com`.
<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
