### PR TITLE
[easy] Fix indent error.

### DIFF
--- a/dss/index/es/validator.py
+++ b/dss/index/es/validator.py
@@ -67,7 +67,7 @@ def scrub_index_data(index_data: dict, bundle_id: str) -> list:
                                 path,
                                 [field for field in _utils.find_additional_properties(error.instance, error.schema)]
                             )
-                        extra_fields.append(fields_to_remove)
+                            extra_fields.append(fields_to_remove)
             else:
                 logger.warning(f"Unable to retrieve JSON schema information from {document} in bundle {bundle_id}.")
                 extra_documents.append(document)


### PR DESCRIPTION
Error:
```
[WARNING]	2019-12-19T01:55:16.4Z	42ae5d7c-5095-5257-b30e-0b088a27c26b	An exception occurred in retry.TX(name='index_bundle', {'bundle': <dss.index.bundle.Bundle object at 0x7efde976f898>}).
Traceback (most recent call last):
  File "/var/task/domovoilib/dss/util/retry.py", line 207, in wrapper
    return f(*args, **kwargs)
  File "/var/task/domovoilib/dss/index/es/backend.py", line 44, in index_bundle
    doc = BundleDocument.from_bundle(bundle)
  File "/var/task/domovoilib/dss/index/es/document.py", line 123, in from_bundle
    scrub_index_data(files, str(self.fqid))
  File "/var/task/domovoilib/dss/index/es/validator.py", line 70, in scrub_index_data
    extra_fields.append(fields_to_remove)
UnboundLocalError: local variable 'fields_to_remove' referenced before assignment
```

Seems to simply be an indentation error.