### PR TITLE
[easy] Move fusillade usage to a non-critical API endpoint.

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -189,9 +189,6 @@ def enumerate(replica: str,
 
 @dss_handler
 def put(uuid: str, replica: str, json_request_body: dict, version: str):
-    security.assert_authorized(security.get_token_email(request.token_info),
-                               ["dss:PutBundle"],
-                               [f'arn:hca:dss:{Config.deployment_stage()}:*:bundle/{uuid}/{version}'])
     uuid = uuid.lower()
 
     files = build_bundle_file_metadata(Replica[replica], json_request_body['files'])
@@ -241,9 +238,6 @@ def bundle_file_id_metadata(bundle_file_metadata):
 
 @dss_handler
 def patch(uuid: str, json_request_body: dict, replica: str, version: str):
-    security.assert_authorized(security.get_token_email(request.token_info),
-                               ["dss:PatchBundle"],
-                               [f'arn:hca:dss:{Config.deployment_stage()}:*:bundle/{uuid}/{version}'])
     bundle = get_bundle_manifest(uuid, Replica[replica], version)
     if bundle is None:
         raise DSSException(404, "not_found", "Could not find bundle for UUID {}".format(uuid))
@@ -263,9 +257,6 @@ def patch(uuid: str, json_request_body: dict, replica: str, version: str):
 
 @dss_handler
 def delete(uuid: str, replica: str, json_request_body: dict, version: str = None):
-    security.assert_authorized(security.get_token_email(request.token_info),
-                               ["dss:DeleteBundle"],
-                               [f'arn:hca:dss:{Config.deployment_stage()}:*:bundle/{uuid}/{version}'])
     email = security.get_token_email(request.token_info)
 
     if email not in ADMIN_USER_EMAILS:

--- a/dss/api/collections.py
+++ b/dss/api/collections.py
@@ -63,6 +63,9 @@ def list_collections(per_page: int, start_at: int = 0):
     """
     # TODO: Replica is unused, so this does not use replica.  Appropriate?
     owner = security.get_token_email(request.token_info)
+    security.assert_authorized(owner,
+                               ["dss:GetCollections"],
+                               [f'arn:hca:dss:${Config.deployment_stage()}:*:*/collections'])
 
     collections = []
     for collection in owner_lookup.get_collection_fqids_for_owner(owner):


### PR DESCRIPTION
This moves fusillade usage from PUT/PATCH/DELETE /bundle to GET /collections.