### PR TITLE
DSS API: enumerating consecutive dead bundles

### DIFF
--- a/dss/storage/bundles.py
+++ b/dss/storage/bundles.py
@@ -169,7 +169,7 @@ class Living():
         self.bundle_info = dict(contains_unversioned_tombstone=False, uuid=None, fqids=OrderedDict())
         if fqid:
             self.bundle_info['uuid'] = fqid.uuid
-            self.bundle_info['fqids'][fqid] = False
+            self.bundle_info['fqids'][fqid] = isinstance(fqid, BundleTombstoneID)
 
     def _living_fqids_in_bundle_info(self):
         if not self.bundle_info['contains_unversioned_tombstone']:

--- a/tests/infra/mock_storage_handler.py
+++ b/tests/infra/mock_storage_handler.py
@@ -41,9 +41,9 @@ class MockStorageHandler:
                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201835.591231Z.dead',
                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201830.591231Z.dead',
                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201820.591231Z.dead',
-                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201835.591231Z.dead',
-                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201830.591231Z',
-                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201820.591231Z.dead'
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad787.2018-10-08T201835.591231Z.dead',
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad787.2018-10-08T201830.591231Z',
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad787.2018-10-08T201820.591231Z.dead'
                    ]
 
     dead_bundles = ['bundles/00000000-1112-4858-bf17-513dc2d05863.2019-02-26T033907.789762Z',
@@ -73,8 +73,8 @@ class MockStorageHandler:
                     'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201835.591231Z.dead',
                     'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201830.591231Z.dead',
                     'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201820.591231Z.dead',
-                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201835.591231Z.dead',
-                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201820.591231Z.dead'
+                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad787.2018-10-08T201835.591231Z.dead',
+                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad787.2018-10-08T201820.591231Z.dead'
                     ]
 
     dead_bundles_without_suffix = map(lambda x: x[:-5] if x.endswith('.dead') else x, dead_bundles)

--- a/tests/infra/mock_storage_handler.py
+++ b/tests/infra/mock_storage_handler.py
@@ -38,7 +38,13 @@ class MockStorageHandler:
                    'bundles/00000000-1113-7197-967c-d6a33233f65e.2018-09-13T131642.918470Z',
                    'bundles/00000000-1113-7670-9dad-92c9fb6534bb.2019-02-26T033443.407780Z',
                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad783.2018-10-08T201847.591231Z',
-                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201847.591231Z']
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201835.591231Z.dead',
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201830.591231Z.dead',
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201820.591231Z.dead',
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201835.591231Z.dead',
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201830.591231Z',
+                   'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201820.591231Z.dead'
+                   ]
 
     dead_bundles = ['bundles/00000000-1112-4858-bf17-513dc2d05863.2019-02-26T033907.789762Z',
                     'bundles/00000000-1112-4858-bf17-513dc2d05863.2019-05-23T220340.829000Z',
@@ -64,7 +70,14 @@ class MockStorageHandler:
                     'bundles/00000000-1113-5719-a070-1fcb25a57519.2018-10-18T203641.653105Z.dead',
                     'bundles/00000000-1113-6452-94d9-293fcb97ba32.2019-05-10T110312.514000Z',
                     'bundles/00000000-1113-6452-94d9-293fcb97ba32.dead',
+                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201835.591231Z.dead',
+                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201830.591231Z.dead',
+                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad786.2018-10-08T201820.591231Z.dead',
+                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201835.591231Z.dead',
+                    'bundles/00000000-1113-7ee4-aefd-6eb2c8cad785.2018-10-08T201820.591231Z.dead'
                     ]
+
+    dead_bundles_without_suffix = map(lambda x: x[:-5] if x.endswith('.dead') else x, dead_bundles)
 
     test_per_page = [{"size": 10,
                       "last_good_bundle": {"uuid": "00000000-1113-5145-9560-430930445071",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -92,6 +92,7 @@ class TestStorageBundles(unittest.TestCase):
         resp = enumerate_available_bundles(replica='aws')
         for x in resp['bundles']:
             self.assertNotIn('.'.join([x['uuid'], x['version']]), MockStorageHandler.dead_bundles)
+            self.assertNotIn('.'.join([x['uuid'], x['version']]), MockStorageHandler.dead_bundles_without_suffix)
 
     @mock.patch("dss.Config.get_blobstore_handle")
     def test_tombstone_pages(self, mock_list_v2):
@@ -104,12 +105,14 @@ class TestStorageBundles(unittest.TestCase):
             page_one = resp['bundles']
             for x in resp['bundles']:
                 self.assertNotIn('.'.join([x['uuid'], x['version']]), MockStorageHandler.dead_bundles)
+                self.assertNotIn('.'.join([x['uuid'], x['version']]), MockStorageHandler.dead_bundles_without_suffix)
             self.assertDictEqual(last_good_bundle, resp['bundles'][-1])
             search_after = resp['search_after']
             resp = enumerate_available_bundles(replica='aws', per_page=test_size,
                                                search_after=search_after)
             for x in resp['bundles']:
                 self.assertNotIn('.'.join([x['uuid'], x['version']]), MockStorageHandler.dead_bundles)
+                self.assertNotIn('.'.join([x['uuid'], x['version']]), MockStorageHandler.dead_bundles_without_suffix)
                 self.assertNotIn(x, page_one)
     # TODO add test to enumerate list and ensure all bundles that should be present are there.
     # TODO: Add test for dss.storage.bundles.get_bundle_manifest


### PR DESCRIPTION
addresses bug where the first bundle shows up when enumerating multiple dead bundles. 
Connected To : #2723