### PR TITLE
Force Codacy to use Python 3 for linting

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+---
+engines:
+  pylint:
+    enabled: true
+    python_version: 3


### PR DESCRIPTION
Codacy code quality checks are enabled for pull requests, but seem
to be inferring Python 2 from the codebase. For example, at time of
submission, checks for #2691 at https://app.codacy.com/manual/natanlao/data-store/pullRequest?prid=4686721
are showing fstrings as a syntax error.

This change to .codacy.yml should force Codacy to use Python 3.

<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
