### PR TITLE
Gentle refactor of tombstoning code, second try

### DIFF
--- a/dss/api/bundles/__init__.py
+++ b/dss/api/bundles/__init__.py
@@ -137,6 +137,7 @@ def get(
     response.headers['X-OpenAPI-Paginated-Content-Key'] = 'bundle.files'
     return response
 
+
 @dss_handler
 def enumerate(replica: str,
               prefix: typing.Optional[str] = None,
@@ -267,8 +268,7 @@ def delete(uuid: str, replica: str, json_request_body: dict, version: str = None
     bundle_prefix = tombstone_id.to_key_prefix()
     tombstone_object_data = _create_tombstone_data(
         email=email,
-        reason=json_request_body.get('reason'),
-        version=version,
+        reason=json_request_body.get('reason')
     )
 
     handle = Config.get_blobstore_handle(Replica[replica])
@@ -365,14 +365,10 @@ def detect_filename_collisions(bundle_file_metadata):
             )
 
 
-def _create_tombstone_data(email: str, reason: str, version: typing.Optional[str]) -> dict:
-    # Future-proofing the case in which garbage collection is added
-    data = dict(
-        email=email,
-        reason=reason,
-        admin_deleted=True,
-    )
-    # optional params
-    if version is not None:
-        data.update(version=version)
-    return data
+def _create_tombstone_data(email: str, reason: str, details: typing.Optional[dict] = {}) -> dict:
+    return {
+        'email': email,
+        'reason': reason,
+        'details': details,
+        'admin_deleted': True
+    }

--- a/dss/storage/__init__.py
+++ b/dss/storage/__init__.py
@@ -1,0 +1,12 @@
+from typing import NamedTuple, Optional
+
+
+class Tombstone(NamedTuple):
+    """
+    Tombstone object compliant with RFC #4 (Deletion of data in the DCP).
+    See HumanCellAtlas/dcp-community.
+    """
+    email: str
+    reason: str
+    details: Optional[dict] = {}
+    admin_deleted: bool = True


### PR DESCRIPTION
Continuation of reverted PR #2516 with bug fixes.

This is the first of several PRs needed to implement the file deletion API (#2409). This PR refactors a tombstone helper function to be consistent with the deletion RFC and relocates it in preparation for use with files (and not just bundles).